### PR TITLE
fix: existing drip list editor broken

### DIFF
--- a/src/e2e-tests/top-up-create-stream.e2e.test.ts
+++ b/src/e2e-tests/top-up-create-stream.e2e.test.ts
@@ -550,6 +550,7 @@ describe('app', async () => {
 
       await expect(page.locator('text=This is an EDITED title')).toHaveCount(1);
       await expect(page.locator('text=This is an EDITED description.')).toHaveCount(1);
+      await expect(page.locator('text=drips-test-repo-11')).toHaveCount(1);
       await expect(page.locator('text=0x43')).toHaveCount(0);
     });
 

--- a/src/lib/flows/edit-drip-list/steps/edit-drip-list.svelte
+++ b/src/lib/flows/edit-drip-list/steps/edit-drip-list.svelte
@@ -105,10 +105,7 @@
           const callerClient = await getCallerClient();
 
           const { receivers, projectsSplitMetadata } =
-            await dripListService.getProjectsSplitMetadataAndReceivers({
-              percentages,
-              items,
-            });
+            await dripListService.getProjectsSplitMetadataAndReceivers(dripList);
 
           const setSplitsTx = await nftDriverTxFactory.setSplits(dripListId, receivers);
 


### PR DESCRIPTION
problem: the drip list editor was bound to the `dripList` variable, but the submit function used `items` and `percentages`, which are just the original values passed in as props from the parent. Thus, any changes made to `dripList` by the editor didn't actually get applied fully.

Also made sure the E2E suite catches this in the future.