### PR TITLE
Ev/iss629

### DIFF
--- a/src/lib/components/carousel/items/carousel-edu-card.svelte
+++ b/src/lib/components/carousel/items/carousel-edu-card.svelte
@@ -2,7 +2,6 @@
   import Button from '$lib/components/button/button.svelte';
   import dismissablesStore from '$lib/stores/dismissables/dismissables.store';
   import type { ComponentType } from 'svelte';
-  import CrossSmall from 'radicle-design-system/icons/CrossSmall.svelte';
 
   export let id: string;
   export let title: string;
@@ -17,9 +16,6 @@
 </script>
 
 <div class="edu-card">
-  <button class="close-button" on:click={() => dismissablesStore.dismiss(id)}>
-    <CrossSmall />
-  </button>
   <div class="illustration-outer">
     <div class="illustration">
       <svelte:component this={illustration} />
@@ -30,7 +26,8 @@
       <h3 class="pixelated">{title}</h3>
       <p>{description}</p>
     </div>
-    <div class="actions">
+    <div class="actions gap-1">
+      <Button variant="ghost" on:click={() => dismissablesStore.dismiss(id)}>Dismiss</Button>
       {#each actions as action}
         <Button
           icon={action.icon}
@@ -90,22 +87,6 @@
   h3 {
     margin-bottom: 0.5rem;
     margin-right: 1.5rem;
-  }
-
-  .close-button {
-    position: absolute;
-    top: 0.5rem;
-    right: 0.5rem;
-    transition: background-color 0.3s;
-    border-radius: 1rem;
-  }
-
-  .close-button:hover {
-    background-color: var(--color-foreground-level-1);
-  }
-
-  .close-button:focus {
-    background-color: var(--color-foreground-level-2);
   }
 
   @media (max-width: 768px) {

--- a/src/lib/components/dropdown/dropdown.svelte
+++ b/src/lib/components/dropdown/dropdown.svelte
@@ -118,7 +118,7 @@
         {selectedOption.title}
       </span>
     </div>
-    <div class="chevron" class:expanded><ChevronDown /></div>
+    <div class="chevron" class:expanded><ChevronDown style="fill: var(--foreground)" /></div>
   </div>
 
   {#if expanded}

--- a/src/lib/components/section/section.svelte
+++ b/src/lib/components/section/section.svelte
@@ -32,6 +32,6 @@
   }
 
   .content {
-    padding-top: 2rem;
+    padding-top: 1.5rem;
   }
 </style>

--- a/src/lib/components/table/cells/chevron-right-cell.svelte
+++ b/src/lib/components/table/cells/chevron-right-cell.svelte
@@ -3,5 +3,5 @@
 </script>
 
 <div class="flex w-full justify-end pr-3">
-  <ChevronRight />
+  <ChevronRight style="fill: var(--color-foreground)" />
 </div>

--- a/src/lib/flows/add-custom-token/enter-details.svelte
+++ b/src/lib/flows/add-custom-token/enter-details.svelte
@@ -114,7 +114,7 @@
     <TextInput placeholder="https://foo.com/token.png" bind:value={tokenLogoUrl} />
   </FormField>
   <svelte:fragment slot="actions">
-    <Button on:click={() => dispatch('conclude')}>Cancel</Button>
+    <Button on:click={() => dispatch('conclude')} variant="ghost">Cancel</Button>
     <Button variant="primary" disabled={!formValid} on:click={submit}>Add custom token</Button>
   </svelte:fragment>
 </StepLayout>

--- a/src/lib/flows/collect-flow/select-token.svelte
+++ b/src/lib/flows/collect-flow/select-token.svelte
@@ -72,7 +72,7 @@
     </div>
   </FormField>
   <svelte:fragment slot="actions">
-    <Button on:click={() => dispatch('conclude')}>Cancel</Button>
+    <Button on:click={() => dispatch('conclude')} variant="ghost">Cancel</Button>
     <Button variant="primary" disabled={selected.length !== 1} on:click={submit}
       >Select {selectedToken?.info.name ?? ''}</Button
     >

--- a/src/lib/flows/create-stream-flow/input-details.svelte
+++ b/src/lib/flows/create-stream-flow/input-details.svelte
@@ -327,7 +327,7 @@
   </Toggleable>
   <SafeAppDisclaimer disclaimerType="drips" />
   <svelte:fragment slot="actions">
-    <Button on:click={() => dispatch('conclude')}>Cancel</Button>
+    <Button on:click={() => dispatch('conclude')} variant="ghost">Cancel</Button>
     <Button variant="primary" on:click={submit} disabled={!formValid}>Create stream</Button>
   </svelte:fragment>
 </StepLayout>

--- a/src/lib/flows/delete-stream-flow/confirm.svelte
+++ b/src/lib/flows/delete-stream-flow/confirm.svelte
@@ -23,7 +23,7 @@
     description="Are you sure that you want to delete this stream? It will immediately stop streaming, and be irreversibly erased."
   />
   <svelte:fragment slot="actions">
-    <Button on:click={() => dispatch('conclude')}>Cancel</Button>
+    <Button on:click={() => dispatch('conclude')} variant="ghost">Cancel</Button>
     <Button on:click={startDeleting} variant="destructive">Delete stream</Button>
   </svelte:fragment>
 </StepLayout>

--- a/src/lib/flows/edit-drip-list/steps/edit-drip-list.svelte
+++ b/src/lib/flows/edit-drip-list/steps/edit-drip-list.svelte
@@ -153,7 +153,7 @@
     <ListEditor bind:items bind:percentages bind:valid={listValid} />
   </FormField>
   <svelte:fragment slot="actions">
-    <Button on:click={modal.hide}>Cancel</Button>
+    <Button on:click={modal.hide} variant="ghost">Cancel</Button>
     <Button on:click={submit} disabled={!listValid || !nameValid} icon={Wallet} variant="primary"
       >Confirm changes in wallet</Button
     >

--- a/src/lib/flows/edit-splits-flow/edit-splits-inputs.svelte
+++ b/src/lib/flows/edit-splits-flow/edit-splits-inputs.svelte
@@ -235,7 +235,7 @@
   <SafeAppDisclaimer disclaimerType="splits" />
 
   <svelte:fragment slot="actions">
-    <Button on:click={() => dispatch('conclude')}>Cancel</Button>
+    <Button on:click={() => dispatch('conclude')} variant="ghost">Cancel</Button>
     <Button variant="primary" disabled={!isValidForm} on:click={submit}>Confirm</Button>
   </svelte:fragment>
 </StepLayout>

--- a/src/lib/flows/edit-stream-flow/enter-new-details.svelte
+++ b/src/lib/flows/edit-stream-flow/enter-new-details.svelte
@@ -310,7 +310,7 @@
   {/if}
   <SafeAppDisclaimer disclaimerType="drips" />
   <svelte:fragment slot="actions">
-    <Button on:click={modal.hide}>Cancel</Button>
+    <Button on:click={modal.hide} variant="ghost">Cancel</Button>
     <Button variant="primary" icon={Wallet} on:click={updateStream} disabled={!canUpdate}
       >Confirm changes in wallet</Button
     >

--- a/src/lib/flows/top-up-flow/select-token.svelte
+++ b/src/lib/flows/top-up-flow/select-token.svelte
@@ -97,7 +97,7 @@
     </div>
   </FormField>
   <svelte:fragment slot="actions">
-    <Button on:click={() => dispatch('conclude')}>Cancel</Button>
+    <Button on:click={() => dispatch('conclude')} variant="ghost">Cancel</Button>
     <Button variant="primary" disabled={selected.length !== 1} on:click={submit}
       >Add {selectedToken?.info.name ?? ''}</Button
     >

--- a/src/lib/flows/withdraw-flow/enter-amount.svelte
+++ b/src/lib/flows/withdraw-flow/enter-amount.svelte
@@ -203,7 +203,7 @@
   </FormField>
   <SafeAppDisclaimer disclaimerType="drips" />
   <svelte:fragment slot="actions">
-    <Button on:click={() => dispatch('conclude')}>Cancel</Button>
+    <Button on:click={() => dispatch('conclude')} variant="ghost">Cancel</Button>
     <Button variant="primary" disabled={validationState.type !== 'valid'} on:click={triggerWithdraw}
       >Withdraw</Button
     >

--- a/src/routes/app/(app)/settings/custom-tokens/components/confirm-deletion.svelte
+++ b/src/routes/app/(app)/settings/custom-tokens/components/confirm-deletion.svelte
@@ -25,7 +25,7 @@
       description={`"${tokenName}" will be removed from your custom tokens. Any streams streaming this token will show up as "Unknown token".`}
     />
     <svelte:fragment slot="actions">
-      <Button on:click={() => modal.hide()}>Cancel</Button>
+      <Button on:click={() => modal.hide()} variant="ghost">Cancel</Button>
       <Button variant="destructive" on:click={deleteToken}>Delete token</Button>
     </svelte:fragment>
   </StepLayout>

--- a/src/routes/app/(app)/streams/+page.svelte
+++ b/src/routes/app/(app)/streams/+page.svelte
@@ -107,7 +107,7 @@
       props: {
         id: 'collect-earnings',
         title: 'Collect earnings',
-        description: "Learn how to collect funds you've earned from incoming streams or splits.",
+        description: 'Learn how to collect funds youʼve earned from incoming streams or splits.',
         illustration: NoWrappedTokens,
         actions: [
           {
@@ -131,7 +131,7 @@
       props: {
         id: 'explore-the-network',
         title: 'Explore the network',
-        description: "You can view other people's activity on Drips and share your profile.",
+        description: 'You can view other peopleʼs activity on Drips and share your profile.',
         illustration: OneContract,
         actions: [
           {

--- a/src/routes/app/(app)/streams/sections/streams.section.svelte
+++ b/src/routes/app/(app)/streams/sections/streams.section.svelte
@@ -322,7 +322,9 @@
 >
   {#if optionsOutgoing.data.length > 0}
     <div class="table-container">
-      {#if !onlyDripListStreams}<h4 class="table-group-header">↑ Outgoing</h4>{/if}
+      {#if !onlyDripListStreams && optionsIncoming.data.length > 0}<h4 class="table-group-header">
+          ↑ Outgoing
+        </h4>{/if}
       <Table
         rowHeight={76}
         options={optionsOutgoing}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -8,6 +8,7 @@ body {
 
 * {
   transition: background-color 0.2s;
+  font-feature-settings: 'ss02', 'calt' 0;
 }
 
 /* hide input[number] arrows */


### PR DESCRIPTION
selected items from #629 

## Global
- [ ]  Disable the font style setting that makes the "x" character be positioned in the middle of the Cap height when it's between two numbers. i.e. 0x4 shows up as 0×4, when it should show up as 0x4.
- [ ] Make "Cancel" button a ghost button on modals instead of a outline button
- [ ] the chevron on the dropdown component should be foreground, not level 4

## Add funds modal
- [ ] the token ticker symbol should be grey-4 instead of foreground
- [ ] placeholder text should be "Search tokens" instead of just "Search"
