### PR TITLE
fix: add back button to edit-project-splits (closes #548)

### DIFF
--- a/src/lib/components/step-layout/step-layout.svelte
+++ b/src/lib/components/step-layout/step-layout.svelte
@@ -6,9 +6,14 @@
   <div class="content">
     <slot />
   </div>
-  <div class="actions">
-    <slot name="actions" />
-  </div>
+  <footer class="flex justify-between gap-4">
+    <div class="flex gap-2">
+      <slot name="left-actions" />
+    </div>
+    <div class="flex gap-2">
+      <slot name="actions" />
+    </div>
+  </footer>
 </div>
 
 <style>
@@ -26,11 +31,5 @@
 
   .center > .content {
     align-items: center;
-  }
-
-  .actions {
-    display: flex;
-    justify-content: flex-end;
-    gap: 1rem;
   }
 </style>

--- a/src/lib/flows/edit-project-splits/steps/edit-dependency-list.svelte
+++ b/src/lib/flows/edit-project-splits/steps/edit-dependency-list.svelte
@@ -8,6 +8,7 @@
   import type { StepComponentEvents } from '$lib/components/stepper/types';
   import Button from '$lib/components/button/button.svelte';
   import ListEditor from '$lib/components/drip-list-members-editor/drip-list-members-editor.svelte';
+  import ArrowLeft from '$lib/components/icons/ArrowLeft.svelte';
 
   const dispatch = createEventDispatcher<StepComponentEvents>();
 
@@ -32,6 +33,9 @@
     maxItems={200 - maintainerKeys.length}
     allowedItems={['eth-addresses', 'projects', 'drip-lists']}
   />
+  <svelte:fragment slot="left-actions">
+    <Button icon={ArrowLeft} on:click={() => dispatch('goBackward')}>Back</Button>
+  </svelte:fragment>
   <svelte:fragment slot="actions">
     <Button
       disabled={!formValid}

--- a/src/lib/flows/edit-project-splits/steps/edit-maintainer-list.svelte
+++ b/src/lib/flows/edit-project-splits/steps/edit-maintainer-list.svelte
@@ -8,6 +8,7 @@
   import type { StepComponentEvents } from '$lib/components/stepper/types';
   import Button from '$lib/components/button/button.svelte';
   import ListEditor from '$lib/components/drip-list-members-editor/drip-list-members-editor.svelte';
+  import ArrowLeft from '$lib/components/icons/ArrowLeft.svelte';
 
   const dispatch = createEventDispatcher<StepComponentEvents>();
 
@@ -42,6 +43,9 @@
     maxItems={200 - dependencyKeys.length}
     allowedItems={['eth-addresses']}
   />
+  <svelte:fragment slot="left-actions">
+    <Button icon={ArrowLeft} on:click={() => dispatch('goBackward')}>Back</Button>
+  </svelte:fragment>
   <svelte:fragment slot="actions">
     <Button disabled={!formValid} icon={ArrowRight} variant="primary" on:click={nextStep}
       >Continue</Button

--- a/src/lib/flows/edit-project-splits/steps/review.svelte
+++ b/src/lib/flows/edit-project-splits/steps/review.svelte
@@ -13,6 +13,7 @@
   import transact, { makeTransactPayload } from '$lib/components/stepper/utils/transact';
   import GitProjectService from '$lib/utils/project/GitProjectService';
   import { getCallerClient } from '$lib/utils/get-drips-clients';
+  import ArrowLeft from '$lib/components/icons/ArrowLeft.svelte';
 
   const dispatch = createEventDispatcher<StepComponentEvents>();
 
@@ -66,7 +67,7 @@
 <StepLayout>
   <StepHeader
     headline="Review"
-    description="Please double-check your new Project Splits and confirm in your wallet."
+    description="Double-check your new project splits then confirm in your wallet."
   />
   <FormField type="div" title="Split funds with">
     <div class="card">
@@ -91,6 +92,9 @@
       </div>
     </div>
   </FormField>
+  <svelte:fragment slot="left-actions">
+    <Button icon={ArrowLeft} on:click={() => dispatch('goBackward')}>Back</Button>
+  </svelte:fragment>
   <svelte:fragment slot="actions">
     <Button icon={WalletIcon} variant="primary" on:click={submit}
       >Confirm changes in your wallet</Button

--- a/src/lib/flows/edit-project-splits/steps/set-new-dependency-maintainer-split.svelte
+++ b/src/lib/flows/edit-project-splits/steps/set-new-dependency-maintainer-split.svelte
@@ -47,6 +47,7 @@
     bind:percentages={$context.highLevelPercentages}
   />
   <svelte:fragment slot="actions">
+    <Button on:click={() => dispatch('conclude')} variant="ghost">Cancel</Button>
     <Button icon={ArrowRight} variant="primary" on:click={nextStep}>Continue</Button>
   </svelte:fragment>
 </StepLayout>


### PR DESCRIPTION
closes #548, add's Cancel + Back buttons to Edit Project Splits flow like our other modals
<img width="796" alt="Screenshot 2024-02-29 at 16 30 12" src="https://github.com/drips-network/app/assets/6071219/ae33b4f9-17ac-434e-960b-7f1f881c0dea">
<img width="752" alt="Screenshot 2024-02-29 at 16 30 16" src="https://github.com/drips-network/app/assets/6071219/3b65bab5-b16d-40c8-8c99-a3e70da3c321">
<img width="750" alt="Screenshot 2024-02-29 at 16 30 21" src="https://github.com/drips-network/app/assets/6071219/3be4e03d-4b0a-436b-ac20-3e640959d434">
