### PR TITLE
sanitize project emoji values for good measure

### DIFF
--- a/src/lib/components/project-avatar/project-avatar.svelte
+++ b/src/lib/components/project-avatar/project-avatar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts" context="module">
   import { gql } from 'graphql-request';
   import type { ProjectAvatarFragment } from './__generated__/gql.generated';
+  import sanitize from 'sanitize-html';
 
   export const PROJECT_AVATAR_FRAGMENT = gql`
     fragment ProjectAvatar on Project {
@@ -35,7 +36,13 @@
 
   $: emojiElem =
     isClaimed(project) && project.emoji
-      ? twemoji.parse(project.emoji, { folder: 'svg', ext: '.svg' })
+      ? twemoji.parse(
+          sanitize(project.emoji, {
+            allowedTags: [],
+            allowedAttributes: {},
+          }),
+          { folder: 'svg', ext: '.svg' },
+        )
       : undefined;
 </script>
 

--- a/src/routes/api/share-images/project/[projectUrl].png/+server.ts
+++ b/src/routes/api/share-images/project/[projectUrl].png/+server.ts
@@ -13,6 +13,7 @@ import { gql } from 'graphql-request';
 import query from '$lib/graphql/dripsQL';
 import isClaimed from '$lib/utils/project/is-claimed';
 import type { ProjectQuery, ProjectQueryVariables } from './__generated__/gql.generated';
+import sanitize from 'sanitize-html';
 
 export const GET: RequestHandler = async ({ url, fetch, params }) => {
   const { projectUrl } = params;
@@ -57,7 +58,12 @@ export const GET: RequestHandler = async ({ url, fetch, params }) => {
   }
 
   const projectName = `${project.source.ownerName}/${project.source.repoName}`;
-  const emoji = isClaimed(project) ? project.emoji : 'none';
+  const emoji = isClaimed(project)
+    ? sanitize(project.emoji, {
+        allowedTags: [],
+        allowedAttributes: {},
+      })
+    : 'none';
   const dependenciesCount = isClaimed(project)
     ? project.splits.dependencies.length.toString()
     : '0';


### PR DESCRIPTION
The API should ever only return an emoji here, but best sanitize for good measure, because `twemoji.parse` preserves arbitrary HTML markup.