### PR TITLE
Button.svelte can be a link/<a>, apply to CodeBox (closes #507)

### DIFF
--- a/src/lib/components/button/button.svelte
+++ b/src/lib/components/button/button.svelte
@@ -13,6 +13,7 @@
   export let dataTestId: string | undefined = undefined;
   export let href: string | undefined = undefined;
   export let target: string | undefined = undefined;
+  export let rel: string | undefined = undefined;
 
   $: isDisabled = disabled || loading;
 
@@ -32,9 +33,11 @@
   aria-label={ariaLabel}
   {href}
   {target}
+  {rel}
   class="button size-{size}"
+  class:disabled={isDisabled}
   disabled={isDisabled}
-  class:pointer-events-none={isDisabled}
+  aria-disabled={isDisabled}
   on:click|stopPropagation
   data-testid={dataTestId}
 >
@@ -63,7 +66,7 @@
 
 <style>
   .button {
-    display: inline-block;
+    display: flex;
     height: calc(2rem + 10px);
     min-width: calc(2rem + 4px); /* so just icons are square (w=h) */
     padding: 5px 2px;
@@ -136,14 +139,14 @@
     padding: 0 0.75rem;
   }
 
-  .button:not(:disabled):hover .inner,
-  .button:not(:disabled):focus-visible .inner {
+  .button:not(.disabled):hover .inner,
+  .button:not(.disabled):focus-visible .inner {
     box-shadow: 0px 0px 0px 1px var(--color-foreground), 0 2px 0px 1px var(--color-foreground),
       inset 0 0px 0px 0px var(--color-foreground);
     transform: translateY(-2px);
   }
 
-  .button:not(:disabled):active .inner {
+  .button:not(.disabled):active .inner {
     transform: translateY(0px);
     box-shadow: 0px 0px 0px 1px var(--color-foreground), 0 0px 0px 0px var(--color-foreground);
   }
@@ -159,7 +162,8 @@
   .button:focus-visible .inner.normal {
     background-color: var(--color-foreground-level-1);
   }
-  .button:disabled {
+  .button.disabled {
     opacity: 0.5;
+    pointer-events: none;
   }
 </style>

--- a/src/lib/components/button/button.svelte
+++ b/src/lib/components/button/button.svelte
@@ -28,12 +28,13 @@
 
 <svelte:element
   this={href ? 'a' : 'button'}
+  bind:this={el}
+  aria-label={ariaLabel}
   {href}
   {target}
   class="button size-{size}"
-  bind:this={el}
-  aria-label={ariaLabel}
   disabled={isDisabled}
+  class:pointer-events-none={isDisabled}
   on:click|stopPropagation
   data-testid={dataTestId}
 >

--- a/src/lib/components/button/button.svelte
+++ b/src/lib/components/button/button.svelte
@@ -11,14 +11,14 @@
   export let size: 'small' | 'normal' | 'large' = 'normal';
   export let loading = false;
   export let dataTestId: string | undefined = undefined;
+  export let href: string | undefined = undefined;
+  export let target: string | undefined = undefined;
 
   $: isDisabled = disabled || loading;
 
-  let buttonEl: HTMLButtonElement;
+  let el: HTMLButtonElement | HTMLAnchorElement;
 
-  $: primaryColor = buttonEl
-    ? getComputedStyle(buttonEl).getPropertyValue('--color-primary')
-    : undefined;
+  $: primaryColor = el ? getComputedStyle(el).getPropertyValue('--color-primary') : undefined;
 
   $: textColor =
     primaryColor && (variant === 'destructive' || variant === 'primary')
@@ -26,9 +26,12 @@
       : 'var(--color-foreground)';
 </script>
 
-<button
-  class="size-{size}"
-  bind:this={buttonEl}
+<svelte:element
+  this={href ? 'a' : 'button'}
+  {href}
+  {target}
+  class="button size-{size}"
+  bind:this={el}
   aria-label={ariaLabel}
   disabled={isDisabled}
   on:click|stopPropagation
@@ -55,10 +58,11 @@
       </div>
     {/if}
   </div>
-</button>
+</svelte:element>
 
 <style>
-  button {
+  .button {
+    display: inline-block;
     height: calc(2rem + 10px);
     min-width: calc(2rem + 4px); /* so just icons are square (w=h) */
     padding: 5px 2px;
@@ -67,17 +71,17 @@
     flex-shrink: 0;
   }
 
-  button.size-large {
+  .button.size-large {
     height: calc(3rem + 10px);
     min-width: calc(3rem + 4px);
   }
 
-  button.size-small {
+  .button.size-small {
     height: 2.5rem;
     min-width: calc(3rem);
   }
 
-  button .inner {
+  .button .inner {
     height: 100%;
     border-radius: 1rem 0 1rem 1rem;
     display: flex;
@@ -91,7 +95,7 @@
     position: relative;
   }
 
-  button .inner .loading {
+  .button .inner .loading {
     position: absolute;
     top: 0;
     left: 0;
@@ -103,54 +107,58 @@
     border-radius: 1rem 0 1rem 1rem;
   }
 
-  button.size-large .inner {
+  .button.size-large .inner {
     border-radius: 1.5rem 0 1.5rem 1.5rem;
   }
 
-  button.size-small .inner {
+  .button.size-small .inner {
     font-size: 14px;
   }
 
-  button .inner:not(.ghost) {
+  .button .inner:not(.ghost) {
     box-shadow: var(--elevation-low);
   }
 
-  button .inner.primary {
+  .button .inner.primary {
     background-color: var(--color-primary);
   }
 
-  button .inner.destructive {
+  .button .inner.destructive {
     background-color: var(--color-negative);
   }
 
-  button .inner.with-icon-text {
+  .button .inner.with-icon-text {
     padding: 0 0.75rem 0 0.5rem;
   }
 
-  button .inner.with-text {
+  .button .inner.with-text {
     padding: 0 0.75rem;
   }
 
-  button:enabled:hover .inner,
-  button:enabled:focus-visible .inner {
+  .button:not(:disabled):hover .inner,
+  .button:not(:disabled):focus-visible .inner {
     box-shadow: 0px 0px 0px 1px var(--color-foreground), 0 2px 0px 1px var(--color-foreground),
       inset 0 0px 0px 0px var(--color-foreground);
     transform: translateY(-2px);
   }
 
-  button:enabled:active .inner {
+  .button:not(:disabled):active .inner {
     transform: translateY(0px);
     box-shadow: 0px 0px 0px 1px var(--color-foreground), 0 0px 0px 0px var(--color-foreground);
   }
 
-  button:focus-visible .inner {
+  .button:focus {
+    outline: none;
+  }
+
+  .button:focus-visible .inner {
     box-shadow: var(--elevation-low);
   }
 
-  button:focus-visible .inner.normal {
+  .button:focus-visible .inner.normal {
     background-color: var(--color-foreground-level-1);
   }
-  button:disabled {
+  .button:disabled {
     opacity: 0.5;
   }
 </style>

--- a/src/lib/components/code-box/code-box.svelte
+++ b/src/lib/components/code-box/code-box.svelte
@@ -3,13 +3,14 @@
   import ArrowBoxUpRight from 'radicle-design-system/icons/ArrowBoxUpRight.svelte';
   import CheckIcon from 'radicle-design-system/icons/CheckCircle.svelte';
   import CopyIcon from 'radicle-design-system/icons/Copy.svelte';
+  import Button from '../button/button.svelte';
 
   export let path: string;
   export let code: string;
   export let repoUrl: string;
   export let defaultBranch = 'main';
 
-  let headerElem: HTMLDivElement | undefined;
+  let headerElem: HTMLElement | undefined;
 
   $: primaryColor = headerElem
     ? getComputedStyle(headerElem).getPropertyValue('--color-primary')
@@ -31,15 +32,10 @@
   )}`;
 </script>
 
-<div class="codebox">
-  <div class="header typo-text-small-mono" bind:this={headerElem} style:color={textColor}>
+<section class="codebox relative">
+  <header class="header typo-text-small-mono" bind:this={headerElem} style:color={textColor}>
     {path}
     <div class="actions">
-      {#if repoUrl.includes('github')}
-        <a href={gitHubProposalUrl} target="_blank">
-          <ArrowBoxUpRight style="fill: {textColor}" />
-        </a>
-      {/if}
       <button on:click={() => copyClipboard(code)}>
         {#if copySuccess}
           <CheckIcon style="fill: {textColor}" />
@@ -48,13 +44,20 @@
         {/if}
       </button>
     </div>
-  </div>
+  </header>
   <div class="code-wrapper">
     <code class="typo-text-mono">
       {@html code}
     </code>
   </div>
-</div>
+  {#if repoUrl.includes('github')}
+    <footer class="absolute bottom-4 right-4">
+      <Button variant="primary" icon={ArrowBoxUpRight} href={gitHubProposalUrl} target="_blank">
+        Add to your repo</Button
+      >
+    </footer>
+  {/if}
+</section>
 
 <style>
   .codebox {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -58,8 +58,8 @@
         <h1>Funding that flows</h1>
         <p>A decentralized toolkit for receiving ongoing support without platform fees.</p>
         <div class="actions">
-          <a href="#fund-projects"><Button icon={TokenStreams}>Fund your dependencies</Button></a>
-          <a href="#get-funding"><Button icon={Globe}>Get support for your project</Button></a>
+          <Button href="#fund-projects" icon={TokenStreams}>Fund your dependencies</Button>
+          <Button href="#get-funding" icon={Globe}>Get support for your project</Button>
         </div>
       </div>
       <div class="illustration">
@@ -98,14 +98,12 @@
             <p>Enter the URL of your public GitHub repository to get started.</p>
             <div class="claim-input">
               <TextInput bind:value={claimProjectInput} placeholder="GitHub repository URL" />
-              <a
-                href={canSubmitProjectClaim
-                  ? buildUrl('/app/claim-project', { projectToAdd: claimProjectInput })
-                  : undefined}
+              <Button
+                href={buildUrl('/app/claim-project', { projectToAdd: claimProjectInput })}
                 target="_blank"
-                ><Button variant="primary" size="large" disabled={!canSubmitProjectClaim}
-                  >Claim project</Button
-                ></a
+                variant="primary"
+                size="large"
+                disabled={!canSubmitProjectClaim}>Claim project</Button
               >
             </div>
           </div>
@@ -252,9 +250,9 @@
           <div class="text">
             <h3>Start your Drip List</h3>
             <p>Give to a personalized list of GitHub projects or Ethereum addresses.</p>
-            <a href="/app/funder-onboarding" target="_blank">
-              <Button variant="primary" size="large">Create your Drip List</Button>
-            </a>
+            <Button variant="primary" size="large" href="/app/funder-onboarding" target="_blank"
+              >Create your Drip List</Button
+            >
           </div>
         </div>
       </div>
@@ -309,14 +307,23 @@
         <div class="socials">
           <h2>Stay up to date</h2>
           <div class="flex gap-4">
-            <a href="https://twitter.com/dripsnetwork" target="_blank" rel="noreferrer"
-              ><Button variant="primary">Twitter</Button></a
+            <Button
+              variant="primary"
+              href="https://twitter.com/dripsnetwork"
+              target="_blank"
+              rel="noreferrer">Twitter</Button
             >
-            <a href="https://mirror.xyz/dripsdev.eth" target="_blank" rel="noreferrer"
-              ><Button variant="primary">Mirror</Button></a
+            <Button
+              variant="primary"
+              href="https://mirror.xyz/dripsdev.eth"
+              target="_blank"
+              rel="noreferrer">Mirror</Button
             >
-            <a href="https://discord.gg/BakDKKDpHF" target="_blank" rel="noreferrer"
-              ><Button variant="primary">Discord</Button></a
+            <Button
+              variant="primary"
+              href="https://discord.gg/BakDKKDpHF"
+              target="_blank"
+              rel="noreferrer">Discord</Button
             >
           </div>
         </div>

--- a/src/routes/app/(app)/projects/+page.svelte
+++ b/src/routes/app/(app)/projects/+page.svelte
@@ -93,9 +93,9 @@
                 every seven days.
               </p>
             </div>
-            <a tabindex="-1" href="https://docs.drips.network/" target="_blank"
-              ><Button icon={ArrowBoxUpRight}>Learn more</Button></a
-            >
+            <Button href="https://docs.drips.network/" target="_blank" icon={ArrowBoxUpRight}>
+              Learn more
+            </Button>
           </div>
           <button
             class="close-button"

--- a/src/routes/components/lp-header.svelte
+++ b/src/routes/components/lp-header.svelte
@@ -18,15 +18,15 @@
     </a>
   </div>
   <nav>
-    <a href="https://github.com/drips-network" target="_blank" rel="noreferrer"
-      ><Button variant="ghost">Code</Button></a
+    <Button variant="ghost" href="https://github.com/drips-network" target="_blank" rel="noreferrer"
+      >Code</Button
     >
-    <a href="https://docs.drips.network" target="_blank" rel="noreferrer"
-      ><Button variant="ghost">Docs</Button></a
+    <Button variant="ghost" href="https://docs.drips.network" target="_blank" rel="noreferrer"
+      >Docs</Button
     >
-    <a class="cta" href="/app" data-sveltekit-preload-code="eager"
-      ><Button variant="primary">Open app</Button></a
-    >
+    <div data-sveltekit-preload-code="eager">
+      <Button variant="primary" href="/app">Open app</Button>
+    </div>
   </nav>
 </header>
 


### PR DESCRIPTION
- refactor Button.svelte to allow being `<a>` tag so the focus/hover state is consistent.
- apply to new, more prominent "Add to your repo" button in the Funding.json codebox (#507)

<img width="758" alt="Screenshot 2023-11-14 at 15 04 08" src="https://github.com/drips-network/app/assets/6071219/3649b366-9007-46ec-a154-5406ea8b2b5a">
