### PR TITLE
feat: developer mode

### DIFF
--- a/src/lib/components/developer-section/developer.section.svelte
+++ b/src/lib/components/developer-section/developer.section.svelte
@@ -1,0 +1,88 @@
+<script lang="ts">
+  import DeviceIcon from 'radicle-design-system/icons/Device.svelte';
+  import Section from '../section/section.svelte';
+  import developerModeStore from '$lib/stores/developer-mode/developer-mode.store';
+  import Copyable from '../copyable/copyable.svelte';
+  import Coin from 'radicle-design-system/icons/Coin.svelte';
+  import Wallet from 'radicle-design-system/icons/Wallet.svelte';
+  import Box from 'radicle-design-system/icons/Box.svelte';
+  import { Utils } from 'radicle-drips';
+  import Splits from 'radicle-design-system/icons/Splits.svelte';
+
+  export let accountId: string | undefined = undefined;
+
+  const DRIVER_FRIENDLY_NAMES = {
+    nft: 'NFT Driver',
+    address: 'Address Driver',
+    repo: 'Repo Driver',
+    immutableSplits: 'Immutable Splits Driver',
+  } as const;
+
+  const DRIVER_ICONS = {
+    nft: Coin,
+    address: Wallet,
+    repo: Box,
+    immutableSplits: Splits,
+  } as const;
+
+  $: driver = accountId && Utils.AccountId.getDriver(accountId);
+</script>
+
+{#if $developerModeStore}
+  <Section
+    collapsable
+    header={{
+      label: 'Developer',
+      icon: DeviceIcon,
+    }}
+    skeleton={{
+      loaded: Boolean(accountId),
+    }}
+  >
+    <div class="values typo-text tabular-nums">
+      {#if accountId}
+        <div class="key-value">
+          <h5 class="key">Account ID</h5>
+          <Copyable value={accountId} alwaysVisible>
+            <span class="value">{accountId}</span>
+          </Copyable>
+        </div>
+      {/if}
+
+      {#if driver}
+        <div class="key-value">
+          <h5 class="key">Driver</h5>
+          <div class="value">
+            <svelte:component this={DRIVER_ICONS[driver]} />
+            {DRIVER_FRIENDLY_NAMES[driver]}
+          </div>
+        </div>
+      {/if}
+    </div>
+  </Section>
+{/if}
+
+<style>
+  .values {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .key-value {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    width: fit-content;
+  }
+
+  .key-value .key {
+    color: var(--color-foreground-level-6);
+  }
+
+  .key-value .value {
+    width: fit-content;
+    display: inline-flex;
+    gap: 0.25rem;
+  }
+</style>

--- a/src/lib/stores/developer-mode/developer-mode.store.ts
+++ b/src/lib/stores/developer-mode/developer-mode.store.ts
@@ -1,0 +1,9 @@
+import { browser } from '$app/environment';
+import storedWritable from '@efstajas/svelte-stored-writable';
+import { z } from 'zod';
+
+/**
+ * If true, the app will display additional dev-only information, such as
+ * account IDs on address profiles, project profiles, and Drip Lists.
+ */
+export default storedWritable('developer-mode', z.boolean(), false, !browser);

--- a/src/routes/app/(app)/[accountId]/+page.svelte
+++ b/src/routes/app/(app)/[accountId]/+page.svelte
@@ -19,6 +19,7 @@
   import HeadMeta from '$lib/components/head-meta/head-meta.svelte';
   import ProjectsSection from '$lib/components/projects-section/projects-section.svelte';
   import DripListsSection from '$lib/components/drip-lists-section/drip-lists-section.svelte';
+  import Developer from '$lib/components/developer-section/developer.section.svelte';
 
   $: accountId = $page.params.accountId;
 
@@ -147,6 +148,7 @@
         </div>
       {/if}
     </SectionSkeleton>
+    <Developer accountId={dripsAccountId} />
     <ProjectsSection collapsable {address} />
     <DripListsSection collapsable {address} />
     <Streams collapsable accountId={dripsAccountId} />

--- a/src/routes/app/(app)/drip-lists/[listId]/+page.svelte
+++ b/src/routes/app/(app)/drip-lists/[listId]/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import Developer from '$lib/components/developer-section/developer.section.svelte';
   import DripListCard from '$lib/components/drip-list-card/drip-list-card.svelte';
   import HeadMeta from '$lib/components/head-meta/head-meta.svelte';
   import IdentityBadge from '$lib/components/identity-badge/identity-badge.svelte';
@@ -37,6 +38,7 @@
       representationalSplits={data.representationalSplits}
     />
   </SectionSkeleton>
+  <Developer accountId={dripList.account.accountId} />
   <Supporters
     headline="Support"
     infoTooltip="A Drip List can be supported by one or more support streams by the list's owner. Others can also add a Drip List to their own Drip Lists to support it."

--- a/src/routes/app/(app)/projects/(forges)/components/project-profile/project-profile.svelte
+++ b/src/routes/app/(app)/projects/(forges)/components/project-profile/project-profile.svelte
@@ -39,6 +39,7 @@
   import editProjectSplitsSteps from '$lib/flows/edit-project-splits/edit-project-splits-steps';
   import { fade } from 'svelte/transition';
   import type getIncomingSplits from '$lib/utils/splits/get-incoming-splits';
+  import Developer from '$lib/components/developer-section/developer.section.svelte';
 
   interface Amount {
     tokenAddress: string;
@@ -173,6 +174,7 @@
       {/if}
     </div>
     <div class="content">
+      <Developer accountId={project.repoDriverAccount.accountId} />
       {#if project.owner}
         <div class="section">
           {#if splits}

--- a/src/routes/app/(app)/settings/+page.svelte
+++ b/src/routes/app/(app)/settings/+page.svelte
@@ -12,6 +12,7 @@
   import tickStore from '$lib/stores/tick/tick.store';
   import HeadMeta from '$lib/components/head-meta/head-meta.svelte';
   import { goto } from '$app/navigation';
+  import developerModeStore from '$lib/stores/developer-mode/developer-mode.store';
 
   const { primaryColor } = themeStore;
 
@@ -165,6 +166,12 @@
       <a class="typo-link" target="_blank" rel="noreferrer" href="https://docs.drips.network"
         >Read the docs</a
       >
+    </Setting>
+    <Setting
+      title="Developer mode"
+      subtitle="When enabled, shows developer-focussed extra information on address profiles, project profiles and Drip Lists."
+    >
+      <Toggle bind:checked={$developerModeStore} />
     </Setting>
   </div>
   <Divider />


### PR DESCRIPTION
Adds a new "Developer mode" toggle to settings (default off) that shows a new "Developer" section on address profiles, project profiles and drip lists, which allows easily seeing and copying account IDs. Can add more info here later.