### PR TITLE
improve unknown token handling

### DIFF
--- a/src/lib/components/aggregate-fiat-estimate/aggregate-fiat-estimate.svelte
+++ b/src/lib/components/aggregate-fiat-estimate/aggregate-fiat-estimate.svelte
@@ -20,6 +20,8 @@
   export let amounts: Amounts | undefined;
   $: tokenAddresses = amounts?.map((a) => a.tokenAddress);
 
+  export let supressUnknownAmountsWarning = false;
+
   const fiatEstimatesStarted = fiatEstimates.started;
   $: {
     if ($fiatEstimatesStarted && tokenAddresses && tokenAddresses.length > 0) {
@@ -50,10 +52,10 @@
 
 <div class="aggregate-fiat-estimate">
   <FiatEstimateValue forceLoading={amounts === undefined} {fiatEstimateCents} />
-  {#if includesUnknownPrice && fiatEstimateCents !== 'pending'}
+  {#if includesUnknownPrice && fiatEstimateCents !== 'pending' && !supressUnknownAmountsWarning}
     <div class="warning" transition:fade|local={{ duration: 100 }}>
       <Tooltip>
-        <WarningIcon style="fill: var(--color-negative)" />
+        <WarningIcon />
         <svelte:fragment slot="tooltip-content">
           This amount includes unknown tokens for which we couldnʼt determine a current USD value.
         </svelte:fragment>

--- a/src/lib/components/drip-list-card/drip-list-card-representational.svelte
+++ b/src/lib/components/drip-list-card/drip-list-card-representational.svelte
@@ -256,7 +256,7 @@
         </div>
         <div class="typo-text tabular-nums total-streamed-badge">
           {#if browser}
-            <AggregateFiatEstimate amounts={totalIncomingAmounts} />
+            <AggregateFiatEstimate supressUnknownAmountsWarning amounts={totalIncomingAmounts} />
           {/if}
           <span class="muted">&nbsp;total</span>
         </div>

--- a/src/lib/components/supporters-section/components/support-item.svelte
+++ b/src/lib/components/supporters-section/components/support-item.svelte
@@ -3,6 +3,9 @@
   import type { ComponentType } from 'svelte';
   import WarningIcon from 'radicle-design-system/icons/ExclamationCircle.svelte';
   import Tooltip from '$lib/components/tooltip/tooltip.svelte';
+  import modal from '$lib/stores/modal';
+  import Stepper from '$lib/components/stepper/stepper.svelte';
+  import addCustomTokenFlowSteps from '$lib/flows/add-custom-token/add-custom-token-flow-steps';
 
   export let title: {
     component: ComponentType;
@@ -11,6 +14,8 @@
   export let href: string | undefined = undefined;
 
   export let subtitle: string | undefined = undefined;
+  export let tokenAddress: string | undefined = undefined;
+
   export let fiatEstimate: {
     fiatEstimateCents: number | 'pending' | 'unsupported' | undefined;
     includesUnknownPrice: boolean;
@@ -27,7 +32,9 @@
       <div class="title">
         <svelte:component this={title.component} {...title.props} />
       </div>
-      {#if subtitle}<div class="subtitle muted">{subtitle}</div>{/if}
+      {#if subtitle}
+        <div class="subtitle muted">{subtitle}</div>
+      {/if}
     </div>
   </div>
   <div class="amount">
@@ -38,11 +45,19 @@
           <svelte:fragment slot="tooltip-content">
             This amount includes unknown tokens for which we couldnʼt determine a current USD value.
           </svelte:fragment>
-          <WarningIcon style="fill: var(--color-negative)" />
+          <WarningIcon />
         </Tooltip>
       {/if}
     </div>
-    <div class="amount-sub muted tabular-nums">{subAmount}</div>
+    {#if subAmount === 'Unknown token' && tokenAddress}
+      <button
+        class="amount-sub muted tabular-nums"
+        on:click={() => modal.show(Stepper, undefined, addCustomTokenFlowSteps(tokenAddress))}
+        >{subAmount}</button
+      >
+    {:else if subAmount}
+      <div class="amount-sub muted tabular-nums">{subAmount}</div>
+    {/if}
   </div>
 </a>
 

--- a/src/lib/components/supporters-section/supporters.section.svelte
+++ b/src/lib/components/supporters-section/supporters.section.svelte
@@ -331,6 +331,7 @@
       {#each sorted as item}
         {#if item.__typename === 'OneTimeDonationSupport'}
           <SupportItem
+            tokenAddress={item.amount.tokenAddress}
             title={{
               component: IdentityBadge,
               props: {
@@ -347,6 +348,7 @@
         {#if item.__typename === 'StreamSupport'}
           {@const stream = item.stream}
           <SupportItem
+            tokenAddress={item.stream.streamConfig.amountPerSecond.tokenAddress}
             href={buildStreamUrl(
               stream.sender.accountId,
               stream.streamConfig.amountPerSecond.tokenAddress,


### PR DESCRIPTION
- Make the warnings when a token USD value is unknown grey instead of red (aka less intense)
- Remove the warning completely from drip list total amount fiat conversion includes unknown tokens (these tokens not listed on CMC likely don't any / much "real world value" anyway)
- Allow clicking on "Unknown token" in support table items (OTD & stream type) to bring up the "add custom token" modal with address pre-filled