### PR TITLE
Revert "Add svelte check in pre-commit hook"

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,8 +2,3 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 npx lint-staged --concurrent false
-
-if ! npm run check; then
-  echo "check script failed"
-  exit 1
-fi


### PR DESCRIPTION
IMO there are a few workflow problems with this:

- It runs the check on the entire repo, not just on your staged changes (like the linter does), so you are blocked from committing a perfectly valid change if you have any in-progress unstaged changes elsewhere in the repo that svelte-check doesn't like.
- It practically makes the VSCode commit button useless, at least on my macbook — takes anywhere between 30 seconds to 1 minute to commit. It's a bit better, but still pretty slow on the terminal, especially if you're making many commits in a row.
- If your workflow is to make a lot of changes, and then selectively stage & commit to break them into multiple chunks, you now have to wait for `svelte-check` to scan the entire repo for _every_ individual commit, even if you already ran svelte-check before and know there's no issues in the repo. You can skip commit verification of course, but then you're also skipping `lint-staged` and may commit badly formatted code.

IMO, it's enough to have svelte-check ran as a check on PRs, which still finishes pretty quickly and effectively prevents bad changes from ending up on main. Of course, you can also run `npm run check` on-demand anytime you want locally.