### PR TITLE
catch redis errors

### DIFF
--- a/src/routes/api/redis.ts
+++ b/src/routes/api/redis.ts
@@ -7,6 +7,11 @@ let client: RedisClientType | undefined;
 if (env.CACHE_REDIS_CONNECTION_STRING) {
   client = redis.createClient({ url: env.CACHE_REDIS_CONNECTION_STRING });
 
+  client.on('error', function (error) {
+    // eslint-disable-next-line no-console
+    console.error(error);
+  });
+
   (async () => {
     try {
       await client.connect();


### PR DESCRIPTION
Sometimes sockets closed unexpectedly, resulting in one-time error 500s. This should catch those errors while keeping the retry logic of the redis client.