### PR TITLE
create multiple drip lists, list as grid of linked card-thumbs (closes #694, closes #695, closes #697)

### DIFF
--- a/src/lib/components/drip-list-card/drip-list-card-representational.svelte
+++ b/src/lib/components/drip-list-card/drip-list-card-representational.svelte
@@ -148,7 +148,7 @@
 >
   <div class="flex flex-col gap-8" class:pointer-events-none={format === 'thumblink'}>
     <header class="px-6 pt-6 flex flex-col gap-4">
-      <div class="flex flex-wrap justify-between">
+      <div class="flex flex-col gap-4 sm:flex-row sm:justify-between">
         <h1 class="flex-1 min-w-0 truncate">
           <a
             href={dripListUrl}

--- a/src/lib/components/drip-list-card/drip-list-card-representational.svelte
+++ b/src/lib/components/drip-list-card/drip-list-card-representational.svelte
@@ -148,7 +148,11 @@
 >
   <div class="flex flex-col gap-8" class:pointer-events-none={format === 'thumblink'}>
     <header class="px-6 pt-6 flex flex-col gap-4">
-      <div class="flex flex-col gap-4 sm:flex-row sm:justify-between">
+      <div
+        class="flex gap-4 items-center {format === 'full'
+          ? 'flex-col sm:flex-row sm:justify-between'
+          : ''}"
+      >
         <h1 class="flex-1 min-w-0 truncate">
           <a
             href={dripListUrl}
@@ -177,7 +181,7 @@
 
     <div class="list">
       <div class="totals">
-        <div class="drip-icon">
+        <div class="drip-icon flex-shrink-0">
           <Drip />
         </div>
         <div class="typo-text tabular-nums total-streamed-badge">
@@ -188,8 +192,8 @@
           <span class="muted">&nbsp;total</span>
         </div>
         {#if supportersPile && supportersPile.length > 0}
-          <div in:fade|local={{ duration: 300 }} class="supporters">
-            <span class="muted">Supported by</span>
+          <div in:fade|local={{ duration: 300 }} class="supporters min-w-0">
+            <span class="truncate muted">Supported by</span>
             <Pile components={supportersPile ?? []} itemsClickable={true} />
           </div>
         {/if}

--- a/src/lib/components/drip-list-card/drip-list-card-representational.svelte
+++ b/src/lib/components/drip-list-card/drip-list-card-representational.svelte
@@ -25,10 +25,12 @@
   import type { Stream } from '$lib/stores/streams/types';
   import type getIncomingSplitTotal from '$lib/utils/splits/get-incoming-split-total';
   import type { DripList } from '$lib/utils/metadata/types';
+  import ChevronRight from 'radicle-design-system/icons/ChevronRight.svelte';
 
   export let dripList: DripList;
-  $: dripListUrl = `/app/drip-lists/${dripList.account.accountId}`;
+  export let format: 'thumblink' | 'full' = 'full';
 
+  $: dripListUrl = `/app/drip-lists/${dripList.account.accountId}`;
   $: isOwnList = $walletStore && checkIsUser(dripList.account.owner.accountId);
 
   export let representationalSplits:
@@ -136,67 +138,73 @@
   }
 </script>
 
