### PR TITLE
fix: list-select checkbox vertical alignment

### DIFF
--- a/src/lib/components/list-select/list-select.svelte
+++ b/src/lib/components/list-select/list-select.svelte
@@ -202,7 +202,7 @@
       <div
         role="option"
         aria-selected={selected.includes(slug)}
-        class="item flex items-start p-3 select-none"
+        class="item flex items-center p-3 select-none"
         class:selected={selected.includes(slug)}
         class:disabled={isItemDisabled(slug)}
         class:hidden={!Object.values(filteredItems).includes(item)}


### PR DESCRIPTION
closes #901 
vertically align check-boxes/select-circles with content
<img width="708" alt="Screenshot 2024-02-26 at 17 15 30" src="https://github.com/drips-network/app/assets/6071219/c20f3d60-f3c2-4cf5-a15e-f6786441b64a">
