### PR TITLE
add 'total dripped' counter to landing page using static values (closes #645)

### DIFF
--- a/src/lib/components/aggregate-fiat-estimate/aggregate-fiat-estimate.svelte
+++ b/src/lib/components/aggregate-fiat-estimate/aggregate-fiat-estimate.svelte
@@ -6,7 +6,9 @@
   import Tooltip from '../tooltip/tooltip.svelte';
   import FiatEstimateValue from './fiat-estimate-value.svelte';
   import aggregateFiatEstimate from './aggregate-fiat-estimate';
+  import { createEventDispatcher } from 'svelte';
 
+  const dispatch = createEventDispatcher<{ loaded: never }>();
   interface Amount {
     tokenAddress: string;
     amount: bigint;
@@ -38,6 +40,9 @@
       const result = aggregateFiatEstimate(priceStore, amounts);
 
       includesUnknownPrice = result.includesUnknownPrice;
+      if (fiatEstimateCents === 'pending' && typeof result.fiatEstimateCents === 'number') {
+        dispatch('loaded');
+      }
       fiatEstimateCents = result.fiatEstimateCents;
     }
   }

--- a/src/lib/components/spinner/spinner.svelte
+++ b/src/lib/components/spinner/spinner.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-  import { fade } from 'svelte/transition';
   import Drip from '../illustrations/drip.svelte';
   import { onMount } from 'svelte';
 
   export let visibilityDelay = 300; // so doesn't flash on loading site from cache
