### PR TITLE
fix: untracked old otf inter fonts appear after every npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint": "prettier --check . && eslint .",
     "format": "prettier --write .",
     "prepare": "husky install",
-    "postinstall": "./scripts/install-twemoji-assets.sh && ./scripts/install-design-system-static-assets.sh"
+    "postinstall": "./scripts/install-twemoji-assets.sh"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.1.2",

--- a/scripts/install-design-system-static-assets.sh
+++ b/scripts/install-design-system-static-assets.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-# Install design system assets.
-
-set -Eeou pipefail
-echo "Installing Radicle Design System assets"
-cp ./node_modules/radicle-design-system/static/fonts/*.otf ./static/fonts


### PR DESCRIPTION
Just removes the leftover font asset script, after #710 