### PR TITLE
ci: run docker-compose outside of e2e script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "preview": "vite preview",
     "test:e2e": "PUBLIC_TEST_MODE=true vitest run e2e",
     "test:unit": "vitest run unit",
-    "e2e": "GQL_URL=http://localhost:8080 GQL_ACCESS_TOKEN=afdb8b7e-8fa7-4de9-bd95-b650b839e745 VITE_TEST_MODE=true npm run build && npm run test:e2e",
+    "e2e": "docker compose up --detach && GQL_URL=http://localhost:8080 GQL_ACCESS_TOKEN=afdb8b7e-8fa7-4de9-bd95-b650b839e745 VITE_TEST_MODE=true npm run build && npm run test:e2e && docker compose down",
     "coverage": "vitest run --coverage",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",

--- a/src/e2e-tests/helpers/environment.ts
+++ b/src/e2e-tests/helpers/environment.ts
@@ -1,13 +1,6 @@
 /* eslint-disable no-console */
-import { execa } from 'execa';
 
-export async function start() {
-  // For good measure
-  await stop();
-
-  console.log('Starting E2E env...');
-  await execa('docker', ['compose', 'up', '--detach']);
-
+export async function wait() {
   console.log('Waiting for Graph Node…');
 
   // Ping port 8000 until the graph node responds
@@ -34,9 +27,4 @@ export async function start() {
   console.log('Ready.');
 }
 
-export async function stop() {
-  console.log('Stopping E2E env…');
-  await execa('docker', ['compose', 'down']);
-}
-
-export default { start, stop };
+export default { wait };

--- a/src/e2e-tests/top-up-create-stream.e2e.test.ts
+++ b/src/e2e-tests/top-up-create-stream.e2e.test.ts
@@ -32,11 +32,10 @@ describe('app', async () => {
   });
 
   beforeAll(async () => {
-    await environment.start();
+    await environment.wait();
 
     console.log('🌳 Environment is up. Running tests...');
   }, 14400000);
-  afterAll(environment.stop, 14400000);
 
   afterAll(async () => {
     await browser.close();


### PR DESCRIPTION
No longer runs docker compose up as part of the test script. Instead, the npm run e2e command now executes docker-compose up ahead of running the test script. This makes it faster (because the docker-compose services can already start while it's building the app), and also allows running the e2e script within the drips graphQL repo, where a different docker environment is required.