-<section class="card">
-  <header class="px-6 pt-6 flex flex-col gap-4">
-    <div class="flex flex-wrap justify-between">
-      <h1 class="flex-1 min-w-0 truncate">
-        <a
-          href={dripListUrl}
-          class="focus-visible:outline-none focus-visible:bg-primary-level-1 rounded"
-        >
-          {dripList.name}
-        </a>
-      </h1>
-      <div class="flex items-center gap-4">
-        <ShareButton url="https://drips.network/app/drip-lists/{dripList.account.accountId}" />
-        {#if isOwnList}
-          <Button on:click={triggerEditModal} icon={Pen}>Edit list</Button>
-        {/if}
-      </div>
-    </div>
-    {#if (dripList.description ?? '').length > 0}
-      <TextExpandable>
-        {dripList.description}
-      </TextExpandable>
-    {/if}
-  </header>
-
-  <div class="list">
-    <div class="totals">
-      <div class="drip-icon">
-        <Drip />
-      </div>
-      <div class="typo-text tabular-nums total-streamed-badge">
-        {#if browser}
-          <!-- TODO: Include incoming splits -->
-          <AggregateFiatEstimate amounts={totalIncomingAmounts} />
-        {/if}
-        <span class="muted">&nbsp;total</span>
-      </div>
-      {#if supportersPile && supportersPile.length > 0}
-        <div in:fade|local={{ duration: 300 }} class="supporters">
-          <span class="muted">Supported by</span>
-          <Pile components={supportersPile ?? []} itemsClickable={true} />
+<svelte:element
+  this={format === 'thumblink' ? 'a' : 'section'}
+  href={format === 'thumblink' ? dripListUrl : undefined}
+  class="rounded-drip-lg shadow-low group transform transition duration-200 mouse:hover:shadow-md mouse:hover:-translate-y-2px focus-visible:shadow-md focus-visible:-translate-y-2px"
+>
+  <div class="flex flex-col gap-8" class:pointer-events-none={format === 'thumblink'}>
+    <header class="px-6 pt-6 flex flex-col gap-4">
+      <div class="flex flex-wrap justify-between">
+        <h1 class="flex-1 min-w-0 truncate">
+          <a
+            href={dripListUrl}
+            class="focus-visible:outline-none focus-visible:bg-primary-level-1 rounded"
+          >
+            {dripList.name}
+          </a>
+        </h1>
+        <div class="flex items-center gap-4">
+          {#if format === 'thumblink'}
+            <div
+              class="h-8 w-8 rounded-full flex items-center justify-center mouse:group-hover:bg-primary-level-1"
+            >
+              <ChevronRight />
+            </div>
+          {:else}
+            <ShareButton url="https://drips.network/app/drip-lists/{dripList.account.accountId}" />
+            {#if isOwnList}
+              <Button on:click={triggerEditModal} icon={Pen}>Edit list</Button>
+            {/if}
+          {/if}
         </div>
+      </div>
+      {#if (dripList.description ?? '').length > 0}
+        <TextExpandable>
+          {dripList.description}
+        </TextExpandable>
+      {/if}
+    </header>
+
+    <div class="list">
+      <div class="totals">
+        <div class="drip-icon">
+          <Drip />
+        </div>
+        <div class="typo-text tabular-nums total-streamed-badge">
+          {#if browser}
+            <!-- TODO: Include incoming splits -->
+            <AggregateFiatEstimate amounts={totalIncomingAmounts} />
+          {/if}
+          <span class="muted">&nbsp;total</span>
+        </div>
+        {#if supportersPile && supportersPile.length > 0}
+          <div in:fade|local={{ duration: 300 }} class="supporters">
+            <span class="muted">Supported by</span>
+            <Pile components={supportersPile ?? []} itemsClickable={true} />
+          </div>
+        {/if}
+      </div>
+      {#if representationalSplits}
+        <div class="splits-component"><Splits list={representationalSplits} /></div>
+      {:else}
+        Loading...
       {/if}
     </div>
-    {#if representationalSplits}
-      <div class="splits-component"><Splits list={representationalSplits} /></div>
-    {:else}
-      Loading...
-    {/if}
   </div>
-</section>
+</svelte:element>
 
 <style>
-  .card {
-    border: 1px solid var(--color-foreground);
-    border-radius: 1rem 0 1rem 1rem;
-    display: flex;
-    flex-direction: column;
-    gap: 2rem;
-  }
-
   .totals {
     display: flex;
     align-items: center;

--- a/src/lib/components/drip-list-card/drip-list-card-representational.svelte
+++ b/src/lib/components/drip-list-card/drip-list-card-representational.svelte
@@ -29,6 +29,7 @@
 
   export let dripList: DripList;
   export let format: 'thumblink' | 'full' = 'full';
+  export let maxSplitsRows: number | undefined = undefined;
 
   $: dripListUrl = `/app/drip-lists/${dripList.account.accountId}`;
   $: isOwnList = $walletStore && checkIsUser(dripList.account.owner.accountId);
@@ -141,7 +142,9 @@
 <svelte:element
   this={format === 'thumblink' ? 'a' : 'section'}
   href={format === 'thumblink' ? dripListUrl : undefined}
-  class="rounded-drip-lg shadow-low group transform transition duration-200 mouse:hover:shadow-md mouse:hover:-translate-y-2px focus-visible:shadow-md focus-visible:-translate-y-2px"
+  class="rounded-drip-lg shadow-low group transform {format === 'thumblink'
+    ? 'transition duration-200 mouse:hover:shadow-md mouse:hover:-translate-y-2px focus-visible:shadow-md focus-visible:-translate-y-2px'
+    : ''}"
 >
   <div class="flex flex-col gap-8" class:pointer-events-none={format === 'thumblink'}>
     <header class="px-6 pt-6 flex flex-col gap-4">
@@ -154,20 +157,16 @@
             {dripList.name}
           </a>
         </h1>
-        <div class="flex items-center gap-4">
-          {#if format === 'thumblink'}
-            <div
-              class="h-8 w-8 rounded-full flex items-center justify-center mouse:group-hover:bg-primary-level-1"
-            >
-              <ChevronRight />
-            </div>
-          {:else}
+        {#if format === 'thumblink'}
+          <ChevronRight />
+        {:else}
+          <div class="flex items-center gap-4">
             <ShareButton url="https://drips.network/app/drip-lists/{dripList.account.accountId}" />
             {#if isOwnList}
               <Button on:click={triggerEditModal} icon={Pen}>Edit list</Button>
             {/if}
-          {/if}
-        </div>
+          </div>
+        {/if}
       </div>
       {#if (dripList.description ?? '').length > 0}
         <TextExpandable>
@@ -196,7 +195,9 @@
         {/if}
       </div>
       {#if representationalSplits}
-        <div class="splits-component"><Splits list={representationalSplits} /></div>
+        <div class="splits-component">
+          <Splits list={representationalSplits} maxRows={maxSplitsRows} />
+        </div>
       {:else}
         Loading...
       {/if}

--- a/src/lib/components/drip-list-card/drip-list-card.svelte
+++ b/src/lib/components/drip-list-card/drip-list-card.svelte
@@ -9,6 +9,7 @@
 
   export let dripList: DripList;
   export let format: 'thumblink' | 'full' = 'full';
+  export let maxSplitsRows: number | undefined = undefined;
 
   /*
     On mount, ensure the streams store has fetched the owner's account so that we can be sure that
@@ -65,4 +66,5 @@
   {incomingSplits}
   {supportStreams}
   {incomingSplitTotal}
+  {maxSplitsRows}
 />

--- a/src/lib/components/drip-list-card/drip-list-card.svelte
+++ b/src/lib/components/drip-list-card/drip-list-card.svelte
@@ -8,6 +8,7 @@
   import getIncomingSplitTotal from '$lib/utils/splits/get-incoming-split-total';
 
   export let dripList: DripList;
+  export let format: 'thumblink' | 'full' = 'full';
 
   /*
     On mount, ensure the streams store has fetched the owner's account so that we can be sure that
@@ -58,6 +59,7 @@
 </script>
 
 <DripListCardRepresentational
+  {format}
   {dripList}
   {representationalSplits}
   {incomingSplits}

--- a/src/lib/components/drip-lists-section/drip-lists-section.svelte
+++ b/src/lib/components/drip-lists-section/drip-lists-section.svelte
@@ -138,7 +138,7 @@
   {#if visibleDripLists}
     <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
       {#each visibleDripLists as dripList}
-        <DripListCard {dripList} format="thumblink" />
+        <DripListCard {dripList} format="thumblink" maxSplitsRows={4} />
       {/each}
     </div>
   {/if}

--- a/src/lib/components/drip-lists-section/drip-lists-section.svelte
+++ b/src/lib/components/drip-lists-section/drip-lists-section.svelte
@@ -103,6 +103,7 @@
   }
 
   $: isSelf = Boolean(accountId && accountId === $walletStore.dripsAccountId);
+  $: isGridFormat = (visibleDripLists?.length ?? 0) > 1;
 </script>
 
 <Section
@@ -110,8 +111,8 @@
   bind:collapsable
   header={{
     icon: DripListIcon,
-    label: 'Drip List',
-    actionsDisabled: !dripLists || dripLists.length > 0,
+    label: 'Drip Lists',
+    actionsDisabled: !dripLists,
     actions: isSelf
       ? [
           {
@@ -136,7 +137,7 @@
   }}
 >
   {#if visibleDripLists}
-    <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
+    <div class="grid gap-6 grid-cols-1 {visibleDripLists.length > 0 ? 'sm:grid-cols-2' : '1'}">
       {#each visibleDripLists as dripList}
         <DripListCard {dripList} format="thumblink" maxSplitsRows={4} />
       {/each}

--- a/src/lib/components/drip-lists-section/drip-lists-section.svelte
+++ b/src/lib/components/drip-lists-section/drip-lists-section.svelte
@@ -140,7 +140,7 @@
   }}
 >
   {#if visibleDripLists}
-    <div class="grid gap-6 grid-cols-1 {visibleDripLists.length > 0 ? 'sm:grid-cols-2' : '1'}">
+    <div class="grid gap-6 grid-cols-1 {visibleDripLists.length > 0 ? 'lg:grid-cols-2' : ''}">
       {#each visibleDripLists as dripList}
         <DripListCard {dripList} format="thumblink" maxSplitsRows={4} />
       {/each}

--- a/src/lib/components/drip-lists-section/drip-lists-section.svelte
+++ b/src/lib/components/drip-lists-section/drip-lists-section.svelte
@@ -132,11 +132,14 @@
     emptyStateText: isSelf
       ? 'Create a Drip List to start supporting your dependencies'
       : 'Drip Lists enable supporting a set of open-source projects',
+    horizontalScroll: false,
   }}
 >
   {#if visibleDripLists}
-    {#each visibleDripLists as dripList}
-      <DripListCard {dripList} />
-    {/each}
+    <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
+      {#each visibleDripLists as dripList}
+        <DripListCard {dripList} format="thumblink" />
+      {/each}
+    </div>
   {/if}
 </Section>

--- a/src/lib/components/drip-lists-section/drip-lists-section.svelte
+++ b/src/lib/components/drip-lists-section/drip-lists-section.svelte
@@ -10,10 +10,13 @@
   import Section from '../section/section.svelte';
   import AddressDriverMetadataManager from '$lib/utils/metadata/AddressDriverMetadataManager';
   import { AddressDriverClient } from 'radicle-drips';
+  import Button from '../button/button.svelte';
+  import Illustration from '../icons/✏️.svelte';
 
   export let accountId: string | undefined;
   export let collapsed = false;
   export let collapsable = false;
+  export let showCreateNewListCard = false;
 
   /** Set to true if the `visibleDripListAccountIds` setting from metadata should be ignored. */
   export let showHiddenDripLists = false;
@@ -141,6 +144,23 @@
       {#each visibleDripLists as dripList}
         <DripListCard {dripList} format="thumblink" maxSplitsRows={4} />
       {/each}
+      {#if showCreateNewListCard}
+        <div
+          class="shadow-low rounded-drip-lg flex items-center justify-center p-1"
+          style:min-height="452px"
+        >
+          <div class="flex flex-col items-center gap-2 text-center">
+            <Illustration size={48} />
+            <h6 class="typo-text-bold">Got a new idea?</h6>
+            <p>You can create as many Drip Lists as you like.</p>
+            <div class="mt-2">
+              <Button icon={Plus} on:click={() => goto('/app/funder-onboarding')}
+                >Create a new Drip List</Button
+              >
+            </div>
+          </div>
+        </div>
+      {/if}
     </div>
   {/if}
 </Section>

--- a/src/lib/components/padded-horizontal-scroll/padded-horizontal-scroll.svelte
+++ b/src/lib/components/padded-horizontal-scroll/padded-horizontal-scroll.svelte
@@ -19,7 +19,7 @@
 
   .padded-horizontal-scroll > .content {
     min-width: 100%;
-    padding: 0 2.5rem;
+    padding: 1px 2.5rem; /* 1px so box-shadow outlined content is not clipped */
     width: fit-content;
   }
 

--- a/src/lib/components/splits/components/split/split.svelte
+++ b/src/lib/components/splits/components/split/split.svelte
@@ -12,10 +12,10 @@
   import ProjectAvatar from '$lib/components/project-avatar/project-avatar.svelte';
   import { tweened } from 'svelte/motion';
   import { sineInOut } from 'svelte/easing';
-  import ChevronDown from 'radicle-design-system/icons/ChevronDown.svelte';
   import DripsLogo from '$lib/components/header/drips-logo.svelte';
   import mapFilterUndefined from '$lib/utils/map-filter-undefined';
   import DripListBadge from '$lib/components/drip-list-badge/drip-list-badge.svelte';
+  import ChevronRight from 'radicle-design-system/icons/ChevronRight.svelte';
 
   export let split: Split | SplitGroup;
   export let linkToNewTab = false;
@@ -194,18 +194,18 @@
               <Pile transitionedOut={groupExpanded} components={getPileComponents(split.list)} />
             </div>
             <div class="label" style:transform="translateX({$groupNameOffset}px)">
-              <h4>{split.name}</h4>
+              <div class="typo-header-4">{split.name}</div>
               {#if split.list.length > 0}
                 <div
                   class="chevron"
-                  style:transform={groupExpanded ? 'rotate3d(1, 0, 0, 180deg)' : ''}
+                  style:transform={groupExpanded ? 'rotate3d(1, 0, 0, 90deg)' : ''}
                 >
-                  <ChevronDown />
+                  <ChevronRight />
                 </div>
               {/if}
             </div>
             <div class="label placeholder" aria-hidden="true">
-              <h4>{split.name}</h4>
+              <div class="typo-header-4">{split.name}</div>
             </div>
           </button>
           {#if groupExpanded}

--- a/src/lib/components/splits/splits.svelte
+++ b/src/lib/components/splits/splits.svelte
@@ -85,23 +85,40 @@
   import SplitComponent from './components/split/split.svelte';
 
   export let list: Splits;
+  export let maxRows: number | undefined = undefined;
 
   // Sort splits by highest percentage first, with groups at the bottom always.
-  $: sortedList = list.sort((a, b) => {
-    if (a.type === 'split-group' && b.type === 'split-group') return 0;
-    if (a.type === 'split-group') return 1;
-    if (b.type === 'split-group') return -1;
+  const sortList = (list: Splits) =>
+    list.sort((a, b) => {
+      if (a.type === 'split-group' && b.type === 'split-group') return 0;
+      if (a.type === 'split-group') return 1;
+      if (b.type === 'split-group') return -1;
 
-    return b.weight - a.weight;
-  });
+      return b.weight - a.weight;
+    });
+
+  function truncateList(list: Splits) {
+    if (!maxRows || list.length === maxRows) {
+      return list;
+    }
+    const clipIndex = maxRows - 1;
+    const truncatedGroup: SplitGroup = {
+      type: 'split-group',
+      list: list.slice(clipIndex, list.length),
+      name: '',
+    };
+    return list.slice(0, clipIndex).concat(truncatedGroup);
+  }
+
+  $: sortedList = truncateList(sortList(list));
 
   export let linkToNewTab = false;
   export let isGroup = false;
 </script>
 
-<div class="splits-list" class:group={isGroup}>
+<ul class="splits-list" class:group={isGroup}>
   {#each sortedList as listItem, index}
-    <div class="split">
+    <li class="split">
       <SplitComponent
         isFirst={index === 0}
         isLast={index === sortedList.length - 1}
@@ -109,9 +126,9 @@
         isNested={isGroup}
         split={listItem}
       />
-    </div>
+    </li>
   {/each}
-</div>
+</ul>
 
 <style>
   .splits-list {

--- a/src/lib/components/user-avatar/user-avatar.svelte
+++ b/src/lib/components/user-avatar/user-avatar.svelte
@@ -48,6 +48,7 @@
   }
 
   img.outlined {
+    margin: 1px;
     box-shadow: var(--elevation-low);
   }
 

--- a/src/routes/app/(app)/[accountId]/+page.svelte
+++ b/src/routes/app/(app)/[accountId]/+page.svelte
@@ -150,7 +150,7 @@
     </SectionSkeleton>
     <Developer accountId={dripsAccountId} />
     <ProjectsSection collapsable {address} />
-    <DripListsSection collapsable {accountId} />
+    <DripListsSection collapsable accountId={dripsAccountId} />
     <Streams collapsable accountId={dripsAccountId} />
     <Balances collapsable collapsed accountId={dripsAccountId} />
     {#if address && !$dismissablesStore.includes('profile-drips-v1')}

--- a/src/routes/app/(app)/drip-lists/+page.svelte
+++ b/src/routes/app/(app)/drip-lists/+page.svelte
@@ -48,7 +48,7 @@
       </div>
     </svelte:fragment>
   </EduCard>
-  <DripListsSection accountId={$walletStore.dripsAccountId} />
+  <DripListsSection accountId={$walletStore.dripsAccountId} showCreateNewListCard={true} />
 </div>
 
 <style>

--- a/src/routes/app/(app)/drip-lists/[listId]/+page.svelte
+++ b/src/routes/app/(app)/drip-lists/[listId]/+page.svelte
@@ -32,7 +32,7 @@
       <IdentityBadge address={data.dripList.account.owner.address} />
     </div>
 
-    <SectionSkeleton loaded={Boolean(data.dripList)}>
+    <SectionSkeleton loaded={Boolean(data.dripList)} horizontalScroll={false}>
       <DripListCardRepresentational
         incomingSplitTotal={data.incomingSplitsTotal}
         {supportStreams}

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -55,6 +55,9 @@ module.exports = {
       boxShadow: {
         'low': 'var(--elevation-low)',
         'md': 'var(--elevation-medium)',
+      },
+      translate: {
+        '2px': '2px'
       }
     },
   },


### PR DESCRIPTION
closes #694, #695, #697
- card thumblink "format"
- create new drip list card
- grid view on dashboard and profile
- improve mobile layout (remove side scrolling)