### PR TITLE
Add 'Total Dripped' badge to landing page (closes #645)

### DIFF
--- a/src/lib/components/network-total-dripped-badge/NetworkTotalDrippedBadge.svelte
+++ b/src/lib/components/network-total-dripped-badge/NetworkTotalDrippedBadge.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+  import Drip from '../illustrations/drip.svelte';
+  import mergeAmounts from '$lib/utils/amounts/merge-amounts';
+  import balancesStore from '$lib/stores/balances/balances.store';
+  import { constants } from 'radicle-drips';
+  import AggregateFiatEstimate from '../aggregate-fiat-estimate/aggregate-fiat-estimate.svelte';
+  import accountFetchStatusses from '$lib/stores/account-fetch-statusses/account-fetch-statusses.store';
+
+  let dripLists = [
+    {
+      // Radworks Software Dep.s list
+      id: '50330452048867519181028275890986093327647919805766323166158196453514',
+      ownerAccountId: '808735843097274646438052281344003835551042056378',
+    },
+  ];
+
+  // copied logic from drip-list-card.svelte
+  // but balances/streams are not loaded
+  // i guess bc it's landing page and outside /app setup?
+
+  // (just focusing on dripLists[0] for simplicity)
+  $: streamEstimates =
+    $balancesStore &&
+    balancesStore.getStreamEstimatesByReceiver('total', dripLists[0].id).map((e) => ({
+      amount: e.totalStreamed / BigInt(constants.AMT_PER_SEC_MULTIPLIER),
+      tokenAddress: e.tokenAddress,
+    }));
+
+  /*
+    Only the list owner can set support streams to the list, so we can consider the stream estimate to the list loaded when
+    the owner account is loaded.
+  */
+  $: streamEstimateLoaded = $accountFetchStatusses[dripLists[0].ownerAccountId]?.all === 'fetched';
+
+  // (ignore incomingSplitTotal for now)
+  let totalIncomingAmounts: ReturnType<typeof mergeAmounts> | undefined = undefined;
+  $: totalIncomingAmounts = /*incomingSplitTotal &&*/ streamEstimateLoaded
+    ? mergeAmounts(streamEstimates /*, incomingSplitTotal*/)
+    : undefined;
+</script>
+
+<div class="rounded-drip-lg bg-primary-level-1 flex items-center h-8 px-3 gap-2 text-primary">
+  <div class="w-2.5">
+    <Drip />
+  </div>
+  <AggregateFiatEstimate amounts={totalIncomingAmounts} />
+  dripped
+</div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -26,6 +26,7 @@
   import CoinAnimation from '$lib/components/coin-animation/coin-animation.svelte';
   import DripList from '$lib/components/illustrations/drip-list.svelte';
   import RadworksLogo from '$lib/components/illustrations/radworks-logo.svelte';
+  import NetworkTotalDrippedBadge from '$lib/components/network-total-dripped-badge/NetworkTotalDrippedBadge.svelte';
 
   onMount(() => {
     // When launching within a Safe, we donʼt want to display the landing page.
@@ -54,6 +55,9 @@
 <div class="wrapper">
   <div class="hero">
     <div class="text">
+      <div class="flex">
+        <NetworkTotalDrippedBadge />
+      </div>
       <h1>Funding that flows</h1>
       <p>A decentralized toolkit for receiving ongoing support without platform fees.</p>
       <div class="actions">
@@ -263,9 +267,7 @@
         <MultiToken slot="image" />
         <div slot="caption" class="text-container">
           <h4>No platform fees</h4>
-          <p>
-            Free to use beyond covering the cost of gas.
-          </p>
+          <p>Free to use beyond covering the cost of gas.</p>
         </div>
       </ImageAndCaption></LpCard
     >
@@ -274,9 +276,7 @@
         <GasOptimized slot="image" />
         <div slot="caption" class="text-container">
           <h4>User controlled data</h4>
-          <p>
-            Fully sovereign infrastructure for maximum data security.
-          </p>
+          <p>Fully sovereign infrastructure for maximum data security.</p>
         </div>
       </ImageAndCaption></LpCard
     >
@@ -285,9 +285,7 @@
         <NoWrappedTokens slot="image" />
         <div slot="caption" class="text-container">
           <h4>No need to wrap tokens</h4>
-          <p>
-            Stream native tokens. No need to trust third-parties with funds.
-          </p>
+          <p>Stream native tokens. No need to trust third-parties with funds.</p>
         </div>
       </ImageAndCaption></LpCard
     >
@@ -296,9 +294,7 @@
         <OneContract slot="image" />
         <div slot="caption" class="text-container">
           <h4>One contract</h4>
-          <p>
-            Drips uses one smart contract for streaming and splitting.
-          </p>
+          <p>Drips uses one smart contract for streaming and splitting.</p>
         </div>
       </ImageAndCaption></LpCard
     >


### PR DESCRIPTION
for #645

I've started with the discussed idea to (for now) just use the 'total dripped' amount to Radworks Software Dependencies list, since it's an increasing number.

I copied logic from `drip-list-card.svelte` but the balances/streams to the list aren't being loaded.

@efstajas, does this have to do with this logic being in the homepage, when the store logic is still under /app?
Guidance on how to initialize / lookup inside the landing page?
(we'll need this for featuring that list lower on the landing page #704 to right?)