### PR TITLE
fix: rounding logic

### DIFF
--- a/src/lib/utils/__test__/round-weights.unit.test.ts
+++ b/src/lib/utils/__test__/round-weights.unit.test.ts
@@ -1,0 +1,69 @@
+import { constants } from 'radicle-drips';
+import roundWeights, { type TypedReceiver } from '../round-weights';
+
+describe('roundWeights', () => {
+  it('should return the same receivers if total weight is already equal to TOTAL_SPLITS_WEIGHT', () => {
+    const receivers: TypedReceiver[] = [
+      { accountId: '1', weight: constants.TOTAL_SPLITS_WEIGHT / 2, typeOfReceiver: 'Maintainer' },
+      { accountId: '2', weight: constants.TOTAL_SPLITS_WEIGHT / 2, typeOfReceiver: 'Maintainer' },
+    ];
+    const result = roundWeights(receivers);
+    expect(result).toEqual(receivers);
+  });
+
+  it('should distribute weights equally if all weights are equal and total weight is less than TOTAL_SPLITS_WEIGHT', () => {
+    const receivers: TypedReceiver[] = [
+      { accountId: '1', weight: 333_331, typeOfReceiver: 'Maintainer' },
+      { accountId: '2', weight: 333_331, typeOfReceiver: 'Maintainer' },
+      { accountId: '3', weight: 333_331, typeOfReceiver: 'Maintainer' },
+    ];
+
+    const result = roundWeights(receivers);
+
+    expect(result).toEqual([
+      { accountId: '1', weight: 333_334, typeOfReceiver: 'Maintainer' },
+      { accountId: '2', weight: 333_333, typeOfReceiver: 'Maintainer' },
+      { accountId: '3', weight: 333_333, typeOfReceiver: 'Maintainer' },
+    ]);
+  });
+
+  it('should increase the weight of the receiver with the highest weight if weights are unequal and total weight is less than TOTAL_SPLITS_WEIGHT', () => {
+    const receivers: TypedReceiver[] = [
+      { accountId: '1', weight: 333_331, typeOfReceiver: 'Maintainer' },
+      { accountId: '2', weight: 333_332, typeOfReceiver: 'Maintainer' },
+      { accountId: '3', weight: 333_333, typeOfReceiver: 'Maintainer' },
+    ];
+
+    const result = roundWeights(receivers);
+
+    expect(result).toEqual([
+      { accountId: '1', weight: 333_331, typeOfReceiver: 'Maintainer' },
+      { accountId: '2', weight: 333_332, typeOfReceiver: 'Maintainer' },
+      { accountId: '3', weight: 333_337, typeOfReceiver: 'Maintainer' },
+    ]);
+  });
+
+  it('should throw an error if total weight exceeds TOTAL_SPLITS_WEIGHT', () => {
+    const receivers: TypedReceiver[] = [
+      { accountId: '1', weight: 333_331, typeOfReceiver: 'Maintainer' },
+      { accountId: '2', weight: 333_332, typeOfReceiver: 'Maintainer' },
+      { accountId: '3', weight: 333_338, typeOfReceiver: 'Maintainer' },
+    ];
+
+    expect(() => roundWeights(receivers)).toThrowError(
+      `Total weight of receivers exceeds ${constants.TOTAL_SPLITS_WEIGHT}.`,
+    );
+  });
+
+  it('should return the same receivers if total weight is already equal to TOTAL_SPLITS_WEIGHT', () => {
+    const receivers: TypedReceiver[] = [
+      { accountId: '1', weight: 333_334, typeOfReceiver: 'Maintainer' },
+      { accountId: '2', weight: 333_333, typeOfReceiver: 'Maintainer' },
+      { accountId: '3', weight: 333_333, typeOfReceiver: 'Maintainer' },
+    ];
+
+    const result = roundWeights(receivers);
+
+    expect(result).toEqual(receivers);
+  });
+});


### PR DESCRIPTION
@efstajas here's a fix for the rounding logic. There were a few edge cases that this PR should fix.
However, I still haven't found the cause of the receivers mismatch (onchain vs metadata) even though I spotted a wrong related assignment.

If we are unsure about this, we can also revert all rounding.

Regarding the reported issue on [Discord](https://discord.com/channels/1096003917717983252/1204581052962578512) we need to suggest the following configuration:
```json
         {
            "accountId": "246143406710477020717494096468966982681784893038",
            "weight": "187500"
          },
          {
            "accountId": "1208577989352973003091899595206122026695351403583",
            "weight": "562501" 👈
          },
          {
            "accountId": "80924457310386880091302880843407861917397762025481227787685752471552",
            "weight": "83333"
          },
          {
            "accountId": "80928961545538538466165477808532767810848587485712440198768076259328",
            "weight": "83333"
          },
          {
            "accountId": "81036473733089919926028385797282177451059549353244988582777280502540",
            "weight": "83333"
          }
``` 