+  export let classes = 'w-6 h-6';
   let render = false;
   onMount(() =>
     setTimeout(() => {
@@ -12,11 +12,13 @@
   );
 </script>
 
-{#if render}
-  <div class="w-6 h-6 drip-animation flex justify-center" in:fade|local={{ duration: 150 }}>
-    <Drip height="100%" />
-  </div>
-{/if}
+<div
+  class="{classes} flex justify-center transition duration-150 {!render
+    ? 'opacity-0'
+    : 'drip-animation'}"
+>
+  <Drip height="100%" />
+</div>
 
 <style>
   .drip-animation {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -26,6 +26,7 @@
   import CoinAnimation from '$lib/components/coin-animation/coin-animation.svelte';
   import DripList from '$lib/components/illustrations/drip-list.svelte';
   import LpFooter from './components/lp-footer.svelte';
+  import LpTotalDrippedBadge from './components/lp-total-dripped-badge.svelte';
 
   onMount(() => {
     // When launching within a Safe, we donʼt want to display the landing page.
@@ -55,6 +56,9 @@
   <div class="wrapper">
     <div class="hero">
       <div class="text">
+        <div class="flex">
+          <LpTotalDrippedBadge />
+        </div>
         <h1>Funding that flows</h1>
         <p>A decentralized toolkit for receiving ongoing support without platform fees.</p>
         <div class="actions">

--- a/src/routes/app/(app)/component-showcase/+page.svelte
+++ b/src/routes/app/(app)/component-showcase/+page.svelte
@@ -121,6 +121,10 @@
     emoji: '🚶',
     color: '#fcc842',
     splits: { __typename: 'Splits', maintainers: [], dependencies: [] },
+    avatar: {
+      __typename: 'EmojiAvatar',
+      emoji: '🍓',
+    },
   };
 
   const MOCK_PROJECT_2: Project = {
@@ -148,6 +152,10 @@
     emoji: '💾',
     color: '#FF0000',
     splits: { __typename: 'Splits', maintainers: [], dependencies: [] },
+    avatar: {
+      __typename: 'EmojiAvatar',
+      emoji: '🎾',
+    },
   };
 
   const mockSplits: Splits = [

--- a/src/routes/components/lp-total-dripped-badge.svelte
+++ b/src/routes/components/lp-total-dripped-badge.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { Amount } from '$lib/components/aggregate-fiat-estimate/aggregate-fiat-estimate';
   import AggregateFiatEstimate from '$lib/components/aggregate-fiat-estimate/aggregate-fiat-estimate.svelte';
-  import Drip from '$lib/components/illustrations/drip.svelte';
+  import Spinner from '$lib/components/spinner/spinner.svelte';
   import tokens from '$lib/stores/tokens';
   import fiatEstimates from '$lib/utils/fiat-estimates/fiat-estimates';
   import { onMount } from 'svelte';
@@ -81,7 +81,7 @@
   class:opacity-0={!visible}
   class:pointer-events-none={!visible}
 >
-  <Drip height="calc(16/14 * 1em)" />
+  <Spinner classes="w-3.5 h-3.5" />
   <div>
     <span class="typo-text-small-bold">
       <AggregateFiatEstimate

--- a/src/routes/components/lp-total-dripped-badge.svelte
+++ b/src/routes/components/lp-total-dripped-badge.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+  import type { Amount } from '$lib/components/aggregate-fiat-estimate/aggregate-fiat-estimate';
+  import AggregateFiatEstimate from '$lib/components/aggregate-fiat-estimate/aggregate-fiat-estimate.svelte';
+  import Drip from '$lib/components/illustrations/drip.svelte';
+  import tokens from '$lib/stores/tokens';
+  import fiatEstimates from '$lib/utils/fiat-estimates/fiat-estimates';
+  import { onMount } from 'svelte';
+
+  let now = new Date().getTime();
+
+  const streams = [
+    // Radworks USDC
+    {
+      token: {
+        address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+        decimals: 9,
+      },
+      started: new Date('September 4, 2023, 12:50 AM').getTime(),
+      amtPerSec: '15854895991882',
+    },
+    // Radworks RAD
+    {
+      token: {
+        address: '0x31c8EAcBFFdD875c74b94b077895Bd78CF1E64A3',
+      },
+      started: new Date('September 4, 2023, 12:50 AM').getTime(),
+      amtPerSec: '11832001522070015220700152',
+    },
+    // Octant WETH
+    // https://drips.network/app/174487241669176381847575438324427367088538936996/tokens/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/streams/3580043985
+    // {
+    //   token: {
+    //     address: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+    //   },
+    //   started: new Date('January 20, 2024, 5:26 PM').getTime(),
+    //   amtPerSec: '1699845679012345679012',
+    // }
+  ];
+
+  const gives: Amount[] = [
+    // Octant https://drips.network/app/drip-lists/30178668158349445547603108732480118476541651095408979232800331391215
+    {
+      tokenAddress: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+      amount: BigInt('9380000000000000000'),
+    },
+  ];
+
+  let amounts: Amount[] = [];
+
+  $: {
+    if (tokens.connected) {
+      const streamedAmoutns = streams.map((stream) => {
+        const durationSec = Math.floor((now - stream.started) / 1000);
+        return {
+          tokenAddress: stream.token.address,
+          amount: (BigInt(stream.amtPerSec) / BigInt(1e9)) * BigInt(durationSec),
+        };
+      });
+      amounts = [...gives, ...streamedAmoutns];
+    }
+  }
+
+  let anim = 0;
+  function step() {
+    now = new Date().getTime();
+    anim = requestAnimationFrame(step);
+  }
+
+  onMount(async () => {
+    tokens.connect(1);
+    fiatEstimates.start();
+    step();
+  });
+</script>
+
+<svelte:window on:blur={() => cancelAnimationFrame(anim)} on:focus={step} />
+
+<div
+  class="rounded-drip-lg flex items-center gap-2 bg-primary-level-1 text-primary px-3 h-8 typo-text-small"
+>
+  <Drip height="calc(16/14 * 1em)" />
+  <div>
+    <span class="typo-text-small-bold">
+      <AggregateFiatEstimate {amounts} />
+    </span> dripped
+  </div>
+</div>

--- a/src/routes/components/lp-total-dripped-badge.svelte
+++ b/src/routes/components/lp-total-dripped-badge.svelte
@@ -77,9 +77,9 @@
 <svelte:window on:blur={() => cancelAnimationFrame(anim)} on:focus={step} />
 
 <div
-  class="rounded-drip-lg flex items-center gap-2 bg-primary-level-1 text-primary px-3 h-8 typo-text-small transition duration-150 transform {!visible
-    ? 'opacity-0 translate-y-1/2 pointer-events-none'
-    : ''}"
+  class="rounded-drip-lg flex items-center gap-2 bg-primary-level-1 text-primary px-3 h-8 typo-text-small transition duration-300"
+  class:opacity-0={!visible}
+  class:pointer-events-none={!visible}
 >
   <Drip height="calc(16/14 * 1em)" />
   <div>

--- a/src/routes/components/lp-total-dripped-badge.svelte
+++ b/src/routes/components/lp-total-dripped-badge.svelte
@@ -14,7 +14,6 @@
     {
       token: {
         address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
-        decimals: 9,
       },
       started: new Date('September 4, 2023, 12:50 AM').getTime(),
       amtPerSec: '15854895991882',
@@ -51,10 +50,10 @@
   $: {
     if (tokens.connected) {
       const streamedAmoutns = streams.map((stream) => {
-        const durationSec = Math.floor((now - stream.started) / 1000);
+        const duration = (now - stream.started) / 1000;
         return {
           tokenAddress: stream.token.address,
-          amount: (BigInt(stream.amtPerSec) / BigInt(1e9)) * BigInt(durationSec),
+          amount: BigInt(Math.floor(Number(BigInt(stream.amtPerSec) / BigInt(1e9)) * duration)),
         };
       });
       amounts = [...gives, ...streamedAmoutns];

--- a/src/routes/components/lp-total-dripped-badge.svelte
+++ b/src/routes/components/lp-total-dripped-badge.svelte
@@ -76,13 +76,13 @@
 <svelte:window on:blur={() => cancelAnimationFrame(anim)} on:focus={step} />
 
 <div
-  class="rounded-drip-lg flex items-center gap-2 bg-primary-level-1 text-primary px-3 h-8 typo-text-small transition duration-300"
+  class="rounded-drip-lg flex items-center gap-2 bg-primary-level-1 text-primary px-3 h-8 typo-text transition duration-300"
   class:opacity-0={!visible}
   class:pointer-events-none={!visible}
 >
   <Spinner classes="w-3.5 h-3.5" />
   <div>
-    <span class="typo-text-small-bold">
+    <span class="typo-text-bold">
       <AggregateFiatEstimate
         {amounts}
         on:loaded={() => {

--- a/src/routes/components/lp-total-dripped-badge.svelte
+++ b/src/routes/components/lp-total-dripped-badge.svelte
@@ -7,6 +7,7 @@
   import { onMount } from 'svelte';
 
   let now = new Date().getTime();
+  let visible = false;
 
   const streams = [
     // Radworks USDC
@@ -76,12 +77,19 @@
 <svelte:window on:blur={() => cancelAnimationFrame(anim)} on:focus={step} />
 
 <div
-  class="rounded-drip-lg flex items-center gap-2 bg-primary-level-1 text-primary px-3 h-8 typo-text-small"
+  class="rounded-drip-lg flex items-center gap-2 bg-primary-level-1 text-primary px-3 h-8 typo-text-small transition duration-150 transform {!visible
+    ? 'opacity-0 translate-y-1/2 pointer-events-none'
+    : ''}"
 >
   <Drip height="calc(16/14 * 1em)" />
   <div>
     <span class="typo-text-small-bold">
-      <AggregateFiatEstimate {amounts} />
+      <AggregateFiatEstimate
+        {amounts}
+        on:loaded={() => {
+          visible = true;
+        }}
+      />
     </span> dripped
   </div>
 </div>


### PR DESCRIPTION
(This PR should replace #725)

Adds "$ XXX,XXX dripped" counter to Landing Page using static values:
- Radworks USDC stream
- Radworks RAD stream
- Octant give

