### PR TITLE
add connect button to connect-page (closes #958)

### DIFF
--- a/src/lib/components/large-empty-state/large-empty-state.svelte
+++ b/src/lib/components/large-empty-state/large-empty-state.svelte
@@ -41,7 +41,7 @@
 <style>
   .large-empty-state {
     height: 100%;
-    padding: 30vh 0;
+    padding: 25vh 0;
     display: flex;
     justify-content: center;
     gap: 2rem;

--- a/src/routes/app/(app)/connect/+page.svelte
+++ b/src/routes/app/(app)/connect/+page.svelte
@@ -29,5 +29,5 @@
   headline="Connect to Drips"
   description="Connect an Ethereum wallet to continue to your Dashboard."
   button={{ label: 'Connect wallet', handler: () => wallet.connect() }}
-  secondaryButton={{ label: 'Go to Explore', handler: () => goto('/app') }}
+  secondaryButton={{ label: 'Explore Drips', handler: () => goto('/app') }}
 />

--- a/src/routes/app/(app)/connect/+page.svelte
+++ b/src/routes/app/(app)/connect/+page.svelte
@@ -27,5 +27,7 @@
 <LargeEmptyState
   emoji="🌐"
   headline="Connect to Drips"
-  description="Connect your wallet to view your Dashboard, or search to find profiles by ENS or address."
+  description="Connect an Ethereum wallet to continue to your Dashboard."
+  button={{ label: 'Connect wallet', handler: () => wallet.connect() }}
+  secondaryButton={{ label: 'Go to Explore', handler: () => goto('/app') }}
 />


### PR DESCRIPTION
closes #958
also thought it nice to give them an option to decline and return to Explore? 
(though not quite sure why "secondary" buttons appear as first button in these large-empty-states?)

<img width="1549" alt="Screenshot 2024-03-05 at 15 24 22" src="https://github.com/drips-network/app/assets/6071219/1297ec1d-86a1-4b3d-bc9e-3354d42673ef">
