### PR TITLE
Fixes dead links.

### DIFF
--- a/src/routes/app/(app)/drip-lists/+page.svelte
+++ b/src/routes/app/(app)/drip-lists/+page.svelte
@@ -30,7 +30,7 @@
       <p>
         Stream any ERC-20 token to a list of individuals, Git projects, or other Drip
         Lists&mdash;weighted by their importance to you. <a
-          href="https://docs.drips.network/fund-your-dependencies"
+          href="https://docs.drips.network/support-your-dependencies"
           class="text-foreground-level-5 hover:text-foreground hover:underline transition duration-150 focus-visible:bg-primary-level-1 focus-visible:text-foreground focus-visible:underline px-1 py-0.5 -mx-1 rounded focus:outline-none"
           >Learn&nbsp;more</a
         >

--- a/src/routes/app/(app)/streams/+page.svelte
+++ b/src/routes/app/(app)/streams/+page.svelte
@@ -37,7 +37,7 @@
         actions: [
           {
             handler: () =>
-              window.open('https://docs.drips.network/fund-your-dependencies', '_blank')?.focus(),
+              window.open('https://docs.drips.network/support-your-dependencies', '_blank')?.focus(),
             label: 'Learn more',
             primary: true,
             icon: ArrowUp,


### PR DESCRIPTION
I took a guess that this is the docs page intended to be linked to:
https://docs.drips.network/support-your-dependencies