### PR TITLE
style: improve claimable funds section on project profile on mobile

### DIFF
--- a/src/lib/components/aggregate-fiat-estimate/aggregate-fiat-estimate.svelte
+++ b/src/lib/components/aggregate-fiat-estimate/aggregate-fiat-estimate.svelte
@@ -83,7 +83,7 @@
 <style>
   .aggregate-fiat-estimate {
     position: relative;
-    display: flex;
+    display: inline-flex;
     align-items: center;
     gap: 0.25rem;
   }

--- a/src/lib/components/aggregate-fiat-estimate/fiat-estimate-value.svelte
+++ b/src/lib/components/aggregate-fiat-estimate/fiat-estimate-value.svelte
@@ -12,7 +12,7 @@
   {#if forceLoading || fiatEstimateCents === 'pending'}
     <span class="animate-pulse">$...</span>
   {:else if formattedFiatEstimate}
-    <span class="text-foreground-level-5">≈</span>{formattedFiatEstimate}
+    <span class="text-foreground-level-4">≈</span>{formattedFiatEstimate}
   {:else}
     <span aria-label="Unknown amount">??</span>
   {/if}

--- a/src/lib/components/annotation-box/annotation-box.svelte
+++ b/src/lib/components/annotation-box/annotation-box.svelte
@@ -5,16 +5,21 @@
   export let size: 'normal' | 'small' = 'normal';
 </script>
 
-<div class="annotation-box typo-text-small {type} {size}">
-  <div class="content">
+<div
+  class="annotation-box typo-text-small {type} {size} flex flex-wrap items-center justify-between gap-3"
+>
+  <div class="flex gap-2 items-start">
     {#if type === 'warning'}
       <WarningIcon style="height: 1.25rem; width: 1.25rem; fill: var(--color-caution-level-6)" />
     {:else}
       <InfoCircle style="height: 1.25rem; width: 1.25rem; fill: var(--color-primary-level-6)" />
     {/if}
-    <div>
+    <div class="flex-1 pt-px">
       <slot />
     </div>
+  </div>
+  <div class="flex-1 flex justify-end">
+    <slot name="actions" />
   </div>
 </div>
 
@@ -33,7 +38,6 @@
   .annotation-box.small {
     border-radius: 0.75rem 0 0.75rem 0.75rem;
     padding: 0.5rem;
-    background-color: red;
     border-color: none;
   }
 

--- a/src/lib/components/annotation-box/annotation-box.svelte
+++ b/src/lib/components/annotation-box/annotation-box.svelte
@@ -12,9 +12,9 @@
     {:else}
       <InfoCircle style="height: 1.25rem; width: 1.25rem; fill: var(--color-primary-level-6)" />
     {/if}
-    <p>
+    <div>
       <slot />
-    </p>
+    </div>
   </div>
 </div>
 

--- a/src/lib/components/annotation-box/annotation-box.svelte
+++ b/src/lib/components/annotation-box/annotation-box.svelte
@@ -30,11 +30,6 @@
     text-align: left;
   }
 
-  .annotation-box > .content {
-    display: flex;
-    gap: 0.5rem;
-  }
-
   .annotation-box.small {
     border-radius: 0.75rem 0 0.75rem 0.75rem;
     padding: 0.5rem;

--- a/src/lib/components/button/button.svelte
+++ b/src/lib/components/button/button.svelte
@@ -88,7 +88,6 @@
     color: var(--color-foreground);
     user-select: none;
     transition: background-color 0.3s, color 0.3s, transform 0.2s, box-shadow 0.2s, opacity 0.3s;
-    background-color: var(--color-background);
     position: relative;
   }
 
@@ -98,7 +97,6 @@
     left: 0;
     right: 0;
     bottom: 0;
-    background-color: var(--color-background);
     display: flex;
     justify-content: center;
     align-items: center;

--- a/src/lib/components/pile/pile.svelte
+++ b/src/lib/components/pile/pile.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { fly } from 'svelte/transition';
 
-  import type { SvelteComponent } from 'svelte';
+  import { createEventDispatcher, type SvelteComponent } from 'svelte';
   import { sineIn, sineOut } from 'svelte/easing';
 
   export let transitionedOut = false;
@@ -19,6 +19,9 @@
   function getTransitionDelay(index: number, direction: 'in' | 'out') {
     return ((direction === 'in' ? components.length : 0) - index) * 15;
   }
+
+  export let overflowCounterClickable = false;
+  const dispatch = createEventDispatcher();
 </script>
 
 {#if components.length !== 0}
@@ -46,8 +49,9 @@
       {/if}
     {/each}
     {#if overflowAmount > 0 && !transitionedOut}
-      <div
-        class="overflow typo-text-small-bold"
+      <svelte:element
+        this={overflowCounterClickable ? 'button' : 'div'}
+        class="overflow typo-text-small focus-visible:ring-4 focus-visible:ring-primary-level-1 "
         out:fly|local={{
           y: 16,
           duration: 200,
@@ -60,9 +64,10 @@
           delay: getTransitionDelay(components.length - 1, 'in'),
           easing: sineOut,
         }}
+        on:click={() => dispatch('overflowCounterClick')}
       >
         +{overflowAmount}
-      </div>
+      </svelte:element>
     {/if}
   </div>
 {/if}
@@ -78,7 +83,7 @@
   }
 
   .overflow {
-    height: 1.5rem;
+    height: 1.25rem;
     background-color: var(--color-foreground);
     color: var(--color-background);
     padding: 0 0.5rem;
@@ -86,6 +91,6 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    margin-left: 0.25rem;
+    margin-left: 0.5rem;
   }
 </style>

--- a/src/lib/components/token-amounts-table/token-amounts-table.svelte
+++ b/src/lib/components/token-amounts-table/token-amounts-table.svelte
@@ -63,82 +63,42 @@
   }
 </script>
 
-<div class="token-amounts-dropdown">
+<ul class="token-amounts-dropdown">
   {#each amounts as { tokenAddress, amount }, i}
-    <div class="token-amount">
+    <li class="flex flex-wrap items-center justify-between px-4 py-4 sm:py-0 sm:h-14 sm:gap-6">
       {#if tokens && tokens[i]}
-        <div class="token">
+        <div class="-ml-1">
           <Token address={tokenAddress} />
         </div>
-        <div class="amounts typo-text tabular-nums">
-          <div class="token amount muted">
-            {formatTokenAmount(amount, tokens[i]?.info.decimals ?? unreachable(), 1n, false)}
-            {tokens[i]?.info.symbol}
-          </div>
-          <div class="fiat amount">
-            <FiatEstimateValue fiatEstimateCents={fiatEstimates[i]} />
-          </div>
-          {#if showCollectButtons}
-            <div class="collect-button">
-              <Button icon={Download} on:click={() => openCollectModal(tokenAddress)}
-                >Collect</Button
-              >
-            </div>
-          {/if}
+        <div class="sm:order-last">
+          <FiatEstimateValue fiatEstimateCents={fiatEstimates[i]} />
         </div>
+        <div class="w-full my-1 sm:hidden" />
+        <div class="muted sm:flex-1 sm:text-right">
+          {formatTokenAmount(amount, tokens[i]?.info.decimals ?? unreachable(), 1n, false)}
+          {tokens[i]?.info.symbol}
+        </div>
+        {#if showCollectButtons}
+          <div class="-mr-1 sm:order-last">
+            <Button icon={Download} on:click={() => openCollectModal(tokenAddress)}>Collect</Button>
+          </div>
+        {/if}
       {:else if $connected}
         <button
           on:click={() => modal.show(Stepper, undefined, addCustomTokenFlowSteps(tokenAddress))}
           >Unknown token</button
         >
       {/if}
-    </div>
+    </li>
   {/each}
-</div>
+</ul>
 
 <style>
-  .token-amounts-dropdown {
-    background-color: var(--color-foreground-level-1);
-  }
-
-  .token-amount {
-    display: flex;
-    gap: 1rem;
-    align-items: center;
-    height: 3rem;
-    padding: 0 1rem;
-  }
-
-  .token-amount:not(:last-child) {
-    border-bottom: 1px solid var(--color-foreground);
-  }
-
-  .token {
-    flex: 1.25;
-    white-space: nowrap;
-  }
-
-  .amounts {
-    display: flex;
-    gap: 1rem;
-    align-items: center;
-    flex: 1;
-  }
-
-  .amounts .amount {
-    flex: 1;
-  }
-
-  .amount {
-    white-space: nowrap;
-  }
-
-  .fiat.amount {
-    display: flex;
-    justify-content: flex-end;
+  li + li {
+    border-top: 1px solid var(--color-foreground);
   }
 
   .muted {
-    color: var(--color-foreground-level-6);
+    color: var(--color-foreground-level-5);
   }
 </style>

--- a/src/lib/components/unclaimed-project-card/unclaimed-project-card.svelte
+++ b/src/lib/components/unclaimed-project-card/unclaimed-project-card.svelte
@@ -11,7 +11,7 @@
   import TokenAmountsTable from '../token-amounts-table/token-amounts-table.svelte';
   import Button from '../button/button.svelte';
   import { createEventDispatcher } from 'svelte';
-  import Registered from 'radicle-design-system/icons/Registered.svelte';
+  import Wallet from 'radicle-design-system/icons/Wallet.svelte';
 
   const dispatch = createEventDispatcher();
 
@@ -88,10 +88,8 @@
 
         {#if unclaimedFunds.length > 0 && showClaimButton}
           <div class="flex-1 flex flex-col sm:flex-row sm:items-center sm:justify-end">
-            <Button
-              icon={Registered}
-              variant="primary"
-              on:click={() => dispatch('claimButtonClick')}>Claim project</Button
+            <Button icon={Wallet} variant="normal" on:click={() => dispatch('claimButtonClick')}
+              >Claim funds</Button
             >
           </div>
         {/if}

--- a/src/lib/components/unclaimed-project-card/unclaimed-project-card.svelte
+++ b/src/lib/components/unclaimed-project-card/unclaimed-project-card.svelte
@@ -9,6 +9,11 @@
   import AggregateFiatEstimate from '../aggregate-fiat-estimate/aggregate-fiat-estimate.svelte';
   import Toggleable from '../toggleable/toggleable.svelte';
   import TokenAmountsTable from '../token-amounts-table/token-amounts-table.svelte';
+  import Button from '../button/button.svelte';
+  import { createEventDispatcher } from 'svelte';
+  import Registered from 'radicle-design-system/icons/Registered.svelte';
+
+  const dispatch = createEventDispatcher();
 
   export let project: UnclaimedGitProject | undefined = undefined;
   export let projectMetadata:
@@ -33,7 +38,10 @@
     },
   }));
 
+  export let unclaimedTokensExpandable = true;
   export let unclaimedTokensExpanded = false;
+  export let showClaimButton = false;
+  export let claimableTokensKey = 'Tokens';
 </script>
 
 <div class="project-info" transition:fly|local={{ y: 8, duration: 300 }}>
@@ -49,28 +57,44 @@
   {/if}
   {#if unclaimedFunds}
     <div class="unclaimed-funds">
-      <div class="row">
-        {#if unclaimedTokenPile}
-          <KeyValuePair key="Claimable tokens">
-            {#if unclaimedFunds.length > 0}
-              <Pile maxItems={4} components={unclaimedTokenPile} />
-              <button
-                class="expand-chevron"
-                on:click={() => (unclaimedTokensExpanded = !unclaimedTokensExpanded)}
-                style:transform="rotate({unclaimedTokensExpanded ? 180 : 0}deg)"
-              >
-                <ChevronDown style="fill: var(--color-foreground); width: 2rem; height: 2rem;" />
-              </button>
-            {:else}
-              <span class="muted">None</span>
-            {/if}
+      <div class="flex flex-col gap-6 p-4 sm:flex-row">
+        <div class="flex flex-wrap items-start gap-6 sm:gap-12">
+          {#if unclaimedTokenPile}
+            <KeyValuePair key={claimableTokensKey}>
+              {#if unclaimedFunds.length > 0}
+                <Pile maxItems={4} components={unclaimedTokenPile} />
+                {#if unclaimedTokensExpandable}
+                  <button
+                    class="expand-chevron"
+                    on:click={() => (unclaimedTokensExpanded = !unclaimedTokensExpanded)}
+                    style:transform="rotate({unclaimedTokensExpanded ? 180 : 0}deg)"
+                  >
+                    <ChevronDown
+                      style="fill: var(--color-foreground); width: 2rem; height: 2rem;"
+                    />
+                  </button>
+                {/if}
+              {:else}
+                <span class="muted">None</span>
+              {/if}
+            </KeyValuePair>
+          {/if}
+          <KeyValuePair highlight key="Estimated value">
+            <span style="color: var(--color-primary)"
+              ><AggregateFiatEstimate amounts={unclaimedFunds} /></span
+            >
           </KeyValuePair>
+        </div>
+
+        {#if unclaimedFunds.length > 0 && showClaimButton}
+          <div class="flex-1 flex flex-col sm:flex-row sm:items-center sm:justify-end">
+            <Button
+              icon={Registered}
+              variant="primary"
+              on:click={() => dispatch('claimButtonClick')}>Claim project</Button
+            >
+          </div>
         {/if}
-        <KeyValuePair highlight key="Total est. claimable funds">
-          <span style="color: var(--color-primary)"
-            ><AggregateFiatEstimate amounts={unclaimedFunds} /></span
-          >
-        </KeyValuePair>
       </div>
       <Toggleable showToggle={false} toggled={unclaimedTokensExpanded}>
         <div class="token-amounts-table"><TokenAmountsTable amounts={unclaimedFunds} /></div>
@@ -100,16 +124,6 @@
     flex-direction: column;
   }
 
-  .unclaimed-funds {
-    padding-top: 1rem;
-  }
-
-  .unclaimed-funds .row {
-    padding: 0 1rem 1rem 1rem;
-    display: flex;
-    gap: 3rem;
-  }
-
   .expand-chevron {
     transition: transform 0.3s, background-color 0.3s;
     border-radius: 50%;
@@ -121,12 +135,5 @@
 
   .muted {
     color: var(--color-foreground-level-5);
-  }
-
-  @media (max-width: 514px) {
-    .unclaimed-funds .row {
-      flex-direction: column;
-      gap: 2rem;
-    }
   }
 </style>

--- a/src/routes/app/(app)/projects/(forges)/components/project-profile/project-profile.svelte
+++ b/src/routes/app/(app)/projects/(forges)/components/project-profile/project-profile.svelte
@@ -41,6 +41,9 @@
   import type getIncomingSplits from '$lib/utils/splits/get-incoming-splits';
   import Developer from '$lib/components/developer-section/developer.section.svelte';
   import { goto } from '$app/navigation';
+  import Link from 'radicle-design-system/icons/Link.svelte';
+  import Copyable from '$lib/components/copyable/copyable.svelte';
+  import { browser } from '$app/environment';
 
   interface Amount {
     tokenAddress: string;
@@ -126,13 +129,25 @@
             {#await unclaimedFunds}
               <span />
             {:then result}
-              {#if result?.length}This project has claimable funds!{:else}This project is unclaimed.{/if}
+              {#if result?.length}This project has <span class="typo-text-small-bold"
+                  ><AggregateFiatEstimate amounts={result} /></span
+                > in available funds! Project owners can collect by claiming their project.{:else}This
+                project has not been claimed yet but can still receive funds that the owner can
+                collect later.{/if}
             {:catch}
               This project is unclaimed.
             {/await}
-            <span class="hidden sm:inline"
-              >Know the owner? Share it with them so they can collect funds or start fundraising.</span
-            >
+            <svelte:fragment slot="actions">
+              <div class="flex gap-3">
+                <Copyable value={browser ? window.location.href : ''}>
+                  <div class="flex gap-1 items-center">
+                    <Link style="fill:currentColor" />
+                    <div class="whitespace-nowrap">Copy URL</div>
+                  </div>
+                </Copyable>
+                <Button size="small" icon={Registered} variant="primary">Claim project</Button>
+              </div>
+            </svelte:fragment>
           </AnnotationBox>
         </div>
       {/if}
@@ -317,7 +332,7 @@
     grid-template-areas:
       'header'
       'content';
-    gap: 4rem;
+    gap: 3rem;
   }
 
   .project-profile.claimed {

--- a/src/routes/app/(app)/projects/(forges)/components/project-profile/project-profile.svelte
+++ b/src/routes/app/(app)/projects/(forges)/components/project-profile/project-profile.svelte
@@ -34,7 +34,6 @@
   import editProjectMetadataSteps from '$lib/flows/edit-project-metadata/edit-project-metadata-steps';
   import AnnotationBox from '$lib/components/annotation-box/annotation-box.svelte';
   import Registered from 'radicle-design-system/icons/Registered.svelte';
-  import OneContract from '$lib/components/illustrations/one-contract.svelte';
   import buildUrl from '$lib/utils/build-url';
   import editProjectSplitsSteps from '$lib/flows/edit-project-splits/edit-project-splits-steps';
   import { fade } from 'svelte/transition';
@@ -276,35 +275,6 @@
                   on:claimButtonClick={() =>
                     goto(buildUrl('/app/claim-project', { projectToAdd: project.source.url }))}
                 />
-                <div class="unclaimed-project-edu-card">
-                  <div class="illustration"><OneContract /></div>
-                  <div class="flex-1 flex flex-col gap-2">
-                    <div class="flex-1 flex items-center">
-                      <div class="flex flex-col gap-4">
-                        <h3>Are you a maintainer of {project.source.repoName}?</h3>
-                        <p>
-                          Claim the project on Drips to start collecting funds from supporters and
-                          split to your dependencies.
-                        </p>
-                      </div>
-                    </div>
-                    <div class="flex justify-end gap-1">
-                      <a
-                        href="https://docs.drips.network/docs/for-fundraisers/how-to-claim-a-project"
-                        class="typo-text-small learn-more-link"
-                        target="_blank"
-                      >
-                        <Button variant="ghost">Learn more</Button>
-                      </a>
-                      <a
-                        href={buildUrl('/app/claim-project', { projectToAdd: project.source.url })}
-                        class="claim-button"
-                      >
-                        <Button icon={Registered} variant="primary">Claim project</Button>
-                      </a>
-                    </div>
-                  </div>
-                </div>
               </div>
             </SectionSkeleton>
           {:catch}
@@ -424,32 +394,6 @@
     gap: 1rem;
   }
 
-  .unclaimed-project-edu-card {
-    padding: 1rem;
-    border: 1px solid var(--color-foreground);
-    border-radius: 1rem 0 1rem 1rem;
-    display: flex;
-    gap: 2rem;
-  }
-
-  .unclaimed-project-edu-card .illustration {
-    height: 12rem;
-    width: 12rem;
-    flex-shrink: 0;
-    background-color: var(--color-primary-level-1);
-    border-radius: 1rem 0 1rem 1rem;
-  }
-
-  .unclaimed-project-edu-card .learn-more-link {
-    color: var(--color-foreground-level-6);
-    text-decoration: underline;
-  }
-
-  .unclaimed-project-edu-card .claim-button {
-    display: flex;
-    justify-content: flex-end;
-  }
-
   .section {
     display: flex;
     gap: 2rem;
@@ -479,11 +423,6 @@
       justify-content: space-between;
       align-items: baseline;
       flex-direction: column;
-    }
-
-    .unclaimed-project-edu-card {
-      flex-direction: column;
-      align-items: flex-start;
     }
   }
 </style>

--- a/src/routes/app/(flows)/claim-project/steps/enter-git-url/enter-git-url.svelte
+++ b/src/routes/app/(flows)/claim-project/steps/enter-git-url/enter-git-url.svelte
@@ -230,6 +230,7 @@
       project={$context.project}
       projectMetadata={$context.projectMetadata}
       unclaimedFunds={$context.unclaimedFunds}
+      claimableTokensKey="Claimable tokens"
     />
   {/if}
   <svelte:fragment slot="actions">


### PR DESCRIPTION
- reflow to fit inside screen
- "claim" button above the fold
- shorten the AnnotationBox text at the top so things aren't pushed down
<img width="359" alt="Screenshot 2023-09-19 at 15 04 17" src="https://github.com/drips-network/app/assets/6071219/ddab86d8-2a2c-43cc-88d2-91860515bb01">
<img width="1441" alt="Screenshot 2023-09-19 at 15 04 51" src="https://github.com/drips-network/app/assets/6071219/f9dd57bd-2177-4b5d-bd10-d43cf5ca52a3">

Projects Dashboard collectable tokens table:
<img width="336" alt="Screenshot 2023-09-19 at 15 19 37" src="https://github.com/drips-network/app/assets/6071219/08ea2d57-0f25-4dd8-a0de-c74ac7755fc4">

