### PR TITLE
Revert "fix: add back button to funder flow, first step (#666)"

### DIFF
--- a/src/lib/components/stepper/stepper.svelte
+++ b/src/lib/components/stepper/stepper.svelte
@@ -10,7 +10,7 @@
   import modal from '$lib/stores/modal';
   import { browser } from '$app/environment';
 
-  const dispatch = createEventDispatcher<{ stepChange: never; conclude: never }>();
+  const dispatch = createEventDispatcher<{ stepChange: never }>();
 
   export let steps: Steps;
   export let context: (() => Writable<unknown>) | undefined = undefined;
@@ -198,8 +198,6 @@
       disableTransitions = false;
     } else {
       modal.hide();
-      // dispatch in case Stepper is being used in a standalone page (like /funder-onboarding)
-      dispatch('conclude');
     }
   }
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -101,6 +101,7 @@
               href={canSubmitProjectClaim
                 ? buildUrl('/app/claim-project', { projectToAdd: claimProjectInput })
                 : undefined}
+              target="_blank"
               ><Button variant="primary" size="large" disabled={!canSubmitProjectClaim}
                 >Claim project</Button
               ></a
@@ -246,7 +247,7 @@
         <div class="text">
           <h3>Start your Drip List</h3>
           <p>Give to a personalized list of GitHub projects or Ethereum addresses.</p>
-          <a href="/app/funder-onboarding">
+          <a href="/app/funder-onboarding" target="_blank">
             <Button variant="primary" size="large">Create your Drip List</Button>
           </a>
         </div>

--- a/src/routes/app/(flows)/funder-onboarding/+page.svelte
+++ b/src/routes/app/(flows)/funder-onboarding/+page.svelte
@@ -31,7 +31,6 @@
 <Stepper
   bind:currentStepIndex
   on:stepChange={() => window.scrollTo({ top: 0 })}
-  on:conclude={() => window.history.back()}
   context={() => state}
   steps={steps()}
   minHeightPx={512}

--- a/src/routes/app/(flows)/funder-onboarding/steps/build-list/build-list.svelte
+++ b/src/routes/app/(flows)/funder-onboarding/steps/build-list/build-list.svelte
@@ -8,7 +8,6 @@
   import type { State } from '../../funder-onboarding-flow';
   import { page } from '$app/stores';
   import DripListEditor from '$lib/components/drip-list-editor/drip-list-editor.svelte';
-  import ArrowLeft from 'radicle-design-system/icons/ArrowLeft.svelte';
 
   const dispatch = createEventDispatcher<StepComponentEvents>();
 
@@ -29,9 +28,6 @@
     showListFirst={true}
     {projectUrlToAdd}
   />
-  <svelte:fragment slot="left-actions">
-    <Button icon={ArrowLeft} on:click={() => dispatch('conclude')}>Back</Button>
-  </svelte:fragment>
   <svelte:fragment slot="actions">
     <Button
       disabled={!isValid}


### PR DESCRIPTION
Imo best to revert this for now:

- user could be linked to this flow from anywhere, including external sites, in which case it's weird to have an on-page back button. we'd have no idea where it leads to
- if you enter the URL directly or get linked from an external app (e.g. Discord), there's a "back" button, but it just doesn't do anything
- the flow isn't being "concluded", so i don't think dispatching the `conclude` event is appropriate

We should rather work on putting this flow into a modal and being able to trigger it from anywhere soon IMO. Wdyt?