### PR TITLE
feat: cached utility, add caching to explore page

### DIFF
--- a/src/lib/graphql/dripsQL.ts
+++ b/src/lib/graphql/dripsQL.ts
@@ -7,13 +7,9 @@ export default async function query<TResponse, TVariables extends Variables = Va
   query: RequestDocument,
   variables?: TVariables,
   customFetch: typeof fetch = fetch,
-  cache = false,
 ): Promise<TResponse> {
   const client = new GraphQLClient('/api/gql', {
     fetch: customFetch,
-    headers: {
-      'X-Cache': cache ? 'Yes' : 'No',
-    },
   });
 
   const parsedQuery = typeof query === 'string' ? parse(query) : query;

--- a/src/lib/utils/cached.ts
+++ b/src/lib/utils/cached.ts
@@ -1,0 +1,30 @@
+import type { getRedis } from '../../routes/api/redis';
+
+/**
+ * Caches the result of a fetcher function using Redis.
+ * @param redis - The Redis instance. If undefined, caching is disabled.
+ * @param key - The cache key.
+ * @param schema - The Zod schema.
+ * @param EX - The expiration time in seconds.
+ * @param fetcher - The fetcher function.
+ * @returns The result, either cached or freshly fetched.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export default async function cached<T>(
+  redis: Awaited<ReturnType<typeof getRedis>> | undefined,
+  key: string,
+  EX: number,
+  fetcher: () => Promise<T>,
+) {
+  const cachedResponse = redis && (await redis.get(key));
+
+  if (cachedResponse) {
+    return JSON.parse(cachedResponse) as Awaited<ReturnType<typeof fetcher>>;
+  } else {
+    const data = await fetcher();
+    await redis?.set(key, JSON.stringify(data), {
+      EX,
+    });
+    return data;
+  }
+}

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,42 +1,12 @@
 import { env } from '$env/dynamic/private';
-import totalDrippedApproximation from '$lib/utils/total-dripped-approx';
-import { z } from 'zod';
+import { cachedTotalDrippedPrices } from '$lib/utils/total-dripped-approx';
 import type { PageServerLoad } from './$types';
 import { getRedis } from './api/redis';
-import type { Prices } from '$lib/utils/fiat-estimates/fiat-estimates';
-import { utils } from 'ethers';
 
 export const load = (async ({ fetch }) => {
-  let prices: Prices = {};
-  const cacheKey = 'total-dripped-prices';
-
   const redis = env.CACHE_REDIS_CONNECTION_STRING ? await getRedis() : undefined;
 
-  const cachedResponse = redis && (await redis.get(cacheKey));
-
-  if (cachedResponse) {
-    prices = JSON.parse(cachedResponse);
-  } else {
-    const tokenAddresses = totalDrippedApproximation().map((a) => a.tokenAddress.toLowerCase());
-
-    // get pricing provider's tokenIds of our tokenAddresses...
-    const idMapRes = await (await fetch('/api/fiat-estimates/id-map')).json();
-    const idMap = z.record(z.string(), z.number()).parse(idMapRes);
-    const tokenIdsString = tokenAddresses.map((address) => idMap[address.toLowerCase()]).join(',');
-
-    // fetch prices...
-    const priceRes = await fetch(`/api/fiat-estimates/price/${tokenIdsString}`);
-    const parsedRes = z.record(z.string(), z.number()).parse(await priceRes.json());
-
-    // format
-    tokenAddresses.forEach(
-      (address: string) => (prices[utils.getAddress(address)] = parsedRes[idMap[address]]),
-    );
-
-    await redis?.set(cacheKey, JSON.stringify(prices), {
-      EX: 60 * 60 * 6,
-    });
-  }
+  const prices = await cachedTotalDrippedPrices(redis, fetch);
 
   return {
     prices,

--- a/src/routes/api/gql/+server.ts
+++ b/src/routes/api/gql/+server.ts
@@ -1,8 +1,5 @@
 import type { RequestEvent, RequestHandler } from './$types';
 import { GQL_ACCESS_TOKEN, GQL_URL } from '$env/static/private';
-import { getRedis } from '../redis';
-import { env } from '$env/dynamic/private';
-import * as crypto from 'crypto';
 
 function fetchFromGQLEndpoint(body: string) {
   return fetch(GQL_URL, {
@@ -18,34 +15,6 @@ function fetchFromGQLEndpoint(body: string) {
 // Proxies requests to the Drips GraphQL API, adding the Authorization header.
 export const POST: RequestHandler = async ({ request }: RequestEvent) => {
   const body = await request.text();
-
-  const cacheEnabled = request.headers.get('X-Cache') === 'Yes';
-
-  if (cacheEnabled && env.CACHE_REDIS_CONNECTION_STRING) {
-    const redis = await getRedis();
-
-    const serializedQuery = JSON.stringify(body);
-    const hash = crypto.createHash('sha256').update(serializedQuery).digest('hex');
-
-    const cached = await redis.get(`gql-${hash}`);
-
-    if (cached) {
-      return new Response(cached, {
-        headers: {
-          'Content-Type': 'application/json', // Assuming JSON response
-        },
-      });
-    } else {
-      const response = await fetchFromGQLEndpoint(body);
-      const responseData = await response.clone().text();
-
-      if (response.ok) {
-        await redis.set(`gql-${hash}`, responseData, { EX: 86400 });
-      }
-
-      return response;
-    }
-  }
 
   return await fetchFromGQLEndpoint(body);
 };

--- a/src/routes/app/(app)/+page.svelte
+++ b/src/routes/app/(app)/+page.svelte
@@ -103,7 +103,10 @@
           <h5>Total dripped</h5>
         </div>
         <span class="large-number pixelated"
-          ><AggregateFiatEstimate amounts={totalDrippedAmounts} /></span
+          ><AggregateFiatEstimate
+            amounts={totalDrippedAmounts}
+            prices={data.totalDrippedPrices}
+          /></span
         >
       </div>
       <div class="value-wrapper">


### PR DESCRIPTION
Adds a new `cached` utility. This simply takes a redis instance, cache key, EX time, and function to fetch data, and then either returns a previously-cached value, or fetches the data and writes it to the cache.

Overhauls the caching logic of the explore page so that the total dripped value on the LP always matches that of the explore page.

Removes the weird `X-Cache` header on the GQL fetch endpoint. Instead of this, we should always wrap GQL calls that we want to cache with the new `cached` utility.