### PR TITLE
ci: cache npm deps

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,6 +13,13 @@ jobs:
           node-version: 20
           cache: 'npm'
 
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: npm-
+
       - name: Populate .env file
         uses: SpicyPizza/create-envfile@v1.3
         with:

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -14,6 +14,13 @@ jobs:
           node-version: 20
           cache: 'npm'
 
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: npm-
+
       - name: Install deps
         run: npm ci
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -13,6 +13,13 @@ jobs:
           node-version: 20
           cache: 'npm'
 
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: npm-
+
       - name: Populate .env file
         uses: SpicyPizza/create-envfile@v1.3
         with:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -13,6 +13,13 @@ jobs:
           node-version: 20
           cache: 'npm'
 
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: npm-
+
       - name: Populate .env file
         uses: SpicyPizza/create-envfile@v1.3
         with:


### PR DESCRIPTION
Speeds up `npm ci` in GitHub actions a lil. We could get it to be much faster if we remove the install scripts in the drips SDK and `radicle-design-system` packages.