### PR TITLE
fix: elevation color should be foreground

### DIFF
--- a/src/styles/elevation.css
+++ b/src/styles/elevation.css
@@ -1,7 +1,7 @@
 :root {
-  --elevation-low: 0px 0px 0px 1px currentColor;
+  --elevation-low: 0px 0px 0px 1px var(--color-foreground);
 
-  --elevation-medium: 0px 0px 0px 1px currentColor, 0 4px 0px 1px currentColor;
+  --elevation-medium: 0px 0px 0px 1px var(--color-foreground), 0 4px 0px 1px var(--color-foreground);
 
-  --elevation-high: 0px 0px 0px 1px currentColor, 0 8px 0px 1px currentColor;
+  --elevation-high: 0px 0px 0px 1px var(--color-foreground), 0 8px 0px 1px var(--color-foreground);
 }


### PR DESCRIPTION
restores proper border color, from
![image](https://github.com/drips-network/app/assets/6071219/1e490de9-ea49-4d10-bf9d-ad10595cf202)
to
<img width="348" alt="Screenshot 2024-02-22 at 15 14 34" src="https://github.com/drips-network/app/assets/6071219/5ef3bd70-3013-40e2-a827-0bd0b62f2713">
