### PR TITLE
fix: wrong support amounts

### DIFF
--- a/src/routes/app/(app)/drip-lists/[listId]/+page.svelte
+++ b/src/routes/app/(app)/drip-lists/[listId]/+page.svelte
@@ -83,6 +83,7 @@
     <Developer accountId={dripList.account.accountId} />
 
     <Supporters
+      accountId={dripList.account.accountId}
       headline="Support"
       infoTooltip="A Drip List can be supported by one or more support streams by the list's owner. Others can also add a Drip List to their own Drip Lists or project's dependencies, or send a one-time donation."
       forceLoading={!streamsFetched}

--- a/src/routes/app/(app)/projects/(forges)/components/project-profile/project-profile.svelte
+++ b/src/routes/app/(app)/projects/(forges)/components/project-profile/project-profile.svelte
@@ -368,7 +368,11 @@
           {/await}
         </section>
       {/if}
-      <SupportersSection type="project" supportItems={project.support} />
+      <SupportersSection
+        accountId={project.account.accountId}
+        type="project"
+        supportItems={project.support}
+      />
     </div>
     <aside>
       <div class="become-supporter-card">


### PR DESCRIPTION
Fixes wrong support amounts in support section. Examples below are ethers.

Before:
<img width="868" alt="Screenshot 2023-12-20 at 11 37 38" src="https://github.com/drips-network/app/assets/1018218/19826724-38cc-4763-9a2c-2f94cd2bec37">

After:
<img width="848" alt="Screenshot 2023-12-20 at 11 38 04" src="https://github.com/drips-network/app/assets/1018218/7b5168d8-47f6-49f9-ab4e-93f36425870f">

Resolves #871 