### PR TITLE
handle project repo renames and incorrect casing

### DIFF
--- a/src/lib/components/project-profile-header/project-profile-header.svelte
+++ b/src/lib/components/project-profile-header/project-profile-header.svelte
@@ -20,17 +20,27 @@
 </script>
 
 <script lang="ts">
-  import ProjectAvatar, { PROJECT_AVATAR_FRAGMENT } from '$lib/components/project-avatar/project-avatar.svelte';
-  import ProjectBadge, { PROJECT_BADGE_FRAGMENT } from '$lib/components/project-badge/project-badge.svelte';
+  import ProjectAvatar, {
+    PROJECT_AVATAR_FRAGMENT,
+  } from '$lib/components/project-avatar/project-avatar.svelte';
+  import ProjectBadge, {
+    PROJECT_BADGE_FRAGMENT,
+  } from '$lib/components/project-badge/project-badge.svelte';
   import { createEventDispatcher } from 'svelte';
   import Button from '../button/button.svelte';
   import Copyable from '../copyable/copyable.svelte';
   import Pen from 'radicle-design-system/icons/Pen.svelte';
   import { gql } from 'graphql-request';
   import type { ProjectProfileHeaderFragment } from './__generated__/gql.generated';
+  import ShareButton from '../share-button/share-button.svelte';
 
   export let project: ProjectProfileHeaderFragment;
   export let editButton: string | undefined = undefined;
+  export let shareButton:
+    | {
+        url: string;
+      }
+    | undefined = undefined;
 
   const dispatch = createEventDispatcher<{ editButtonClick: never }>();
 </script>
@@ -46,10 +56,22 @@
         <ProjectBadge {project} forceUnclaimed tooltip={false} linkTo="external-url" />
       </Copyable>
     </div>
