### PR TITLE
only allow http and https protocols on external route

### DIFF
--- a/src/routes/external/[url]/+page.ts
+++ b/src/routes/external/[url]/+page.ts
@@ -1,11 +1,13 @@
 import { error } from '@sveltejs/kit';
 import type { PageLoad } from './$types';
 
+const ALLOWED_PROTOCOLS = ['http:', 'https:'];
+
 export const load = (({ params }) => {
   const url = new URL(decodeURI(params.url));
 
-  if (url.protocol.includes('javascript')) {
-    throw error(404);
+  if (!ALLOWED_PROTOCOLS.includes(url.protocol)) {
+    throw error(400, 'Invalid protocol');
   }
 
   return {


### PR DESCRIPTION
It previously allowed everything except `javascript` protocol links. This restricts it further to only allow `http` and `https` links, to ensure absolutely no potentially funky things / app interactions with locally installed applications can be triggered.