### PR TITLE
feat: highlight store, highlight projects tab for earnings after claiming project

### DIFF
--- a/src/lib/components/bottom-nav/bottom-nav.svelte
+++ b/src/lib/components/bottom-nav/bottom-nav.svelte
@@ -45,6 +45,7 @@
   <div class="items">
     {#each items as item}
       <a
+        data-highlightid="bottomnav-{item.href}"
         class="item typo-text-small-bold"
         class:active={$page.url.pathname === item.href}
         bind:this={itemElems[item.href]}

--- a/src/lib/components/header/header.svelte
+++ b/src/lib/components/header/header.svelte
@@ -44,6 +44,7 @@
           on:click={() => (searchMode = true)}
           transition:fly|local={{ duration: 300, x: -64, easing: quadInOut }}
           data-testid="search-button"
+          data-highlightid="search"
         >
           <SearchIcon style="fill: var(--color-foreground)" />
         </button>

--- a/src/lib/components/highlight/highlight.svelte
+++ b/src/lib/components/highlight/highlight.svelte
@@ -44,21 +44,23 @@
     const windowWidth = window.innerWidth;
     const windowHeight = window.innerHeight;
 
-    const remainingSpaceFromRight = highlightBB.right;
-    const remainingSpaceFromLeft = windowWidth - highlightBB.left;
+    const horizontalCenter = highlightBB.left + highlightBB.width / 2;
+
+    const remainingSpaceFromRight = windowWidth - horizontalCenter;
+    const remainingSpaceFromLeft = horizontalCenter;
     const remainingSpaceFromTop = highlightBB.top;
     const remainingSpaceFromBottom = windowHeight - highlightBB.bottom;
 
-    const textAlignment = remainingSpaceFromRight > remainingSpaceFromLeft ? 'right' : 'left';
+    const textAlignment = remainingSpaceFromRight > remainingSpaceFromLeft ? 'left' : 'right';
 
     let highlightWidth: number;
     switch (textAlignment) {
       case 'left': {
-        highlightWidth = Math.min(remainingSpaceFromLeft, 384);
+        highlightWidth = Math.min(remainingSpaceFromRight, 384);
         break;
       }
       case 'right': {
-        highlightWidth = Math.min(remainingSpaceFromRight, 384);
+        highlightWidth = Math.min(remainingSpaceFromLeft, 384);
         break;
       }
     }
@@ -75,9 +77,9 @@
     let x: number;
     if (alignment === 'top' || alignment === 'bottom') {
       if (textAlignment === 'right') {
-        x = highlightBB.right - highlightWidth;
+        x = horizontalCenter - highlightWidth + 8;
       } else {
-        x = highlightBB.left;
+        x = horizontalCenter - 8;
       }
     } else if (alignment === 'left') {
       x = highlightBB.right + 24;

--- a/src/lib/components/highlight/highlight.svelte
+++ b/src/lib/components/highlight/highlight.svelte
@@ -284,12 +284,13 @@
     z-index: 103;
     cursor: pointer;
     transition: background-color 0.2s;
+    opacity: 0.2;
   }
 
   .click-catcher:focus-visible,
   .click-catcher:hover {
     outline: none;
-    background-color: var(--color-primary-level-1);
+    background-color: var(--color-primary);
   }
 
   .background {

--- a/src/lib/components/highlight/highlight.svelte
+++ b/src/lib/components/highlight/highlight.svelte
@@ -1,0 +1,415 @@
+<script lang="ts">
+  import { browser } from '$app/environment';
+  import highlightStore from '$lib/stores/highlight/highlight.store';
+  import scrollStore from '$lib/stores/scroll/scroll.store';
+  import { onDestroy } from 'svelte';
+  import { fade, fly } from 'svelte/transition';
+  import FocusTrap from '../focus-trap/focus-trap.svelte';
+
+  let highlightBB = $highlightStore?.element.getBoundingClientRect();
+  function updateBB() {
+    highlightBB = $highlightStore?.element.getBoundingClientRect();
+  }
+
+  $: $highlightStore && updateBB();
+
+  function dismiss() {
+    highlightStore.clearHighlight();
+  }
+
+  $: {
+    if ($highlightStore && browser) {
+      scrollStore.lock();
+    } else if (browser) {
+      scrollStore.unlock();
+    }
+  }
+
+  onDestroy(() => {
+    browser && scrollStore.unlock();
+  });
+
+  let highlightPos:
+    | {
+        x: number;
+        y: number;
+        width: number;
+        textAlignment: 'left' | 'right';
+        alignment: 'top' | 'bottom' | 'left' | 'right';
+      }
+    | undefined;
+  function updateHighlightPos() {
+    if (!highlightBB) return;
+
+    const windowWidth = window.innerWidth;
+    const windowHeight = window.innerHeight;
+
+    const remainingSpaceFromRight = highlightBB.right;
+    const remainingSpaceFromLeft = windowWidth - highlightBB.left;
+    const remainingSpaceFromTop = highlightBB.top;
+    const remainingSpaceFromBottom = windowHeight - highlightBB.bottom;
+
+    const textAlignment = remainingSpaceFromRight > remainingSpaceFromLeft ? 'right' : 'left';
+
+    let highlightWidth: number;
+    switch (textAlignment) {
+      case 'left': {
+        highlightWidth = Math.min(remainingSpaceFromLeft, 384);
+        break;
+      }
+      case 'right': {
+        highlightWidth = Math.min(remainingSpaceFromRight, 384);
+        break;
+      }
+    }
+
+    let alignment: 'top' | 'bottom' | 'left' | 'right';
+    if (remainingSpaceFromTop < 64) {
+      alignment = 'bottom';
+    } else if (remainingSpaceFromTop > 64 && remainingSpaceFromBottom > 64) {
+      alignment = textAlignment;
+    } else {
+      alignment = 'top';
+    }
+
+    let x: number;
+    if (alignment === 'top' || alignment === 'bottom') {
+      if (textAlignment === 'right') {
+        x = highlightBB.right - highlightWidth;
+      } else {
+        x = highlightBB.left;
+      }
+    } else if (alignment === 'left') {
+      x = highlightBB.right + 24;
+    } else {
+      x = highlightBB.left - 24;
+    }
+
+    let y: number;
+    switch (alignment) {
+      case 'left':
+      case 'right': {
+        // 12 is the height of half the arrow.
+        y = highlightBB.top + highlightBB.height / 2 - 12;
+        break;
+      }
+      case 'bottom': {
+        y = highlightBB.bottom + 16;
+        break;
+      }
+      case 'top': {
+        y = highlightBB.top - 24;
+      }
+    }
+
+    highlightPos = {
+      x,
+      y,
+      textAlignment: textAlignment,
+      width: highlightWidth,
+      alignment,
+    };
+  }
+  $: {
+    if ($highlightStore && highlightBB) {
+      updateHighlightPos();
+    }
+  }
+
+  const ARROWS = {
+    left: '←',
+    right: '→',
+    bottom: '↑',
+    top: '↓',
+  };
+
+  const ANIMATION_SETTINGS = {
+    left: {
+      x: 16,
+    },
+    right: {
+      x: -16,
+    },
+    top: {
+      y: -16,
+    },
+    bottom: {
+      y: 16,
+    },
+  };
+
+  // Observe target element resizes and re-run calculations
+  let observer: ResizeObserver | undefined;
+  $: {
+    if ($highlightStore && highlightBB) {
+      observer?.disconnect();
+      observer = new ResizeObserver(() => {
+        updateBB();
+        updateHighlightPos();
+      });
+      observer.observe($highlightStore.element);
+    } else {
+      observer?.disconnect();
+    }
+  }
+
+  function handleClickCatcherEvent(e: MouseEvent | KeyboardEvent) {
+    if (
+      (e instanceof MouseEvent && e.type === 'click') ||
+      (e instanceof KeyboardEvent && e.key === 'Enter')
+    ) {
+      // Forward to target
+      $highlightStore?.element.dispatchEvent(
+        new MouseEvent('click', {
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+
+      dismiss();
+    }
+  }
+
+  function handleWindowKeyboardEvent(e: KeyboardEvent) {
+    if (e.key === 'Escape') {
+      dismiss();
+    }
+  }
+
+  let wrapperElem: HTMLDivElement;
+</script>
+
+<svelte:window on:keydown={handleWindowKeyboardEvent} />
+
+<FocusTrap containers={new Set([wrapperElem])} enabled={Boolean($highlightStore)} />
+
+{#if $highlightStore && highlightBB && highlightPos}
+  <div
+    transition:fade|local={{ duration: 300 }}
+    class="highlight-wrapper"
+    style:top="{highlightBB.top - $highlightStore.paddingPx}px"
+    style:left="{highlightBB.left - $highlightStore.paddingPx}px"
+    style:height="{highlightBB.height + $highlightStore.paddingPx * 2}px"
+    style:width="{highlightBB.width + $highlightStore.paddingPx * 2}px"
+    style:padding="{$highlightStore.paddingPx}px"
+    bind:this={wrapperElem}
+  >
+    <div class="background" style:border-radius={$highlightStore.borderRadius} />
+    <div class="animated-outline" style:border-radius={$highlightStore.borderRadius} />
+    <div
+      transition:fly|local={{ duration: 600, ...ANIMATION_SETTINGS[highlightPos.alignment] }}
+      class="highlight {highlightPos.alignment} side-{highlightPos.textAlignment}"
+      style:width="{highlightPos.width}px"
+      style:top="{highlightPos.y}px"
+      style:left="{highlightPos.x}px"
+    >
+      <h3 class="arrow">{ARROWS[highlightPos.alignment]}</h3>
+      <div class="content">
+        <h3>{$highlightStore.title}</h3>
+        <p>{$highlightStore.description}</p>
+      </div>
+    </div>
+    <!-- Dismisses clicks outside the target -->
+    <!-- svelte-ignore a11y-click-events-have-key-events -->
+    <div class="click-preventer" on:click={dismiss} />
+    <!-- Catches & forwards clicks on the target -->
+    <div
+      role="button"
+      class="click-catcher"
+      tabindex="0"
+      style:top="{highlightBB.top - $highlightStore.paddingPx}px"
+      style:left="{highlightBB.left - $highlightStore.paddingPx}px"
+      style:height="{highlightBB.height + $highlightStore.paddingPx * 2}px"
+      style:width="{highlightBB.width + $highlightStore.paddingPx * 2}px"
+      on:mouseenter={handleClickCatcherEvent}
+      on:mouseleave={handleClickCatcherEvent}
+      on:click={handleClickCatcherEvent}
+      on:keydown={handleClickCatcherEvent}
+      style:border-radius={$highlightStore.borderRadius}
+    />
+  </div>
+{/if}
+
+<style>
+  .highlight-wrapper {
+    position: fixed;
+    z-index: 101;
+  }
+
+  .animated-outline {
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    border: 2px solid var(--color-primary);
+    pointer-events: none;
+    z-index: 11;
+    animation: animatedOutline 3s infinite linear;
+  }
+
+  @keyframes animatedOutline {
+    0% {
+      transform: scale(1);
+      opacity: 0;
+    }
+
+    25% {
+      transform: scale(1.25);
+      opacity: 0.25;
+    }
+
+    50% {
+      transform: scale(1.5);
+      opacity: 0;
+    }
+
+    100% {
+      transform: scale(1.5);
+      opacity: 0;
+    }
+  }
+
+  .click-preventer {
+    z-index: 102;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+  }
+
+  .click-catcher {
+    position: fixed;
+    z-index: 103;
+    cursor: pointer;
+  }
+
+  .click-catcher:focus-visible,
+  .click-catcher:hover {
+    outline: none;
+    background-color: var(--color-primary-level-1);
+  }
+
+  .background {
+    position: absolute;
+    top: 0;
+    left: 0;
+    opacity: 0.9;
+    width: 100%;
+    height: 100%;
+    border-radius: 1.5rem 0 1.5rem 1.5rem;
+    pointer-events: none;
+    box-shadow: 0px 0px 0px 99999px var(--color-background);
+  }
+
+  .highlight {
+    position: fixed;
+    z-index: 11;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    pointer-events: none;
+  }
+
+  .highlight.top {
+    flex-direction: column-reverse;
+  }
+
+  .highlight.side-right {
+    text-align: right;
+  }
+
+  .highlight.side-left {
+    text-align: left;
+  }
+  .highlight .content h3 {
+    margin-bottom: 0.5rem;
+  }
+
+  .highlight.top {
+    transform: translateY(-100%);
+  }
+
+  .highlight.top .arrow {
+    animation: ArrowBounceDown 3s infinite;
+  }
+  .highlight.bottom .arrow {
+    animation: ArrowBounceUp 3s infinite;
+  }
+  .highlight.left .arrow {
+    animation: ArrowBounceLeft 3s infinite;
+  }
+  .highlight.right .arrow {
+    animation: ArrowBounceRight 3s infinite;
+  }
+
+  @keyframes ArrowBounceLeft {
+    0% {
+      transform: translateX(0rem);
+    }
+
+    12.5% {
+      transform: translateX(-0.25rem);
+    }
+
+    25% {
+      transform: translateX(0rem);
+    }
+
+    100% {
+      transform: translateX(0rem);
+    }
+  }
+  @keyframes ArrowBounceRight {
+    0% {
+      transform: translateX(0rem);
+    }
+
+    12.5% {
+      transform: translateX(0.25rem);
+    }
+
+    25% {
+      transform: translateX(0rem);
+    }
+
+    100% {
+      transform: translateX(0rem);
+    }
+  }
+  @keyframes ArrowBounceUp {
+    0% {
+      transform: translateY(0rem);
+    }
+
+    12.5% {
+      transform: translateY(-0.25rem);
+    }
+
+    25% {
+      transform: translateY(0rem);
+    }
+
+    100% {
+      transform: translateY(0rem);
+    }
+  }
+  @keyframes ArrowBounceDown {
+    0% {
+      transform: translateY(0rem);
+    }
+
+    12.5% {
+      transform: translateY(0.25rem);
+    }
+
+    25% {
+      transform: translateY(0rem);
+    }
+
+    100% {
+      transform: translateY(0rem);
+    }
+  }
+</style>

--- a/src/lib/components/highlight/highlight.svelte
+++ b/src/lib/components/highlight/highlight.svelte
@@ -283,6 +283,7 @@
     position: fixed;
     z-index: 103;
     cursor: pointer;
+    transition: background-color 0.2s;
   }
 
   .click-catcher:focus-visible,

--- a/src/lib/components/sidenav/components/sidenav-item.svelte
+++ b/src/lib/components/sidenav/components/sidenav-item.svelte
@@ -8,7 +8,13 @@
   export let external = false;
 </script>
 
-<a class="sidenav-item typo-text" class:active {href} target={external ? '_blank' : undefined}>
+<a
+  data-highlightid="sidenav-{href}"
+  class="sidenav-item typo-text"
+  class:active
+  {href}
+  target={external ? '_blank' : undefined}
+>
   <svelte:component
     this={icon}
     style="fill: {active

--- a/src/lib/stores/highlight/highlight.store.ts
+++ b/src/lib/stores/highlight/highlight.store.ts
@@ -1,0 +1,32 @@
+import { writable } from 'svelte/store';
+
+export interface Highlight {
+  title: string;
+  description: string;
+  element: Element;
+  borderRadius: string;
+  paddingPx: number;
+}
+
+const currentHighlight = writable<Highlight | null>(null);
+
+/**
+ * Display a highlight around `config.element`, with the provided text.
+ * @param config Title, description and element for the highlight.
+ */
+function highlight(config: Highlight) {
+  currentHighlight.set(config);
+}
+
+/**
+ * Clear the current highlight, if any.
+ */
+function clearHighlight() {
+  currentHighlight.set(null);
+}
+
+export default {
+  subscribe: currentHighlight.subscribe,
+  highlight,
+  clearHighlight,
+};

--- a/src/routes/app/(app)/component-showcase/+page.svelte
+++ b/src/routes/app/(app)/component-showcase/+page.svelte
@@ -29,6 +29,9 @@
   import ShareButton from '$lib/components/share-button/share-button.svelte';
   import Section from '$lib/components/section/section.svelte';
   import Toggleable from '$lib/components/toggleable/toggleable.svelte';
+  import highlightStore from '$lib/stores/highlight/highlight.store';
+  import breakpointsStore from '$lib/stores/breakpoints/breakpoints.store';
+  import walletStore from '$lib/stores/wallet/wallet.store';
 
   // Button
   let disabled = false;
@@ -239,11 +242,43 @@
   let sectionError = false;
   let sectionCollapsable = false;
   let sectionCollapsed = false;
+
+  $: mobileView =
+    $breakpointsStore?.breakpoint === 'mobile' || $breakpointsStore?.breakpoint === 'tablet';
 </script>
 
 <HeadMeta />
 
 <h1>Component showcase</h1>
+
+<div class="showcase-item">
+  <h2>Highlight</h2>
+  <Button
+    on:click={() =>
+      highlightStore.highlight({
+        title: 'Highlight title',
+        description: 'Description here',
+        element: document.querySelectorAll("[data-highlightid='search']")[0],
+        borderRadius: '2rem',
+        paddingPx: 0,
+      })}>Attach highlight to search button</Button
+  >
+  <Button
+    on:click={() =>
+      highlightStore.highlight({
+        title: 'Collect your earnings',
+        description: 'You can collect earnings to your wallet on the Projects screen.',
+        element: document.querySelectorAll(
+          mobileView
+            ? "[data-highlightid='bottomnav-/app/projects']"
+            : "[data-highlightid='sidenav-/app/projects']",
+        )[0],
+        borderRadius: mobileView ? '1rem 0 1rem 1rem' : '2rem 0 2rem 2rem',
+        paddingPx: mobileView ? 8 : 0,
+      })}
+    disabled={!$walletStore.connected}>Attach highlight to projects button</Button
+  >
+</div>
 
 <div class="showcase-item">
   <h2>Toggleable</h2>

--- a/src/routes/app/(app)/drip-lists/+page.svelte
+++ b/src/routes/app/(app)/drip-lists/+page.svelte
@@ -17,8 +17,6 @@
 
     guardConnected();
   }
-
-  $: address = $walletStore.address;
 </script>
 
 <HeadMeta title="Drip List" />

--- a/src/routes/app/(app)/projects/(forges)/components/project-profile/project-profile.svelte
+++ b/src/routes/app/(app)/projects/(forges)/components/project-profile/project-profile.svelte
@@ -42,6 +42,8 @@
   import { goto } from '$app/navigation';
   import { browser } from '$app/environment';
   import ShareButton from '$lib/components/share-button/share-button.svelte';
+  import highlightStore from '$lib/stores/highlight/highlight.store';
+  import breakpointsStore from '$lib/stores/breakpoints/breakpoints.store';
 
   interface Amount {
     tokenAddress: string;
@@ -102,6 +104,42 @@
           return undefined;
       }
     });
+  }
+
+  $: mobileView =
+    $breakpointsStore?.breakpoint === 'mobile' || $breakpointsStore?.breakpoint === 'tablet';
+
+  let collectHintTriggered = false;
+
+  function triggerCollectHint() {
+    collectHintTriggered = true;
+
+    setTimeout(() => {
+      highlightStore.highlight({
+        title: 'Collect your earnings',
+        description: 'You can collect earnings to your wallet on the Projects screen.',
+        element: document.querySelectorAll(
+          mobileView
+            ? "[data-highlightid='bottomnav-/app/projects']"
+            : "[data-highlightid='sidenav-/app/projects']",
+        )[0],
+        borderRadius: mobileView ? '1rem 0 1rem 1rem' : '2rem 0 2rem 2rem',
+        paddingPx: mobileView ? 8 : 0,
+      });
+    }, 2000);
+  }
+
+  const walletInitialized = walletStore.initialized;
+
+  $: {
+    if (browser && !collectHintTriggered && $walletInitialized) {
+      let url = new URL(window.location.href);
+      if (url.searchParams.get('collectHint') === 'true') {
+        url.searchParams.delete('collectHint');
+        window.history.replaceState({}, '', url.toString());
+        triggerCollectHint();
+      }
+    }
   }
 </script>
 

--- a/src/routes/app/(app)/projects/(forges)/components/project-profile/project-profile.svelte
+++ b/src/routes/app/(app)/projects/(forges)/components/project-profile/project-profile.svelte
@@ -44,6 +44,7 @@
   import ShareButton from '$lib/components/share-button/share-button.svelte';
   import highlightStore from '$lib/stores/highlight/highlight.store';
   import breakpointsStore from '$lib/stores/breakpoints/breakpoints.store';
+  import dismissablesStore from '$lib/stores/dismissables/dismissables.store';
 
   interface Amount {
     tokenAddress: string;
@@ -134,10 +135,15 @@
   $: {
     if (browser && !collectHintTriggered && $walletInitialized) {
       let url = new URL(window.location.href);
+
       if (url.searchParams.get('collectHint') === 'true') {
         url.searchParams.delete('collectHint');
         window.history.replaceState({}, '', url.toString());
-        triggerCollectHint();
+
+        if (!dismissablesStore.isDismissed('project-claim-collect-hint')) {
+          triggerCollectHint();
+          dismissablesStore.dismiss('project-claim-collect-hint');
+        }
       }
     }
   }

--- a/src/routes/app/(flows)/claim-project/steps/success/success.svelte
+++ b/src/routes/app/(flows)/claim-project/steps/success/success.svelte
@@ -6,6 +6,7 @@
   import Spinner from '$lib/components/spinner/spinner.svelte';
   import ArrowBoxUpRight from 'radicle-design-system/icons/ArrowBoxUpRight.svelte';
   import walletStore from '$lib/stores/wallet/wallet.store';
+  import buildUrl from '$lib/utils/build-url';
 
   export let context: Writable<State>;
 
@@ -20,7 +21,14 @@
     const username = $context.project?.source.ownerName;
     const repoName = $context.project?.source.repoName;
 
-    await goto(`/app/projects/${forge}/${username}/${repoName}`).then(() => {
+    const collectedFunds = ($context.unclaimedFunds?.length ?? 0) > 0;
+
+    await goto(
+      buildUrl(
+        `/app/projects/${forge}/${username}/${repoName}`,
+        collectedFunds ? { collectHint: 'true' } : {},
+      ),
+    ).then(() => {
       loading = false;
     });
   }

--- a/src/routes/app/(flows)/claim-project/steps/success/success.svelte
+++ b/src/routes/app/(flows)/claim-project/steps/success/success.svelte
@@ -7,6 +7,8 @@
   import ArrowBoxUpRight from 'radicle-design-system/icons/ArrowBoxUpRight.svelte';
   import walletStore from '$lib/stores/wallet/wallet.store';
   import buildUrl from '$lib/utils/build-url';
+  import balancesStore from '$lib/stores/balances/balances.store';
+  import assert from '$lib/utils/assert';
 
   export let context: Writable<State>;
 
@@ -22,6 +24,11 @@
     const repoName = $context.project?.source.repoName;
 
     const collectedFunds = ($context.unclaimedFunds?.length ?? 0) > 0;
+
+    const ownAccountId = $walletStore.dripsAccountId;
+    assert(ownAccountId);
+
+    await balancesStore.updateBalances($walletStore.dripsAccountId);
 
     await goto(
       buildUrl(

--- a/src/routes/app/+layout.svelte
+++ b/src/routes/app/+layout.svelte
@@ -23,6 +23,7 @@
   import ModalLayout from '$lib/components/modal-layout/modal-layout.svelte';
   import Spinner from '$lib/components/spinner/spinner.svelte';
   import { page } from '$app/stores';
+  import Highlight from '$lib/components/highlight/highlight.svelte';
 
   let walletConnected = false;
   let loaded = false;
@@ -145,6 +146,8 @@
     await fiatEstimates.start();
   });
 </script>
+
+<Highlight />
 
 <GlobalAdvisory />
 


### PR DESCRIPTION
Adds a store that can be used to globally "highlight" any element on the page, and implements a highlight of the "projects" tab right after claiming a project.

<img width="956" alt="Screenshot 2023-11-10 at 13 31 14" src="https://github.com/drips-network/app/assets/1018218/2ffa57f1-5c35-4ac2-8951-7380a785eb78">

https://discord.com/channels/1096003917717983252/1096004153085530253/1172144860430618695