+    {#if editButton || shareButton}
+      <div class="actions">
+        {#if shareButton}
+          <ShareButton url={shareButton.url} />
+        {/if}
+        {#if editButton}
+          <Button icon={Pen} on:click={() => dispatch('editButtonClick')}>{editButton}</Button>
+        {/if}
+      </div>
+    {/if}
   </div>
-  {#if editButton}
-    <div class="absolute top-0 right-0 sm:static">
-      <Button icon={Pen} on:click={() => dispatch('editButtonClick')}>{editButton}</Button>
-    </div>
-  {/if}
 </div>
+
+<style>
+  .actions {
+    display: flex;
+    gap: 1rem;
+  }
+</style>

--- a/src/lib/components/support-card/support-card.svelte
+++ b/src/lib/components/support-card/support-card.svelte
@@ -84,6 +84,8 @@
   export let project: SupportCardProjectFragment | undefined = undefined;
   export let dripList: SupportCardDripListFragment | undefined = undefined;
 
+  export let disabled = false;
+
   $: type = project ? ('project' as const) : ('dripList' as const);
 
   let ownDripLists: OwnDripListsQuery['dripLists'] | null | undefined = undefined;
@@ -105,7 +107,6 @@
   }
 
   const { initialized } = walletStore;
-  $: isWalletConnected = $walletStore.connected;
 
   let updating = true;
   async function updateState() {
@@ -199,7 +200,7 @@
   }
 </script>
 
-<div class="become-supporter-card">
+<div class="become-supporter-card" class:disabled>
   {#if ownDripLists === undefined || updating}
     <div transition:fade|local={{ duration: 300 }} class="loading-overlay">
       <Spinner />
@@ -254,6 +255,11 @@
     padding: 1rem;
     gap: 1rem;
     position: relative;
+  }
+
+  .become-supporter-card.disabled {
+    opacity: 0.5;
+    pointer-events: none;
   }
 
   .loading-overlay {

--- a/src/lib/utils/build-project-url.ts
+++ b/src/lib/utils/build-project-url.ts
@@ -1,16 +1,20 @@
-import { Forge } from "$lib/graphql/__generated__/base-types";
+import { Forge } from '$lib/graphql/__generated__/base-types';
 
 /**
  * Builds a project profile URL from a project source object.
- * @param source The source to build the URL from.
+ * @param forge The forge to build the URL for.
+ * @param ownerName The github username owning the project.
+ * @param repoName The github repo name.
+ * @param exact If true, link to the the exact project provided, even if it has been renamed or mis-cased.
+ * If false, will auto-redirect to the "real" project URL. Defaults to true.
  * @returns The URL.
  */
-export default function (forge: Forge, ownerName: string, repoName: string): string {
+export default function (forge: Forge, ownerName: string, repoName: string, exact = true): string {
   switch (forge) {
     case Forge.GitHub:
       return `/app/projects/github/${encodeURIComponent(ownerName)}/${encodeURIComponent(
         repoName,
-      )}`;
+      )}${exact ? '?exact' : ''}`;
     default:
       throw new Error(`Unsupported forge: ${forge}`);
   }

--- a/src/routes/api/github/[repoUrl]/+server.ts
+++ b/src/routes/api/github/[repoUrl]/+server.ts
@@ -40,7 +40,7 @@ export const GET: RequestHandler = async ({ params }) => {
 
       if (redis) {
         await redis.set(lowercaseRepoUrl, JSON.stringify(repo), {
-          EX: 864000,
+          EX: 86400,
           NX: true,
         });
       }

--- a/src/routes/app/(app)/projects/(forges)/components/project-profile/project-profile.svelte
+++ b/src/routes/app/(app)/projects/(forges)/components/project-profile/project-profile.svelte
@@ -242,6 +242,8 @@
       }
     }
   }
+
+  $: canonicalRepoInfo = newRepo ?? correctCasingRepo ?? project.source;
 </script>
 
 {#if true}
@@ -262,37 +264,15 @@
     - The correct-casing repo URL if the project has different casing to the Drips project
     - The project URL, without ?exact parameter
   -->
-  {#if newRepo}
-    <link
-      rel="canonical"
-      href="https://drips.network{buildProjectUrl(
-        Forge.GitHub,
-        newRepo.ownerName,
-        newRepo.repoName,
-        false,
-      )}"
-    />
-  {:else if correctCasingRepo}
-    <link
-      rel="canonical"
-      href="https://drips.network{buildProjectUrl(
-        Forge.GitHub,
-        correctCasingRepo.ownerName,
-        correctCasingRepo.repoName,
-        false,
-      )}"
-    />
-  {:else}
-    <link
-      rel="canonical"
-      href="https://drips.network{buildProjectUrl(
-        project.source.forge,
-        project.source.ownerName,
-        project.source.repoName,
-        false,
-      )}"
-    />
-  {/if}
+  <link
+    rel="canonical"
+    href="https://drips.network{buildProjectUrl(
+      Forge.GitHub,
+      canonicalRepoInfo.ownerName,
+      canonicalRepoInfo.repoName,
+      false,
+    )}"
+  />
 </svelte:head>
 
 <PrimaryColorThemer colorHex={isClaimed(project) ? project.color : undefined}>
@@ -378,6 +358,14 @@
         <ProjectProfileHeader
           {project}
           editButton={isClaimed(project) && isOwnProject ? 'Edit' : undefined}
+          shareButton={{
+            url: `https://drips.network${buildProjectUrl(
+              Forge.GitHub,
+              project.source.ownerName,
+              project.source.repoName,
+              false,
+            )}`,
+          }}
           on:editButtonClick={() =>
             isClaimed(project) && modal.show(Stepper, undefined, editProjectMetadataSteps(project))}
         />
@@ -520,7 +508,7 @@
     </div>
     <aside>
       <div class="become-supporter-card">
-        <SupportCard {project} disabled={!!newRepo} />
+        <SupportCard {project} disabled={!!newRepo || !!correctCasingRepo} />
       </div>
     </aside>
   </article>

--- a/src/routes/app/(app)/projects/(forges)/components/project-profile/project-profile.svelte
+++ b/src/routes/app/(app)/projects/(forges)/components/project-profile/project-profile.svelte
@@ -107,6 +107,7 @@
   import buildProjectUrl from '$lib/utils/build-project-url';
   import { Forge } from '$lib/graphql/__generated__/base-types';
   import ArrowRight from 'radicle-design-system/icons/ArrowRight.svelte';
+  import EyeOpen from 'radicle-design-system/icons/EyeOpen.svelte';
 
   interface Amount {
     tokenAddress: string;
@@ -294,19 +295,19 @@
   {#if correctCasingRepo}
     <div class="notice">
       <AnnotationBox>
-        The GitHub repo for this project ({correctCasingRepo.ownerName}/{correctCasingRepo.repoName})
-        has different casing to this Drips project. New splits to this project will automatically be
-        corrected to the correct casing.
+        This project resolves to a GitHub repo with different casing ({correctCasingRepo.ownerName}/{correctCasingRepo.repoName}).
+        Any new splits to this misnamed project will automatically be routed to the correct project.
         <svelte:fragment slot="actions">
           <Button
-            icon={ArrowRight}
+            size="small"
+            icon={EyeOpen}
             variant="primary"
             href={buildProjectUrl(
               Forge.GitHub,
               correctCasingRepo.ownerName,
               correctCasingRepo.repoName,
               false,
-            )}>View the canonical project</Button
+            )}>View correct project</Button
           >
         </svelte:fragment>
       </AnnotationBox>

--- a/src/routes/app/(app)/projects/(forges)/github/[githubUsername]/[githubRepoName]/+page.server.ts
+++ b/src/routes/app/(app)/projects/(forges)/github/[githubUsername]/[githubRepoName]/+page.server.ts
@@ -1,4 +1,4 @@
-import { error } from '@sveltejs/kit';
+import { error, redirect } from '@sveltejs/kit';
 import fetchUnclaimedFunds from '$lib/utils/project/unclaimed-funds';
 import type { PageServerLoad } from './$types';
 import fetchEarnedFunds from '$lib/utils/project/earned-funds';
@@ -9,65 +9,111 @@ import type { ProjectByUrlQuery } from './__generated__/gql.generated';
 import type { QueryProjectByUrlArgs } from '$lib/graphql/__generated__/base-types';
 import isClaimed from '$lib/utils/project/is-claimed';
 import { PROJECT_PROFILE_FRAGMENT } from '../../../components/project-profile/project-profile.svelte';
+import { z } from 'zod';
 
-export const load = (async ({ params, fetch }) => {
+export const load = (async ({ params, fetch, url }) => {
   const { githubUsername, githubRepoName } = uriDecodeParams(params);
 
-  try {
-    const url = `https://github.com/${githubUsername}/${githubRepoName}`;
+  // `exact` param disables the redirect to the "real" github repo URL.
+  // For example, after a repo has been renamed, it would usually automatically redirect
+  // to the new repo name, but it must still be possible to access the old project.
+  const exact = url.searchParams.has('exact');
 
-    const repoRes = await fetch(`/api/github/${encodeURIComponent(url)}`);
-    const repo = await repoRes.json();
+  const repoSchema = z.object({
+    url: z.string(),
+    description: z.string().nullable(),
+    repoName: z.string(),
+    ownerName: z.string(),
+    forksCount: z.number(),
+    stargazersCount: z.number(),
+    defaultBranch: z.string(),
+  });
 
-    const { url: gitHubUrl } = repo;
+  let repo: z.infer<typeof repoSchema>;
 
-    const getProjectsQuery = gql`
-      ${PROJECT_PROFILE_FRAGMENT}
-      query ProjectByUrl($url: String!) {
-        projectByUrl(url: $url) {
-          ...ProjectProfile
-        }
-      }
-    `;
+  const repoUrl = `https://github.com/${githubUsername}/${githubRepoName}`;
 
-    const { projectByUrl: project } = await query<ProjectByUrlQuery, QueryProjectByUrlArgs>(
-      getProjectsQuery,
-      {
-        url: gitHubUrl,
-      },
-      fetch,
-    );
+  const repoRes = await fetch(`/api/github/${encodeURIComponent(repoUrl)}`);
+  const repoResJson = await repoRes.json();
 
-    if (!project) {
-      throw error(404);
-    }
-
-    const unclaimedFunds = !isClaimed(project)
-      ? fetchUnclaimedFunds(project.account.accountId)
-      : undefined;
-
-    const earnedFunds = isClaimed(project)
-      ? fetchEarnedFunds(project.account.accountId)
-      : undefined;
-
-    if (isClaimed(project) && !project.splits) {
-      throw new Error('Claimed project somehow does not have splits');
-    }
-
-    return {
-      project,
-      streamed: {
-        unclaimedFunds,
-        earnedFunds,
-      },
-      blockWhileInitializing: false,
-    };
-  } catch (e) {
-    const status =
-      typeof e === 'object' && e && 'status' in e && typeof e.status === 'number' ? e.status : 500;
-
-    // eslint-disable-next-line no-console
-    console.error(e);
-    throw error(status);
+  if ('message' in repoResJson && repoResJson.message === 'Error: 404') {
+    throw error(404);
   }
+
+  try {
+    repo = repoSchema.parse(repoResJson);
+  } catch (e) {
+    throw error(500, 'Unable to fetch repo info from GitHub / cache');
+  }
+
+  const { url: realRepoUrl } = repo;
+
+  const repoUrlIsCanonical = repoUrl === realRepoUrl;
+
+  if (!exact && !repoUrlIsCanonical) {
+    throw redirect(301, `/app/projects/github/${repo.ownerName}/${repo.repoName}`);
+  }
+
+  const getProjectsQuery = gql`
+    ${PROJECT_PROFILE_FRAGMENT}
+    query ProjectByUrl($url: String!) {
+      projectByUrl(url: $url) {
+        ...ProjectProfile
+      }
+    }
+  `;
+
+  const { projectByUrl: project } = await query<ProjectByUrlQuery, QueryProjectByUrlArgs>(
+    getProjectsQuery,
+    {
+      url: repoUrl,
+    },
+    fetch,
+  );
+
+  if (!project) {
+    throw error(404);
+  }
+
+  const unclaimedFunds = !isClaimed(project)
+    ? fetchUnclaimedFunds(project.account.accountId)
+    : undefined;
+
+  const earnedFunds = isClaimed(project) ? fetchEarnedFunds(project.account.accountId) : undefined;
+
+  if (isClaimed(project) && !project.splits) {
+    throw new Error('Claimed project somehow does not have splits');
+  }
+
+  // True if the repo URL is non-canonical, but only the casing is wrong
+  const wrongCasing = !repoUrlIsCanonical && repoUrl.toLowerCase() === realRepoUrl.toLowerCase();
+
+  const correctCasingRepo = wrongCasing
+    ? {
+        url: realRepoUrl,
+        repoName: repo.repoName,
+        ownerName: repo.ownerName,
+      }
+    : undefined;
+
+  // If the repo has been renamed / moved, this is the new URL
+  const newRepo =
+    !repoUrlIsCanonical && !wrongCasing
+      ? {
+          url: realRepoUrl,
+          repoName: repo.repoName,
+          ownerName: repo.ownerName,
+        }
+      : undefined;
+
+  return {
+    project,
+    streamed: {
+      unclaimedFunds,
+      earnedFunds,
+    },
+    newRepo,
+    correctCasingRepo,
+    blockWhileInitializing: false,
+  };
 }) satisfies PageServerLoad;

--- a/src/routes/app/(app)/projects/(forges)/github/[githubUsername]/[githubRepoName]/+page.svelte
+++ b/src/routes/app/(app)/projects/(forges)/github/[githubUsername]/[githubRepoName]/+page.svelte
@@ -7,6 +7,8 @@
 
 <ProjectProfile
   project={data.project}
+  newRepo={data.newRepo}
+  correctCasingRepo={data.correctCasingRepo}
   unclaimedFunds={data.streamed.unclaimedFunds}
   earnedFunds={data.streamed.earnedFunds}
 />


### PR DESCRIPTION
Adds additional handling for renamed repos, and incorrect casing (related to #856). Does NOT yet include full handling for deleted repos, because that will require some API work.

Changes:

- The server now sends a 301 redirect when "correcting" the casing or name (if repo renamed) of a Drips project, instead of just loading the "correct" project while keeping the URL untouched / wrong.
- Appending `?exact` to a project URL will disable the automatic redirection for project entirely. This makes it possible to view "outdated" old projects that still receive funds.
- Links to specific projects within the app (e.g. project cards on Projects tab, splits in project / drip list splits etc.) now include said `?exact` parameter, ensuring that you always go to the exact project that a split goes to / you have claimed
- When viewing a project that has been renamed on GitHub with the `?exact` param, supporting is disabled, and a banner appears that links you to the canonical project:

<img width="1474" alt="Screenshot 2024-01-16 at 12 52 15" src="https://github.com/drips-network/app/assets/1018218/46d3173b-1ef6-4e83-9a7d-9844bcb79ea7">

- When viewing a project with "wrong casing" in the URL and the `?exact` parameter, supporting is disabled, and a banner appears that links you to the canonical project. This one is super rare and should really never happen, apart from the one case we know of (ricmoo splitting to typescript with "wrong" casing), so I think it's ok if the copy is a bit convoluted.

<img width="1476" alt="Screenshot 2024-01-16 at 12 53 49" src="https://github.com/drips-network/app/assets/1018218/05f45a5c-58e7-412f-a02d-9bc8ffb9cf74">

- A canonical link for Google is generated in the header in all cases that always links to the up-to-date, correct casing repo URL, ensuring only those are indexed
- A new share button in the project profile header is added that always copies the URL for the project WITHOUT the `?exact` param

<img width="838" alt="Screenshot 2024-01-16 at 13 10 45" src="https://github.com/drips-network/app/assets/1018218/aef9fcfb-66eb-4c60-ac38-b82c1c26a5cf">

- Projects for deleted repos now return 404 instead of 500, which isn't the full fix proposed in #856, but is still a more appropriate response code.