### PR TITLE
fix: fiat estimate makes useless price call if no known tokens

### DIFF
--- a/src/lib/utils/fiat-estimates/fiat-estimates.ts
+++ b/src/lib/utils/fiat-estimates/fiat-estimates.ts
@@ -99,6 +99,9 @@ export async function track(addresses: TokenAddress[]) {
     (i): i is [string, number] => i[1] !== undefined,
   );
 
+  // If knownIds is empty, we're done.
+  if (knownIds.length === 0) return;
+
   // Build a string of all known IDs
   const idString = knownIds.map((i) => i[1]).join(',');
 


### PR DESCRIPTION
If all tokens are unknown, don't call the `/price` without any IDs, because it's just a 404 and creates an unnecessary unhandled exception. 