### PR TITLE
Ev/badges

### DIFF
--- a/src/lib/components/drip-list-badge/drip-list-badge.svelte
+++ b/src/lib/components/drip-list-badge/drip-list-badge.svelte
@@ -1,43 +1,39 @@
 <script lang="ts">
   import Ledger from 'radicle-design-system/icons/Ledger.svelte';
-  import IdentityBadge from '$lib/components/identity-badge/identity-badge.svelte';
+  import ensStore from '$lib/stores/ens';
+  import formatAddress from '$lib/utils/format-address';
 
   export let listName: string;
   export let listId: string;
-  export let owner: string | undefined = undefined;
+  export let owner: string;
 
   export let showAvatar = true;
   export let showName = true;
+
+  $: ensStore.connected && ensStore.lookup(owner);
+  $: ens = $ensStore[owner];
+
+  $: username = ens?.name ? ens.name : formatAddress(owner);
 </script>
 
-<a href="/app/drip-lists/{listId}" tabindex="-1" class="drip-list-badge">
+<a href="/app/drip-lists/{listId}" tabindex="-1" class="drip-list-badge flex gap-2 items-center">
   {#if showAvatar}
     <div class="drip-list-icon">
       <Ledger style="fill: var(--color-background)" />
     </div>
   {/if}
   {#if showName}
-    <div class="name">
-      {#if owner}
-        <span>
-          <IdentityBadge muted showAvatar={false} address={owner} />
-        </span>
-      {/if}
-      <span class="typo-text">/</span>
-      <a class="typo-text-bold" href="/app/drip-lists/{listId}">{listName}</a>
+    <div class="name typo-text text-foreground flex-1 min-w-0 truncate">
+      <span class="text-foreground-level-5">{username}/</span><a href="/app/drip-lists/{listId}"
+        >{listName}</a
+      >
     </div>
   {/if}
 </a>
 
 <style>
-  .drip-list-badge {
-    display: flex;
-    gap: 0.5rem;
-    align-items: center;
-  }
-
   .drip-list-icon {
-    background-color: var(--color-foreground);
+    background-color: var(--color-primary);
     height: 2rem;
     width: 2rem;
     display: flex;
@@ -47,13 +43,6 @@
     flex-shrink: 0;
   }
 
-  .name {
-    display: flex;
-    gap: 0;
-    align-items: last-baseline;
-    white-space: nowrap;
-  }
-
   .name a:focus {
     outline: none;
   }
@@ -61,9 +50,5 @@
   .name a:focus-visible {
     background-color: var(--color-primary-level-1);
     border-radius: 0.25rem;
-  }
-
-  .name > span {
-    display: inline-block;
   }
 </style>

--- a/src/lib/components/drip-list-badge/drip-list-badge.svelte
+++ b/src/lib/components/drip-list-badge/drip-list-badge.svelte
@@ -9,6 +9,7 @@
 
   export let showAvatar = true;
   export let showName = true;
+  export let isLinked = true;
 
   $: ensStore.connected && ensStore.lookup(owner);
   $: ens = $ensStore[owner];
@@ -16,7 +17,12 @@
   $: username = ens?.name ? ens.name : formatAddress(owner);
 </script>
 
-<a href="/app/drip-lists/{listId}" tabindex="-1" class="drip-list-badge flex gap-2 items-center">
+<svelte:element
+  this={isLinked ? 'a' : 'div'}
+  href={isLinked ? `/app/drip-lists/{listId}` : undefined}
+  tabindex={isLinked ? 0 : -1}
+  class="drip-list-badge flex gap-2 items-center"
+>
   {#if showAvatar}
     <div class="drip-list-icon">
       <Ledger style="fill: var(--color-primary)" />
@@ -24,12 +30,10 @@
   {/if}
   {#if showName}
     <div class="name typo-text text-foreground flex-1 min-w-0 truncate">
-      <span class="text-foreground-level-5">{username}/</span><a href="/app/drip-lists/{listId}"
-        >{listName}</a
-      >
+      <span><span class="text-foreground-level-5">{username}/</span>{listName}</span>
     </div>
   {/if}
-</a>
+</svelte:element>
 
 <style>
   .drip-list-icon {
@@ -43,12 +47,11 @@
     flex-shrink: 0;
   }
 
-  .name a:focus {
+  a.drip-list-badge {
     outline: none;
   }
-
-  .name a:focus-visible {
-    background-color: var(--color-primary-level-1);
+  a.drip-list-badge:focus-visible .name > span {
+    background: var(--color-primary-level-1);
     border-radius: 0.25rem;
   }
 </style>

--- a/src/lib/components/drip-list-badge/drip-list-badge.svelte
+++ b/src/lib/components/drip-list-badge/drip-list-badge.svelte
@@ -19,7 +19,7 @@
 
 <svelte:element
   this={isLinked ? 'a' : 'div'}
-  href={isLinked ? `/app/drip-lists/{listId}` : undefined}
+  href={isLinked ? `/app/drip-lists/${listId}` : undefined}
   tabindex={isLinked ? 0 : -1}
   class="drip-list-badge flex gap-2 items-center"
 >

--- a/src/lib/components/drip-list-badge/drip-list-badge.svelte
+++ b/src/lib/components/drip-list-badge/drip-list-badge.svelte
@@ -19,7 +19,7 @@
 <a href="/app/drip-lists/{listId}" tabindex="-1" class="drip-list-badge flex gap-2 items-center">
   {#if showAvatar}
     <div class="drip-list-icon">
-      <Ledger style="fill: var(--color-background)" />
+      <Ledger style="fill: var(--color-primary)" />
     </div>
   {/if}
   {#if showName}
@@ -33,7 +33,7 @@
 
 <style>
   .drip-list-icon {
-    background-color: var(--color-primary);
+    background-color: var(--color-primary-level-1);
     height: 2rem;
     width: 2rem;
     display: flex;

--- a/src/lib/components/identity-badge/identity-badge.svelte
+++ b/src/lib/components/identity-badge/identity-badge.svelte
@@ -67,82 +67,78 @@
   $: currentFontClassEns = fontClassesEns[size];
 
   const fontClassesAddress = {
-    tiny: 'typo-text-small tabular-nums',
-    small: 'typo-text-small tabular-nums',
-    normal: 'typo-text tabular-nums',
-    medium: 'typo-text tabular-nums',
-    big: 'typo-header-4 tabular-nums',
-    huge: 'typo-header-3 tabular-nums',
-    gigantic: 'typo-header-1 mono tabular-nums',
+    tiny: 'typo-text-small',
+    small: 'typo-text-small',
+    normal: 'typo-text',
+    medium: 'typo-text',
+    big: 'typo-header-4',
+    huge: 'typo-header-3',
+    gigantic: 'typo-header-1',
   };
   $: currentFontClassAddress = fontClassesAddress[size];
 
   $: currentFontClass = ens?.name ? currentFontClassEns : currentFontClassAddress;
 </script>
 
-<div class="wrapper">
-  <Tooltip text={address} copyable disabled={disableTooltip}>
-    <svelte:element
-      this={getLink() ? 'a' : 'span'}
-      href={getLink()}
-      target={linkToNewTab ? '_blank' : undefined}
-      class="identity-badge flex items-center relative text-left text-foreground"
-      class:flex-row-reverse={isReverse}
-      class:select-none={disableSelection}
-      style:height={showAvatar ? `${currentSize}px` : ''}
-      style:gap={showAvatar && showIdentity ? `${currentSize / 4}px` : ''}
-      class:muted
-    >
-      {#if showAvatar}
-        <Avatar
-          size={currentSize}
-          bind:imgElem={avatarImgElem}
-          src={ens?.avatarUrl}
-          placeholderSrc={blockyUrl}
-          {outline}
-        />
-      {/if}
-      {#if showIdentity}
-        <div class="identity relative flex-1 max-w-full">
+<Tooltip text={address} copyable disabled={disableTooltip}>
+  <svelte:element
+    this={getLink() ? 'a' : 'span'}
+    href={getLink()}
+    target={linkToNewTab ? '_blank' : undefined}
+    class="identity-badge flex items-center relative text-left text-foreground tabular-nums"
+    class:flex-row-reverse={isReverse}
+    class:select-none={disableSelection}
+    style:height={showAvatar ? `${currentSize}px` : ''}
+    style:gap={showAvatar && showIdentity ? `${currentSize / 4}px` : ''}
+    class:muted
+  >
+    {#if showAvatar}
+      <Avatar
+        size={currentSize}
+        bind:imgElem={avatarImgElem}
+        src={ens?.avatarUrl}
+        placeholderSrc={blockyUrl}
+        {outline}
+      />
+    {/if}
+    {#if showIdentity}
+      <div class="identity relative flex-1 min-w-0">
+        <div
+          class={`${currentFontClass} identity opacity-0 pointer-events-none flex items-center`}
+          class:hideOnMobile={hideAvatarOnMobile}
+        >
+          {toDisplay}
+          {#if ens?.name && showFullAddress}
+            <div class="typo-text-small leading-none truncate">{address}</div>
+          {/if}
+        </div>
+        {#key toDisplay}
           <div
-            class={`${currentFontClass} identity opacity-0 pointer-events-none`}
+            transition:fade|local={{ duration: 300 }}
+            class:text-foreground={size === 'gigantic'}
+            class={`${currentFontClass} identity absolute overlay flex items-center`}
+            data-style:left={showAvatar ? `${currentSize + currentSize / 3}px` : '0'}
             class:hideOnMobile={hideAvatarOnMobile}
           >
-            {toDisplay}
-            {#if ens?.name && showFullAddress}<span class="typo-text-small-mono full-address"
-                >{address}</span
-              >{/if}
-          </div>
-          {#key toDisplay}
-            <div
-              transition:fade|local={{ duration: 300 }}
-              class:foreground={size === 'gigantic'}
-              class={`${currentFontClass} identity absolute overlay`}
-              data-style:left={showAvatar ? `${currentSize + currentSize / 3}px` : '0'}
-              class:hideOnMobile={hideAvatarOnMobile}
-            >
-              {toDisplay}
-              {#if ens?.name && showFullAddress}<span class="typo-text-small-mono full-address"
-                  >{address}</span
-                >{/if}
+            <div class="flex-1 min-w-0">
+              <div class="truncate">{toDisplay}</div>
+              {#if ens?.name && showFullAddress}
+                <div class="typo-text-small leading-none truncate text-foreground-level-5">
+                  {address}
+                </div>
+              {/if}
             </div>
-          {/key}
-        </div>
-      {/if}
-    </svelte:element>
-    <svelte:fragment slot="tooltip-content">
-      {address}
-    </svelte:fragment>
-  </Tooltip>
-</div>
+          </div>
+        {/key}
+      </div>
+    {/if}
+  </svelte:element>
+  <svelte:fragment slot="tooltip-content">
+    {address}
+  </svelte:fragment>
+</Tooltip>
 
 <style>
-  .wrapper {
-    width: fit-content;
-    max-width: 100%;
-    overflow: hidden;
-  }
-
   .identity-badge:focus {
     outline: none;
   }
@@ -160,23 +156,6 @@
     font-family: var(--typeface-regular);
     white-space: nowrap;
     font-style: normal;
-  }
-
-  .foreground {
-    color: var(--color-foreground);
-  }
-
-  .identity {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
-  .full-address {
-    color: var(--color-foreground-level-5);
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    overflow: hidden;
   }
 
   .muted {

--- a/src/lib/components/list-editor/list-editor.svelte
+++ b/src/lib/components/list-editor/list-editor.svelte
@@ -333,9 +333,14 @@
             data-testid={`item-${slug}`}
           >
             <div class="flex-1 max-w-full">
-              <div class="w-full overflow-x-scroll px-3">
+              <div class="w-full px-3">
                 {#if item.type === 'address'}
-                  <IdentityBadge address={item.address} size="medium" disableLink={true} />
+                  <IdentityBadge
+                    address={item.address}
+                    size="medium"
+                    disableLink={true}
+                    showFullAddress={true}
+                  />
                 {:else if item.type === 'project'}
                   <ProjectBadge project={item.project} linkTo="nothing" />
                 {:else if item.type === 'drip-list'}
@@ -343,6 +348,7 @@
                     listName={item.list.name}
                     listId={item.list.id}
                     owner={item.list.owner}
+                    isLinked={false}
                   />
                 {/if}
               </div>

--- a/src/lib/components/project-badge/components/project-name.svelte
+++ b/src/lib/components/project-badge/components/project-name.svelte
@@ -6,17 +6,14 @@
   export let project: GitProject;
 </script>
 
-<span class="project-name">
-  {#if showSource}
-    <span style:color="var(--color-foreground-level-5)" class="owner-name typo-text">
-      {project.source.ownerName}/
-    </span>
-  {/if}
-  <span class="repo-name typo-text-bold">{project.source.repoName}</span>
-</span>
+<span class="text-foreground-level-5 typo-text"
+  >{#if showSource}{project.source.ownerName}/{/if}<span class="text-foreground"
+    >{project.source.repoName}</span
+  ></span
+>
 
 <style>
-  .project-name {
+  /* .project-name {
     display: inline-flex;
     width: 100%;
     white-space: nowrap;
@@ -29,5 +26,5 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-  }
+  } */
 </style>

--- a/src/lib/components/project-badge/components/project-name.svelte
+++ b/src/lib/components/project-badge/components/project-name.svelte
@@ -11,20 +11,3 @@
     >{project.source.repoName}</span
   ></span
 >
-
-<style>
-  /* .project-name {
-    display: inline-flex;
-    width: 100%;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    overflow: hidden;
-  }
-
-  .project-name .repo-name,
-  .project-name .owner-name {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  } */
-</style>

--- a/src/lib/components/project-badge/project-badge.svelte
+++ b/src/lib/components/project-badge/project-badge.svelte
@@ -77,11 +77,6 @@
     border-radius: 0.25rem;
   }
 
-  /* .name {
-    display: flex;
-    min-width: 0;
-  } */
-
   .avatar-and-forge {
     display: flex;
     flex-direction: row;

--- a/src/lib/components/project-badge/project-badge.svelte
+++ b/src/lib/components/project-badge/project-badge.svelte
@@ -11,14 +11,12 @@
     type UnclaimedGitProject,
   } from '$lib/utils/metadata/types';
   import PrimaryColorThemer from '../primary-color-themer/primary-color-themer.svelte';
-  import Copyable from '../copyable/copyable.svelte';
 
   export let project: GitProject;
   export let tooltip = true;
   export let forceUnclaimed = false;
   export let hideAvatar = false;
   export let linkToNewTab = false;
-  export let urlCopyable = false;
   export let linkTo: 'external-url' | 'project-page' | 'nothing' = 'project-page';
 
   let unclaimedProject: UnclaimedGitProject;
@@ -35,43 +33,37 @@
   $: processedProject = forceUnclaimed ? unclaimedProject : project;
 </script>
 
-<div class="wrapper">
-  <PrimaryColorThemer colorHex={processedProject.claimed ? processedProject.color : undefined}>
-    <Tooltip disabled={!tooltip}>
-      <Copyable alwaysVisible={urlCopyable} disabled={!urlCopyable} value={project.source.url}>
-        <svelte:element
-          this={linkTo === 'nothing' ? 'div' : 'a'}
-          class="project-badge"
-          href={linkTo === 'project-page'
-            ? buildProjectUrl(project.source)
-            : buildExternalUrl(processedProject.source.url)}
-          target={linkTo === 'external-url' || linkToNewTab ? '_blank' : ''}
-        >
-          {#if !hideAvatar}<div class="avatar-and-forge">
-              {#if !forceUnclaimed && project.claimed}
-                <div>
-                  <ProjectAvatar project={unclaimedProject} />
-                </div>
-              {/if}
-              <div><ProjectAvatar project={processedProject} /></div>
-            </div>{/if}
-          <div class="name">
-            <ProjectName project={processedProject} />
-          </div>
-        </svelte:element>
-      </Copyable>
-      <svelte:fragment slot="tooltip-content">
-        <ProjectTooltip project={processedProject} />
-      </svelte:fragment>
-    </Tooltip>
-  </PrimaryColorThemer>
-</div>
+<PrimaryColorThemer colorHex={processedProject.claimed ? processedProject.color : undefined}>
+  <Tooltip disabled={!tooltip}>
+    <svelte:element
+      this={linkTo === 'nothing' ? 'div' : 'a'}
+      class="project-badge flex gap-2 items-center typo-text"
+      href={linkTo === 'project-page'
+        ? buildProjectUrl(project.source)
+        : buildExternalUrl(processedProject.source.url)}
+      target={linkTo === 'external-url' || linkToNewTab ? '_blank' : ''}
+    >
+      {#if !hideAvatar}
+        <div class="avatar-and-forge">
+          {#if !forceUnclaimed && project.claimed}
+            <div>
+              <ProjectAvatar project={unclaimedProject} />
+            </div>
+          {/if}
+          <div><ProjectAvatar project={processedProject} /></div>
+        </div>
+      {/if}
+      <div class="name flex-1 min-w-0 truncate">
+        <ProjectName project={processedProject} />
+      </div>
+    </svelte:element>
+    <svelte:fragment slot="tooltip-content">
+      <ProjectTooltip project={processedProject} />
+    </svelte:fragment>
+  </Tooltip>
+</PrimaryColorThemer>
 
 <style>
-  .wrapper {
-    width: fit-content;
-  }
-
   a:focus-visible {
     outline: none;
   }
@@ -85,16 +77,10 @@
     border-radius: 0.25rem;
   }
 
-  .project-badge {
-    display: flex;
-    gap: 0.5rem;
-    align-items: center;
-  }
-
-  .name {
+  /* .name {
     display: flex;
     min-width: 0;
-  }
+  } */
 
   .avatar-and-forge {
     display: flex;

--- a/src/lib/components/project-profile-header/project-profile-header.svelte
+++ b/src/lib/components/project-profile-header/project-profile-header.svelte
@@ -2,6 +2,7 @@
   import ProjectAvatar from '$lib/components/project-avatar/project-avatar.svelte';
   import ProjectBadge from '$lib/components/project-badge/project-badge.svelte';
   import type { GitProject } from '$lib/utils/metadata/types';
+  import Copyable from '../copyable/copyable.svelte';
 
   export let project: GitProject;
 </script>
@@ -12,7 +13,9 @@
   </div>
   <div class="name">
     <h1>{project.source.repoName}</h1>
-    <ProjectBadge urlCopyable {project} forceUnclaimed tooltip={false} linkTo="external-url" />
+    <Copyable alwaysVisible={true} value={project.source.url}>
+      <ProjectBadge {project} forceUnclaimed tooltip={false} linkTo="external-url" />
+    </Copyable>
   </div>
 </div>
 

--- a/src/lib/components/splits/components/split/split.svelte
+++ b/src/lib/components/splits/components/split/split.svelte
@@ -82,6 +82,7 @@
             props: {
               listId: s.listId,
               listName: s.listName,
+              owner: s.listOwner,
               showName: false,
             },
           } as ComponentAndProps;

--- a/src/lib/components/user-avatar/user-avatar.svelte
+++ b/src/lib/components/user-avatar/user-avatar.svelte
@@ -34,6 +34,7 @@
   .avatar {
     position: relative;
     margin: 1px;
+    flex-shrink: 0;
   }
 
   img,

--- a/src/routes/app/(app)/component-showcase/+page.svelte
+++ b/src/routes/app/(app)/component-showcase/+page.svelte
@@ -220,7 +220,7 @@
     },
     {
       type: 'address-split',
-      address: '0x99505B669C6064BA2B2f26f2E4fffa5e8d906299',
+      address: '0xbaf6dc2e647aeb6f510f9e318856a1bcd66c5e19',
       weight: 62500,
     },
     {


### PR DESCRIPTION
- restyle Identity, Project, Drip-List badges...
  - matching typographic weights (.typo-text)
  - each badge will truncate ("...") on overflow
- show addresses on list-editor (for #629)

<img width="473" alt="Screenshot 2023-08-23 at 17 03 30" src="https://github.com/drips-network/app/assets/6071219/753341cc-15ba-4105-a2a6-69dbaf52668a">
<img width="489" alt="Screenshot 2023-08-23 at 17 03 39" src="https://github.com/drips-network/app/assets/6071219/862852e2-9351-408a-b284-3ea53f5f3a95">
<img width="194" alt="Screenshot 2023-08-23 at 17 03 50" src="https://github.com/drips-network/app/assets/6071219/941120f2-4078-44a6-9aa2-93efb76dcefb">
