### PR TITLE
fix: allow closing create-drip-list modal (closes #1006)

### DIFF
--- a/src/lib/components/drip-lists-section/drip-lists-section.svelte
+++ b/src/lib/components/drip-lists-section/drip-lists-section.svelte
@@ -69,7 +69,10 @@
             icon: Plus,
             variant: 'primary',
             handler: () =>
-              modal.show(CreateDripListStepper, undefined, { skipWalletConnect: true }),
+              modal.show(CreateDripListStepper, undefined, {
+                skipWalletConnect: true,
+                isModal: true,
+              }),
           },
         ]
       : [],

--- a/src/lib/flows/create-drip-list-flow/create-drip-list-flow.ts
+++ b/src/lib/flows/create-drip-list-flow/create-drip-list-flow.ts
@@ -118,10 +118,12 @@ export function slotsTemplate(state: State, stepIndex: number): Slots {
   }
 }
 
-export const steps = (state: Writable<State>, skipWalletConnect = false) => [
+export const steps = (state: Writable<State>, skipWalletConnect = false, isModal = false) => [
   makeStep({
     component: BuildListStep,
-    props: undefined,
+    props: {
+      canCancel: isModal,
+    },
   }),
   ...(skipWalletConnect
     ? []

--- a/src/lib/flows/create-drip-list-flow/create-drip-list-stepper.svelte
+++ b/src/lib/flows/create-drip-list-flow/create-drip-list-stepper.svelte
@@ -5,6 +5,7 @@
   import DripList from '$lib/components/illustrations/drip-list.svelte';
 
   export let skipWalletConnect = false;
+  export let isModal = false;
 
   let currentStepIndex = 0;
 
@@ -29,7 +30,7 @@
   bind:currentStepIndex
   on:stepChange={() => window.scrollTo({ top: 0 })}
   context={() => state}
-  steps={steps(state, skipWalletConnect)}
+  steps={steps(state, skipWalletConnect, isModal)}
   minHeightPx={128}
 />
 

--- a/src/lib/flows/create-drip-list-flow/steps/build-list/build-list.svelte
+++ b/src/lib/flows/create-drip-list-flow/steps/build-list/build-list.svelte
@@ -12,6 +12,7 @@
   const dispatch = createEventDispatcher<StepComponentEvents>();
 
   export let context: Writable<State>;
+  export let canCancel = false;
 
   const { searchParams } = $page.url;
   const urlToAdd = searchParams.get('urlToAdd') ?? undefined;
@@ -25,6 +26,9 @@
 >
   <DripListEditor bind:isValid bind:dripList={$context.dripList} {urlToAdd} />
   <svelte:fragment slot="actions">
+    {#if canCancel}
+      <Button on:click={() => dispatch('conclude')} variant="ghost">Cancel</Button>
+    {/if}
     <Button
       disabled={!isValid}
       icon={Check}


### PR DESCRIPTION
closes #1006 
- adds "Cancel" button to modal stepper (but not to funder onboarding)
<img width="758" alt="Screenshot 2024-02-27 at 18 24 32" src="https://github.com/drips-network/app/assets/6071219/a8ede1d2-96d6-4d56-8d89-e6c79eecfeaf">
<img width="898" alt="Screenshot 2024-02-27 at 18 24 43" src="https://github.com/drips-network/app/assets/6071219/62363588-78dd-478d-a2ca-b09683fc0d40">