### PR TITLE
feat: stable drip lists view

### DIFF
--- a/src/lib/components/drip-list-card/drip-list-card-representational.svelte
+++ b/src/lib/components/drip-list-card/drip-list-card-representational.svelte
@@ -234,7 +234,6 @@
     top: 0;
     right: 0;
     bottom: 0;
-    /* gradient from transparent to var(--color-background), left to right */
     background: linear-gradient(to right, transparent, var(--color-background) 75%);
   }
 

--- a/src/lib/components/drip-list-card/drip-list-card-representational.svelte
+++ b/src/lib/components/drip-list-card/drip-list-card-representational.svelte
@@ -26,6 +26,8 @@
   import type getIncomingSplitTotal from '$lib/utils/splits/get-incoming-split-total';
   import type { DripList } from '$lib/utils/metadata/types';
   import ChevronRight from 'radicle-design-system/icons/ChevronRight.svelte';
+  import TransitionedHeight from '../transitioned-height/transitioned-height.svelte';
+  import Spinner from '../spinner/spinner.svelte';
 
   export let dripList: DripList;
   export let format: 'thumblink' | 'full' = 'full';
@@ -142,7 +144,7 @@
 <svelte:element
   this={format === 'thumblink' ? 'a' : 'section'}
   href={format === 'thumblink' ? dripListUrl : undefined}
-  class="rounded-drip-lg shadow-low group transform {format === 'thumblink'
+  class="rounded-drip-lg overflow-hidden shadow-low group transform {format === 'thumblink'
     ? 'transition duration-200 mouse:hover:shadow-md mouse:hover:-translate-y-2px focus-visible:shadow-md focus-visible:-translate-y-2px'
     : ''}"
 >
@@ -172,7 +174,7 @@
           </div>
         {/if}
       </div>
