### PR TITLE
style: empty values in percentage editor as normal (not error/negative)

### DIFF
--- a/src/lib/components/percentage-editor/percentage-editor.svelte
+++ b/src/lib/components/percentage-editor/percentage-editor.svelte
@@ -4,6 +4,7 @@
   export let percentage = 0;
   export let disabled = false;
   export let editable = true;
+  export let emptyIsError = true;
 
   let error = false;
   let empty = false;
@@ -87,6 +88,7 @@
   class="percentage-editor typo-text tabular-nums cursor-text"
   class:focus
   class:error
+  class:empty-is-error={emptyIsError}
   class:empty
   class:disabled
   class:editable
@@ -139,7 +141,7 @@
   }
 
   .percentage-editor:not(.disabled).error,
-  .percentage-editor:not(.disabled).empty {
+  .percentage-editor:not(.disabled).empty-is-error.empty {
     box-shadow: 0px 0px 0px 2px var(--color-negative);
     color: var(--color-negative);
   }

--- a/src/lib/components/visual-percentage-editor/visual-percentage-editor.svelte
+++ b/src/lib/components/visual-percentage-editor/visual-percentage-editor.svelte
@@ -222,6 +222,7 @@
               <PercentageEditor
                 bind:percentage={percentageInputValues[id]}
                 on:confirm={() => handleConfirmPercentageInput(id)}
+                emptyIsError={false}
               />
             </div>
           {:else}
@@ -230,6 +231,7 @@
                 editable={false}
                 bind:percentage={percentageInputValues[id]}
                 on:confirm={() => handleConfirmPercentageInput(id)}
+                emptyIsError={false}
               />
             </div>
           {/if}


### PR DESCRIPTION
0% is allowed on the sliders so style as normal values:
so change this:
<img width="747" alt="Screenshot 2024-01-10 at 12 52 46" src="https://github.com/drips-network/app/assets/6071219/33dadeea-c484-4776-97f7-d689e812e116">
to this:
<img width="746" alt="Screenshot 2024-01-10 at 12 54 43" src="https://github.com/drips-network/app/assets/6071219/3412e7b3-2c90-49ec-b35e-e78fa903b58a">
