### PR TITLE
feat: simplified collect screen

### DIFF
--- a/src/e2e-tests/top-up-create-stream.e2e.test.ts
+++ b/src/e2e-tests/top-up-create-stream.e2e.test.ts
@@ -387,7 +387,7 @@ describe('app', async () => {
       });
 
       it('expands the squeezing section', async () => {
-        await page.locator('label:has-text("Include funds from current cycle")').click();
+        await page.locator('label:has-text("Include funds streamed in current cycle")').click();
 
         await page
           .locator(`data-testid=item-383620263794848526656662033323214000554911775452`)

--- a/src/e2e-tests/top-up-create-stream.e2e.test.ts
+++ b/src/e2e-tests/top-up-create-stream.e2e.test.ts
@@ -387,11 +387,11 @@ describe('app', async () => {
       });
 
       it('expands the squeezing section', async () => {
-        await page.locator('label:has-text("Include funds streamed in current cycle")').click();
+        await page.locator('label:has-text("Include unsettled stream earnings")').click();
 
-        await page
-          .locator(`data-testid=item-383620263794848526656662033323214000554911775452`)
-          .click();
+        await expect(
+          page.locator(`data-testid=item-383620263794848526656662033323214000554911775452`),
+        ).toHaveAttribute('aria-selected', 'true');
 
         await page.locator('button', { hasText: 'Collect TEST' }).click();
       });

--- a/src/lib/components/annotation-box/annotation-box.svelte
+++ b/src/lib/components/annotation-box/annotation-box.svelte
@@ -18,9 +18,11 @@
       <slot />
     </div>
   </div>
-  <div class="flex-1 flex justify-end">
-    <slot name="actions" />
-  </div>
+  {#if $$slots.actions}
+    <div class="flex-1 flex justify-end">
+      <slot name="actions" />
+    </div>
+  {/if}
 </div>
 
 <style>

--- a/src/lib/flows/collect-flow/collect-amounts.svelte
+++ b/src/lib/flows/collect-flow/collect-amounts.svelte
@@ -224,7 +224,7 @@
   <StepHeader headline={`Collect ${selectedToken.symbol}`} />
   <div>
     <p>
-      Income from Projects, Drip Lists and streams can be collected on a weekly cycle. Your
+      Income from Drip Lists, projects, and streams becomes collectable on a weekly cycle. Your
       collectable balance updates next on <span class="typo-text-bold"
         >{formatDate(currentCycleEnd, 'onlyDay')}</span
       >.

--- a/src/lib/flows/collect-flow/collect-amounts.svelte
+++ b/src/lib/flows/collect-flow/collect-amounts.svelte
@@ -224,9 +224,9 @@
   <StepHeader headline={`Collect ${selectedToken.symbol}`} />
   <div>
     <p>
-      Tokens streamed to your account automatically become receivable on a weekly cycle. Your
-      receivable balance updates next on <span class="typo-text-bold"
-        >{formatDate(currentCycleEnd)}</span
+      Income from Projects, Drip Lists and streams can be collected on a weekly cycle. Your
+      collectable balance updates next on <span class="typo-text-bold"
+        >{formatDate(currentCycleEnd, 'onlyDay')}</span
       >.
     </p>
     <a
@@ -237,34 +237,37 @@
       >Learn more</a
     >
   </div>
-  <div class="squeeze-section">
-    <Toggleable label="Include funds from current cycle" bind:toggled={squeezeEnabled}>
-      <p>
-        Select which senders from the current cycle you would like to collect from. The network fee
-        for collecting increases with each selected sender.
-      </p>
-      <AnnotationBox type="warning">
-        The amounts shown below are estimated based on your system time so the value you collect may
-        slightly differ.
-      </AnnotationBox>
-      <div class="list-wrapper">
-        <ListSelect
-          items={currentCycleSenders}
-          multiselect
-          bind:selected={selectedSqueezeSenderItems}
-          searchable={false}
-        />
-      </div>
-    </Toggleable>
-  </div>
+  {#if incomingEstimatesBySender.length > 0}
+    <div class="squeeze-section">
+      <Toggleable label="Include funds streamed in current cycle" bind:toggled={squeezeEnabled}>
+        <p>
+          You may collect stream income from specific senders already before the current cycle
+          concludes, but the network fee for collecting increases with each selected sender.
+        </p>
+        <AnnotationBox type="warning">
+          The amounts shown below are estimated based on your system time so the value you collect
+          may slightly differ.
+        </AnnotationBox>
+        <div class="list-wrapper">
+          <ListSelect
+            items={currentCycleSenders}
+            multiselect
+            bind:selected={selectedSqueezeSenderItems}
+            searchable={false}
+            emptyStateText="No funds were streamed to you during the current cycle."
+          />
+        </div>
+      </Toggleable>
+    </div>
+  {/if}
   <FormField title="Review">
     <LineItems
       lineItems={mapFilterUndefined(
         [
           squeezeEnabled
             ? {
-                title: `${selectedToken.symbol} from current cycle`,
-                subtitle: 'Earned from incoming streams',
+                title: `${selectedToken.symbol} streamed in current cycle`,
+                subtitle: 'From incoming streams',
                 value:
                   '≈ ' +
                   formatTokenAmount(
@@ -275,17 +278,22 @@
                 symbol: selectedToken.symbol,
               }
             : undefined,
-          {
-            title: `${selectedToken.symbol} from concluded cycles`,
-            subtitle: 'Earned from incoming streams',
-            value: formatTokenAmount(makeAmount(balances.receivable), selectedToken.decimals, 1n),
-            symbol: selectedToken.symbol,
-            disabled: balances.receivable === 0n,
-          },
+          balances.receivable > 0n
+            ? {
+                title: `${selectedToken.symbol} streamed in concluded cycles`,
+                subtitle: 'From incoming streams',
+                value: formatTokenAmount(
+                  makeAmount(balances.receivable),
+                  selectedToken.decimals,
+                  1n,
+                ),
+                symbol: selectedToken.symbol,
+              }
+            : undefined,
           balances.splittable > 0n
             ? {
-                title: `Splittable ${selectedToken.symbol}`,
-                subtitle: 'Earned from already-received streams or incoming splits & gives',
+                title: `Earned ${selectedToken.symbol}`,
+                subtitle: 'From Projects or Drip Lists',
                 value:
                   '+' +
                   formatTokenAmount(makeAmount(balances.splittable), selectedToken.decimals, 1n),

--- a/src/lib/flows/collect-flow/collect-amounts.svelte
+++ b/src/lib/flows/collect-flow/collect-amounts.svelte
@@ -224,10 +224,8 @@
   <StepHeader headline={`Collect ${selectedToken.symbol}`} />
   <div>
     <p>
-      Income from Drip Lists, projects, and streams becomes collectable on a weekly cycle. Your
-      collectable balance updates next on <span class="typo-text-bold"
-        >{formatDate(currentCycleEnd, 'onlyDay')}</span
-      >.
+      Income from Drip Lists, projects, and streams settles once per week. Your collectable balance
+      updates next on <span class="typo-text-bold">{formatDate(currentCycleEnd, 'onlyDay')}</span>.
     </p>
     <a
       class="typo-text-small"
@@ -239,10 +237,10 @@
   </div>
   {#if incomingEstimatesBySender.length > 0}
     <div class="squeeze-section">
-      <Toggleable label="Include funds streamed in current cycle" bind:toggled={squeezeEnabled}>
+      <Toggleable label="Include unsettled stream income" bind:toggled={squeezeEnabled}>
         <p>
-          You may collect stream income from specific senders already before the current cycle
-          concludes, but the network fee for collecting increases with each selected sender.
+          You may collect stream income from specific senders already before it settles, but the
+          network fee for collecting increases with each selected sender.
         </p>
         <AnnotationBox type="warning">
           The amounts shown below are estimated based on your system time so the value you collect
@@ -254,7 +252,7 @@
             multiselect
             bind:selected={selectedSqueezeSenderItems}
             searchable={false}
-            emptyStateText="No funds were streamed to you during the current cycle."
+            emptyStateText="You don't have any unsettled income from streams."
           />
         </div>
       </Toggleable>
@@ -266,7 +264,7 @@
         [
           squeezeEnabled
             ? {
-                title: `${selectedToken.symbol} streamed in current cycle`,
+                title: `Unsettled ${selectedToken.symbol}`,
                 subtitle: 'From incoming streams',
                 value:
                   '≈ ' +
@@ -280,7 +278,7 @@
             : undefined,
           balances.receivable > 0n
             ? {
-                title: `${selectedToken.symbol} streamed in concluded cycles`,
+                title: `Settled ${selectedToken.symbol}`,
                 subtitle: 'From incoming streams',
                 value: formatTokenAmount(
                   makeAmount(balances.receivable),
@@ -292,8 +290,8 @@
             : undefined,
           balances.splittable > 0n
             ? {
-                title: `Earned ${selectedToken.symbol}`,
-                subtitle: 'From Projects or Drip Lists',
+                title: `Settled ${selectedToken.symbol}`,
+                subtitle: 'From Drip Lists and projects',
                 value: formatTokenAmount(
                   makeAmount(balances.splittable),
                   selectedToken.decimals,

--- a/src/lib/flows/collect-flow/collect-amounts.svelte
+++ b/src/lib/flows/collect-flow/collect-amounts.svelte
@@ -293,6 +293,12 @@
                 disabled: balances.splittable === 0n,
               }
             : undefined,
+          /*
+          It used to be possible to set splits for your own AddressDriver account in the Drips App.
+          Even though it's no longer possible to do so, maybe some old account still has splits set,
+          or maybe the user manually configured splits outside the app. For this reason, we display
+          the splitting percentage while collecting, but only if it's more than 0%.
+          */
           ownSplitsWeight < 1000000n
             ? {
                 title: `Splitting ${getSplitPercent(1000000n - ownSplitsWeight, 'pretty')}`,

--- a/src/lib/flows/collect-flow/collect-amounts.svelte
+++ b/src/lib/flows/collect-flow/collect-amounts.svelte
@@ -293,19 +293,22 @@
                 disabled: balances.splittable === 0n,
               }
             : undefined,
-          {
-            title: `Splitting ${getSplitPercent(1000000n - ownSplitsWeight, 'pretty')}`,
-            value:
-              (squeezeEnabled ? '≈ ' : '') +
-              formatTokenAmount(
-                makeAmount(collectableAfterSplit - splittableAfterReceive),
-                selectedToken.decimals,
-                1n,
-              ),
-            disabled:
-              ownSplitsWeight === 1000000n || collectableAfterSplit - splittableAfterReceive === 0n,
-            symbol: selectedToken.symbol,
-          },
+          ownSplitsWeight < 1000000n
+            ? {
+                title: `Splitting ${getSplitPercent(1000000n - ownSplitsWeight, 'pretty')}`,
+                value:
+                  (squeezeEnabled ? '≈ ' : '') +
+                  formatTokenAmount(
+                    makeAmount(collectableAfterSplit - splittableAfterReceive),
+                    selectedToken.decimals,
+                    1n,
+                  ),
+                disabled:
+                  ownSplitsWeight === 1000000n ||
+                  collectableAfterSplit - splittableAfterReceive === 0n,
+                symbol: selectedToken.symbol,
+              }
+            : undefined,
           balances.collectable !== 0n
             ? {
                 title: `Previously-split funds`,

--- a/src/lib/flows/collect-flow/collect-amounts.svelte
+++ b/src/lib/flows/collect-flow/collect-amounts.svelte
@@ -32,13 +32,11 @@
   import expect from '$lib/utils/expect';
   import transact, { makeTransactPayload } from '$lib/components/stepper/utils/transact';
   import type { StepComponentEvents } from '$lib/components/stepper/types';
-  import { createEventDispatcher } from 'svelte';
+  import { createEventDispatcher, onMount } from 'svelte';
   import SafeAppDisclaimer from '$lib/components/safe-app-disclaimer/safe-app-disclaimer.svelte';
   import type { AddressDriverAccount } from '$lib/stores/streams/types';
 
   export let context: Writable<CollectFlowState>;
-
-  const restorer = $context.restorer;
 
   $: cycle = $context.currentDripsCycle ?? unreachable();
   $: currentCycleEnd = new Date(cycle.start.getTime() + cycle.durationMillis);
@@ -86,6 +84,15 @@
         return acc;
       }, []);
 
+  // Initially select all incoming squeeze senders by default, unless there's prior state.
+  onMount(() => {
+    if ($context.selectedSqueezeSenderItems?.length === 0 && !$context.squeezeEnabled) {
+      $context.selectedSqueezeSenderItems = incomingEstimatesBySender.map(
+        (e) => e.sender.accountId,
+      );
+    }
+  });
+
   let currentCycleSenders: Items;
   $: currentCycleSenders = Object.fromEntries(
     mapFilterUndefined(incomingEstimatesBySender, (estimate) => {
@@ -110,11 +117,8 @@
     }),
   );
 
-  let squeezeEnabled = restorer.restore('squeezeEnabled');
-  let selectedSqueezeSenderItems: string[] = restorer.restore('selectedSqueezeSenderItems');
-
-  $: totalSelectedSqueezeAmount = squeezeEnabled
-    ? selectedSqueezeSenderItems.reduce<bigint>(
+  $: totalSelectedSqueezeAmount = $context.squeezeEnabled
+    ? $context.selectedSqueezeSenderItems.reduce<bigint>(
         (acc, sender) =>
           acc +
           (incomingEstimatesBySender.find((e) => e.sender.accountId === sender)?.amount ??
@@ -145,8 +149,8 @@
           const { DRIPS, ADDRESS_DRIVER } = getNetworkConfig();
 
           let squeezeArgs: Awaited<ReturnType<typeof getSqueezeArgs>> | undefined;
-          if (squeezeEnabled && selectedSqueezeSenderItems.length > 0) {
-            squeezeArgs = await getSqueezeArgs(selectedSqueezeSenderItems, tokenAddress);
+          if ($context.squeezeEnabled && $context.selectedSqueezeSenderItems.length > 0) {
+            squeezeArgs = await getSqueezeArgs($context.selectedSqueezeSenderItems, tokenAddress);
           }
 
           const collectFlow = await AddressDriverPresets.Presets.createCollectFlow({
@@ -201,22 +205,18 @@
           context.update((c) => ({
             ...c,
             amountCollected,
-            squeezeEnabled,
             receipt,
           }));
 
           // The squeeze event should be indexed by now, so this should cause the dashboard to update
           // in the background to reflect the newly reduced incoming balance.
-          if (squeezeEnabled) await balancesStore.updateSqueezeHistory(transactContext.accountId);
+          if ($context.squeezeEnabled) {
+            await balancesStore.updateSqueezeHistory(transactContext.accountId);
+          }
         },
       }),
     );
   }
-
-  $: restorer.saveAll({
-    squeezeEnabled,
-    selectedSqueezeSenderItems,
-  });
 </script>
 
 <StepLayout>
@@ -224,35 +224,25 @@
   <StepHeader headline={`Collect ${selectedToken.symbol}`} />
   <div>
     <p>
-      Income from Drip Lists, projects, and streams settles once per week. Your collectable balance
-      updates next on <span class="typo-text-bold">{formatDate(currentCycleEnd, 'onlyDay')}</span>.
+      Earnings settle once per week. The next settlement date is <span class="typo-text-bold"
+        >{formatDate(currentCycleEnd, 'onlyDay')}</span
+      >.
     </p>
-    <a
-      class="typo-text-small"
-      target="_blank"
-      rel="noreferrer"
-      href="https://docs.drips.network/docs/streaming-and-splitting/manage-funds/collect-earnings"
-      >Learn more</a
-    >
   </div>
   {#if incomingEstimatesBySender.length > 0}
     <div class="squeeze-section">
-      <Toggleable label="Include unsettled stream income" bind:toggled={squeezeEnabled}>
-        <p>
-          You may collect stream income from specific senders already before it settles, but the
-          network fee for collecting increases with each selected sender.
-        </p>
+      <Toggleable label="Include unsettled stream earnings" bind:toggled={$context.squeezeEnabled}>
         <AnnotationBox type="warning">
-          The amounts shown below are estimated based on your system time so the value you collect
-          may slightly differ.
+          The network fee for collecting increases with each selected sender. Unsettled earnings are
+          estimates, so you may collect less than expected.
         </AnnotationBox>
         <div class="list-wrapper">
           <ListSelect
             items={currentCycleSenders}
             multiselect
-            bind:selected={selectedSqueezeSenderItems}
+            bind:selected={$context.selectedSqueezeSenderItems}
             searchable={false}
-            emptyStateText="You don't have any unsettled income from streams."
+            emptyStateText="You don't have any unsettled earnings from streams."
           />
         </div>
       </Toggleable>
@@ -262,36 +252,29 @@
     <LineItems
       lineItems={mapFilterUndefined(
         [
-          squeezeEnabled
-            ? {
-                title: `Unsettled ${selectedToken.symbol}`,
-                subtitle: 'From incoming streams',
-                value:
-                  '≈ ' +
-                  formatTokenAmount(
-                    makeAmount(totalSelectedSqueezeAmount ?? 0n),
-                    selectedToken.decimals,
-                    1n,
-                  ),
-                symbol: selectedToken.symbol,
-              }
-            : undefined,
           balances.receivable > 0n
             ? {
-                title: `Settled ${selectedToken.symbol}`,
-                subtitle: 'From incoming streams',
-                value: formatTokenAmount(
-                  makeAmount(balances.receivable),
-                  selectedToken.decimals,
-                  1n,
-                ),
+                title: `Streams`,
+                subtitle: $context.squeezeEnabled ? 'Including unsettled earnings' : undefined,
+                value:
+                  $context.squeezeEnabled && totalSelectedSqueezeAmount > 0n
+                    ? '≈ ' +
+                      formatTokenAmount(
+                        makeAmount(balances.receivable + (totalSelectedSqueezeAmount ?? 0n)),
+                        selectedToken.decimals,
+                        1n,
+                      )
+                    : formatTokenAmount(
+                        makeAmount(balances.receivable),
+                        selectedToken.decimals,
+                        1n,
+                      ),
                 symbol: selectedToken.symbol,
               }
             : undefined,
           balances.splittable > 0n
             ? {
-                title: `Settled ${selectedToken.symbol}`,
-                subtitle: 'From Drip Lists and projects',
+                title: 'Drip Lists and projects',
                 value: formatTokenAmount(
                   makeAmount(balances.splittable),
                   selectedToken.decimals,
@@ -311,7 +294,7 @@
             ? {
                 title: `Splitting ${getSplitPercent(1000000n - ownSplitsWeight, 'pretty')}`,
                 value:
-                  (squeezeEnabled ? '≈ ' : '') +
+                  ($context.squeezeEnabled ? '≈ ' : '') +
                   formatTokenAmount(
                     makeAmount(collectableAfterSplit - splittableAfterReceive),
                     selectedToken.decimals,
@@ -338,7 +321,7 @@
             title: 'You collect',
             subtitle: 'These funds will be sent to your wallet.',
             value:
-              (squeezeEnabled ? '≈ ' : '') +
+              ($context.squeezeEnabled && totalSelectedSqueezeAmount > 0n ? '≈ ' : '') +
               formatTokenAmount(makeAmount(collectableAfterSplit), selectedToken.decimals, 1n),
             symbol: selectedToken.symbol,
             disabled: collectableAfterSplit === 0n,
@@ -362,18 +345,6 @@
 <style>
   p {
     color: var(--color-foreground-level-6);
-    text-align: left;
-  }
-
-  .squeeze-section p {
-    margin-bottom: 1rem;
-  }
-
-  a {
-    color: var(--color-foreground-level-6);
-    text-decoration: underline;
-    display: block;
-    margin-top: 0.5rem;
     text-align: left;
   }
 

--- a/src/lib/flows/collect-flow/collect-amounts.svelte
+++ b/src/lib/flows/collect-flow/collect-amounts.svelte
@@ -294,9 +294,11 @@
             ? {
                 title: `Earned ${selectedToken.symbol}`,
                 subtitle: 'From Projects or Drip Lists',
-                value:
-                  '+' +
-                  formatTokenAmount(makeAmount(balances.splittable), selectedToken.decimals, 1n),
+                value: formatTokenAmount(
+                  makeAmount(balances.splittable),
+                  selectedToken.decimals,
+                  1n,
+                ),
                 symbol: selectedToken.symbol,
                 disabled: balances.splittable === 0n,
               }
@@ -326,9 +328,11 @@
           balances.collectable !== 0n
             ? {
                 title: `Previously-split funds`,
-                value:
-                  '+' +
-                  formatTokenAmount(makeAmount(balances.collectable), selectedToken.decimals, 1n),
+                value: formatTokenAmount(
+                  makeAmount(balances.collectable),
+                  selectedToken.decimals,
+                  1n,
+                ),
                 symbol: selectedToken.symbol,
               }
             : undefined,

--- a/src/lib/flows/collect-flow/collect-flow-state.ts
+++ b/src/lib/flows/collect-flow/collect-flow-state.ts
@@ -1,12 +1,6 @@
-import { newRestorer, type Restorer } from '$lib/utils/restorer';
 import type { ContractReceipt } from 'ethers';
 import type { SplitsEntry } from 'radicle-drips';
 import { writable } from 'svelte/store';
-
-type Restorable = {
-  squeezeEnabled: boolean;
-  selectedSqueezeSenderItems: string[];
-};
 
 export interface CollectFlowState {
   tokenAddress?: string;
@@ -23,13 +17,14 @@ export interface CollectFlowState {
     durationMillis: number;
   };
   amountCollected?: bigint;
-  squeezeEnabled?: boolean;
+  squeezeEnabled: boolean;
+  selectedSqueezeSenderItems: string[];
   receipt?: ContractReceipt;
-  restorer: Restorer<Restorable>;
 }
 
 export default (tokenAddress?: string) =>
   writable<CollectFlowState>({
     tokenAddress,
-    restorer: newRestorer<Restorable>({ squeezeEnabled: false, selectedSqueezeSenderItems: [] }),
+    squeezeEnabled: false,
+    selectedSqueezeSenderItems: [],
   });

--- a/src/lib/flows/collect-flow/fetch-collectable-amounts.svelte
+++ b/src/lib/flows/collect-flow/fetch-collectable-amounts.svelte
@@ -80,7 +80,7 @@
   onMount(() =>
     dispatch('await', {
       promise,
-      message: 'Fetching collectable amounts…',
+      message: 'Getting ready…',
     }),
   );
 </script>

--- a/src/lib/utils/format-date.ts
+++ b/src/lib/utils/format-date.ts
@@ -23,6 +23,20 @@ const DATE_FORMAT_CONVENTIONS = {
   },
 } as const;
 
+function suffixNumber(n: number) {
+  if (n > 3 && n < 21) return 'th';
+  switch (n % 10) {
+    case 1:
+      return 'st';
+    case 2:
+      return 'nd';
+    case 3:
+      return 'rd';
+    default:
+      return 'th';
+  }
+}
+
 /**
  * Format a date with a reusable, pre-configured date format convention.
  * @param date The date to format.
@@ -33,5 +47,8 @@ export default function (
   date: Date,
   convention: keyof typeof DATE_FORMAT_CONVENTIONS = 'standard',
 ): string {
-  return Intl.DateTimeFormat('en-US', DATE_FORMAT_CONVENTIONS[convention]).format(date);
+  return (
+    Intl.DateTimeFormat('en-US', DATE_FORMAT_CONVENTIONS[convention]).format(date) +
+    (convention === 'onlyDay' ? suffixNumber(date.getDate()) : '')
+  );
 }

--- a/src/routes/app/(app)/projects/+page.svelte
+++ b/src/routes/app/(app)/projects/+page.svelte
@@ -62,10 +62,10 @@
       <div class="earnings card">
         <div class="content">
           <div class="values">
-            <KeyValuePair key="Collectable now" highlight>
+            <KeyValuePair key="Settled earnings" highlight>
               <AggregateFiatEstimate amounts={$splittableStore} />
             </KeyValuePair>
-            <KeyValuePair key="Next payout">{formatDate(cycle.end, 'onlyDay')}</KeyValuePair>
+            <KeyValuePair key="Next settlement">{formatDate(cycle.end, 'onlyDay')}</KeyValuePair>
           </div>
           <div />
         </div>


### PR DESCRIPTION
Most users will only be collecting split income (from Drip Lists and Projects), so this aims to simplify their collect screen by hiding most streaming-related stuff.

- Completely hides streaming-related balances if they're zero
- Hides squeezing if they're zero
- Greatly simplifies language around collectable balances — no more "cycle", no more "splittable", etc.… just "settlement once per week".

Also:
- Fix for `AnnotationBox` having a wonky layout if actions slot is empty (cc @evvvritt)

Someone who is collecting income from Drip Lists / Projects & also has some stream income now sees the screen like this: 

<img width="725" alt="Screenshot 2023-10-02 at 17 14 30" src="https://github.com/drips-network/app/assets/1018218/58642899-6590-4d85-812e-c598767d15ca">