-      {#if (dripList.description ?? '').length > 0}
+      {#if format === 'full' && (dripList.description ?? '').length > 0}
         <TextExpandable>
           {dripList.description}
         </TextExpandable>
@@ -186,27 +188,35 @@
         </div>
         <div class="typo-text tabular-nums total-streamed-badge">
           {#if browser}
-            <!-- TODO: Include incoming splits -->
             <AggregateFiatEstimate amounts={totalIncomingAmounts} />
           {/if}
           <span class="muted">&nbsp;total</span>
         </div>
-        {#if supportersPile && supportersPile.length > 0}
+        {#if supportersPile && supportersPile.length > 0 && format === 'full'}
           <div in:fade|local={{ duration: 300 }} class="supporters min-w-0">
             <span class="truncate muted">Supported by</span>
             <Pile components={supportersPile ?? []} itemsClickable={true} />
           </div>
         {/if}
       </div>
-      {#if representationalSplits}
-        <div class="splits-component">
-          <Splits list={representationalSplits} maxRows={maxSplitsRows} />
-        </div>
-      {:else}
-        Loading...
-      {/if}
+      <TransitionedHeight transitionHeightChanges={true}>
+        {#if representationalSplits}
+          <div in:fade class="splits-component">
+            <Splits
+              groupsExpandable={format === 'full'}
+              list={representationalSplits}
+              maxRows={maxSplitsRows}
+            />
+          </div>
+        {:else}
+          <div class="loading-state">
+            <Spinner />
+          </div>
+        {/if}
+      </TransitionedHeight>
     </div>
   </div>
+  <div class="overflow-gradient" />
 </svelte:element>
 
 <style>
@@ -214,6 +224,18 @@
     display: flex;
     align-items: center;
     gap: 1rem;
+    position: relative;
+  }
+
+  .overflow-gradient {
+    position: absolute;
+    z-index: 1;
+    width: 2rem;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    /* gradient from transparent to var(--color-background), left to right */
+    background: linear-gradient(to right, transparent, var(--color-background) 75%);
   }
 
   .totals .drip-icon {
@@ -247,6 +269,13 @@
     display: flex;
     align-items: center;
     gap: 0.5rem;
+  }
+
+  .loading-state {
+    min-height: 212px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
   }
 
   .muted {

--- a/src/lib/components/drip-list-card/drip-list-card-representational.svelte
+++ b/src/lib/components/drip-list-card/drip-list-card-representational.svelte
@@ -186,7 +186,7 @@
       </div>
       {#if (dripList.description ?? '').length > 0}
         <div class="description">
-          <TextExpandable isExpandable={format === 'full'} lines={format === 'full' ? 2 : 1}>
+          <TextExpandable isExpandable={format === 'full'}>
             {dripList.description}
           </TextExpandable>
         </div>

--- a/src/lib/components/drip-list-card/drip-list-card-representational.svelte
+++ b/src/lib/components/drip-list-card/drip-list-card-representational.svelte
@@ -31,7 +31,6 @@
 
   export let dripList: DripList;
   export let format: 'thumblink' | 'full' = 'full';
-  export let maxSplitsRows: number | undefined = undefined;
 
   $: dripListUrl = `/app/drip-lists/${dripList.account.accountId}`;
   $: isOwnList = $walletStore && checkIsUser(dripList.account.owner.accountId);
@@ -139,12 +138,23 @@
       ),
     );
   }
+
+  let maxRows: number | undefined;
+  $: {
+    if (format === 'full') {
+      maxRows = undefined;
+    } else {
+      maxRows = dripList.description ? 3 : 4;
+    }
+  }
 </script>
 
 <svelte:element
   this={format === 'thumblink' ? 'a' : 'section'}
+  class:has-description={dripList.description}
   href={format === 'thumblink' ? dripListUrl : undefined}
-  class="rounded-drip-lg overflow-hidden shadow-low group transform {format === 'thumblink'
+  class="drip-list-card {format} rounded-drip-lg overflow-hidden shadow-low group transform {format ===
+  'thumblink'
     ? 'transition duration-200 mouse:hover:shadow-md mouse:hover:-translate-y-2px focus-visible:shadow-md focus-visible:-translate-y-2px'
     : ''}"
 >
@@ -174,10 +184,12 @@
           </div>
         {/if}
       </div>
-      {#if format === 'full' && (dripList.description ?? '').length > 0}
-        <TextExpandable>
-          {dripList.description}
-        </TextExpandable>
+      {#if (dripList.description ?? '').length > 0}
+        <div class="description">
+          <TextExpandable isExpandable={format === 'full'} lines={format === 'full' ? 2 : 1}>
+            {dripList.description}
+          </TextExpandable>
+        </div>
       {/if}
     </header>
 
@@ -202,11 +214,7 @@
       <TransitionedHeight transitionHeightChanges={true}>
         {#if representationalSplits}
           <div in:fade class="splits-component">
-            <Splits
-              groupsExpandable={format === 'full'}
-              list={representationalSplits}
-              maxRows={maxSplitsRows}
-            />
+            <Splits groupsExpandable={format === 'full'} list={representationalSplits} {maxRows} />
           </div>
         {:else}
           <div class="loading-state">
@@ -270,11 +278,24 @@
     gap: 0.5rem;
   }
 
-  .loading-state {
-    min-height: 212px;
+  .drip-list-card .loading-state {
     display: flex;
     justify-content: center;
     align-items: center;
+  }
+
+  .drip-list-card:not(.has-description) .loading-state {
+    /** Height of exactly 3 splits rows. */
+    height: 212px;
+  }
+
+  .drip-list-card.has-description .loading-state {
+    /** Height of exactly 4 splits rows. */
+    height: 163px;
+  }
+
+  .thumblink .description {
+    height: 2rem;
   }
 
   .muted {

--- a/src/lib/components/drip-lists-section/drip-lists-section.svelte
+++ b/src/lib/components/drip-lists-section/drip-lists-section.svelte
@@ -146,12 +146,12 @@
         : ''}"
     >
       {#each visibleDripLists as dripList}
-        <DripListCard {dripList} format="thumblink" maxSplitsRows={4} />
+        <DripListCard {dripList} format="thumblink" />
       {/each}
       {#if showCreateNewListCard}
         <div
           class="shadow-low rounded-drip-lg flex items-center justify-center p-1"
-          style:min-height="452px"
+          style:min-height="398px"
         >
           <div class="flex flex-col items-center gap-2 text-center">
             <Illustration size={48} />

--- a/src/lib/components/drip-lists-section/drip-lists-section.svelte
+++ b/src/lib/components/drip-lists-section/drip-lists-section.svelte
@@ -140,7 +140,11 @@
   }}
 >
   {#if visibleDripLists}
-    <div class="grid gap-6 grid-cols-1 {visibleDripLists.length > 0 ? 'lg:grid-cols-2' : ''}">
+    <div
+      class="grid gap-6 grid-cols-1 padding pt-px {visibleDripLists.length > 0
+        ? 'lg:grid-cols-2'
+        : ''}"
+    >
       {#each visibleDripLists as dripList}
         <DripListCard {dripList} format="thumblink" maxSplitsRows={4} />
       {/each}

--- a/src/lib/components/splits/components/split/split.svelte
+++ b/src/lib/components/splits/components/split/split.svelte
@@ -21,6 +21,9 @@
   export let linkToNewTab = false;
   export let isNested = false;
 
+  /** Set to false to hide the chevron next to split groups. */
+  export let groupsExpandable = true;
+
   /** Set to true if it's the last split in a list. Disables the lefthand line down to the next split. */
   export let isLast = false;
   /** Set to true if it's the first split in a list. Enables the little gradient line at the top from the source. */
@@ -192,7 +195,7 @@
             </div>
             <div class="label" style:transform="translateX({$groupNameOffset}px)">
               <div class="typo-header-4">{split.name}</div>
-              {#if split.list.length > 0}
+              {#if split.list.length > 0 && groupsExpandable}
                 <div
                   class="chevron"
                   style:transform={groupExpanded ? 'rotate3d(1, 0, 0, 90deg)' : ''}

--- a/src/lib/components/splits/splits.svelte
+++ b/src/lib/components/splits/splits.svelte
@@ -87,6 +87,9 @@
   export let list: Splits;
   export let maxRows: number | undefined = undefined;
 
+  /** Set to false to hide the chevron next to split groups. */
+  export let groupsExpandable = true;
+
   // Sort splits by highest percentage first, with groups at the bottom always.
   const sortList = (list: Splits) =>
     list.sort((a, b) => {
@@ -98,7 +101,7 @@
     });
 
   function truncateList(list: Splits) {
-    if (!maxRows || list.length === maxRows) {
+    if (!maxRows || list.length <= maxRows) {
       return list;
     }
     const clipIndex = maxRows - 1;
@@ -120,6 +123,7 @@
   {#each sortedList as listItem, index}
     <li class="split">
       <SplitComponent
+        {groupsExpandable}
         isFirst={index === 0}
         isLast={index === sortedList.length - 1}
         {linkToNewTab}

--- a/src/lib/components/text-expandable.svelte/text-expandable.svelte
+++ b/src/lib/components/text-expandable.svelte/text-expandable.svelte
@@ -2,10 +2,12 @@
   import { browser } from '$app/environment';
   import { onDestroy, onMount } from 'svelte';
 
+  export let isExpandable = true;
+  export let lines = 2;
+
   let element: HTMLElement | undefined = undefined;
   let isClamped = false;
   let expanded: boolean | undefined = undefined;
-  export let isExpandable = true;
 
   function setIsClamped() {
     isClamped = element ? element.scrollHeight > element.clientHeight : false;
@@ -28,7 +30,7 @@
   bind:this={element}
   class="
     expandable-text relative
-    {!expanded ? 'line-clamp-2' : ''}
+    {!expanded ? `line-clamp-${lines}` : ''}
     "
 >
   <slot />

--- a/src/lib/components/transitioned-height/transitioned-height.svelte
+++ b/src/lib/components/transitioned-height/transitioned-height.svelte
@@ -2,7 +2,7 @@
   import setTabIndexRecursively from '$lib/utils/set-tab-index-recursive';
   import { onMount } from 'svelte';
   import { cubicInOut } from 'svelte/easing';
-  import { tweened } from 'svelte/motion';
+  import { tweened, type Tweened } from 'svelte/motion';
 
   // ___________
   // PROPS
@@ -45,7 +45,7 @@
   */
   let fitContent = !collapsed;
 
-  let containerHeight = tweened(0);
+  let containerHeight: Tweened<number> | undefined;
 
   let animating = false;
 
@@ -67,6 +67,11 @@
     if (shouldTransition) {
       fitContent = false;
       animating = true;
+    }
+
+    if (!containerHeight) {
+      // Set initially to the current height value of the container
+      containerHeight = tweened(contentContainerElem.getBoundingClientRect().height);
     }
 
     containerHeight.set(

--- a/src/routes/app/(app)/+layout.svelte
+++ b/src/routes/app/(app)/+layout.svelte
@@ -50,7 +50,7 @@
           top: [
             { label: 'Streams', href: '/app/streams', icon: TokenStreams },
             { label: 'Projects', href: '/app/projects', icon: Box },
-            { label: 'Drip List', href: '/app/drip-lists', icon: DripListIcon },
+            { label: 'Drip Lists', href: '/app/drip-lists', icon: DripListIcon },
             {
               label: 'Profile',
               href: `/app/${$ens[$wallet.address]?.name ?? $wallet.address}`,
@@ -73,7 +73,7 @@
         items={[
           { label: 'Streams', href: '/app/streams', icon: TokenStreams },
           { label: 'Projects', href: '/app/projects', icon: Box },
-          { label: 'Drip List', href: '/app/drip-lists', icon: DripListIcon },
+          { label: 'Drip Lists', href: '/app/drip-lists', icon: DripListIcon },
           {
             label: 'Profile',
             href: `/app/${$ens[$wallet.address]?.name ?? $wallet.address}`,


### PR DESCRIPTION
Makes the drip list "thumb" card layout stable while loading, and neatly interpolates the height of the splits on the single drip list view:

https://github.com/drips-network/app/assets/1018218/ff92b52b-e5f4-4788-bcd3-186acd4bf9dc

Caveat is that this no longer shows list descriptions in listing contexts… Which I think is probably fine, since they still exist when viewing a single drip list directly. If we definitely want to show them, we could:

1. Show max a single truncated line of description, in a container exactly as high as one row in the splits component 
2. reduce the max rows in the split component for drip lists card w/ description by 1

… then the height would still remain stable. Wdyt?
