### PR TITLE
bump uniswap token list, add USDGLO

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@safe-global/safe-apps-sdk": "^7.10.0",
         "@sveltejs/adapter-netlify": "^2.0.6",
         "@tanstack/svelte-table": "^8.5.15",
-        "@uniswap/default-token-list": "^10.0.0",
+        "@uniswap/default-token-list": "^11.15.0",
         "@uniswap/token-lists": "^1.0.0-beta.31",
         "@web3-onboard/core": "^2.20.2",
         "@web3-onboard/injected-wallets": "^2.10.1",
@@ -5608,9 +5608,9 @@
       "dev": true
     },
     "node_modules/@uniswap/default-token-list": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@uniswap/default-token-list/-/default-token-list-10.0.0.tgz",
-      "integrity": "sha512-xz9exeJe1sJl6qJxtGF73iqjnv1V/lWBzMhGpLtalPJXQIfoJwW1g8qs//FiGITsi8tmynoyC6hfd6Pnc1tBTA=="
+      "version": "11.15.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/default-token-list/-/default-token-list-11.15.0.tgz",
+      "integrity": "sha512-EqKvShhsmm1M5OE11PUWsc5rzRTDdbEyGV9OmLi8xvia4LyrT/6xE9JteqaV1UT13vGtk8sqqq0QYAwuuubY7A=="
     },
     "node_modules/@uniswap/token-lists": {
       "version": "1.0.0-beta.33",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@safe-global/safe-apps-sdk": "^7.10.0",
     "@sveltejs/adapter-netlify": "^2.0.6",
     "@tanstack/svelte-table": "^8.5.15",
-    "@uniswap/default-token-list": "^10.0.0",
+    "@uniswap/default-token-list": "^11.15.0",
     "@uniswap/token-lists": "^1.0.0-beta.31",
     "@web3-onboard/core": "^2.20.2",
     "@web3-onboard/injected-wallets": "^2.10.1",

--- a/src/lib/stores/tokens/additional-tokens.json
+++ b/src/lib/stores/tokens/additional-tokens.json
@@ -1,0 +1,20 @@
+{
+  "name": "Drips App Extra Default Tokens",
+  "timestamp": "2024-02-26T23:41:27.220Z",
+  "version": {
+    "major": 0,
+    "minor": 0,
+    "patch": 1
+  },
+  "tags": {},
+  "tokens": [
+    {
+      "chainId": 1,
+      "address": "0x4F604735c1cF31399C6E711D5962b2B3E0225AD3",
+      "name": "Glo Dollar",
+      "symbol": "USDGLO",
+      "decimals": 18,
+      "logoURI": "https://etherscan.io/token/images/glo_32.png"
+    }
+  ]
+}

--- a/src/lib/stores/tokens/token-list.ts
+++ b/src/lib/stores/tokens/token-list.ts
@@ -1,0 +1,4 @@
+import uniswapTokenList from '@uniswap/default-token-list';
+import additionalTokens from './additional-tokens.json';
+
+export const DRIPS_DEFAULT_TOKEN_LIST = [...uniswapTokenList.tokens, ...additionalTokens.tokens];

--- a/src/lib/stores/tokens/tokens.store.ts
+++ b/src/lib/stores/tokens/tokens.store.ts
@@ -1,5 +1,4 @@
-import uniswapTokenList from '@uniswap/default-token-list';
-import additionalTokens from './additional-tokens.json';
+import { DRIPS_DEFAULT_TOKEN_LIST } from './token-list';
 
 import type { TokenInfo } from '@uniswap/token-lists';
 import { get, writable } from 'svelte/store';
@@ -21,8 +20,6 @@ export interface CustomTokenInfoWrapper {
 
 export type TokenInfoWrapper = DefaultTokenInfoWrapper | CustomTokenInfoWrapper;
 
-const TOKEN_LIST = [...uniswapTokenList.tokens, ...additionalTokens.tokens];
-
 export default (() => {
   let chainId: number | undefined;
   const tokenList = writable<TokenInfoWrapper[] | undefined>();
@@ -40,12 +37,12 @@ export default (() => {
       ? storedTokens.readCustomTokensList().filter((t) => t.info.chainId === chainId)
       : [];
 
-    const defaultTokens: TokenInfoWrapper[] = TOKEN_LIST.filter((t) => t.chainId === chainId).map(
-      (t) => ({
-        info: t,
-        source: 'default',
-      }),
-    );
+    const defaultTokens: TokenInfoWrapper[] = DRIPS_DEFAULT_TOKEN_LIST.filter(
+      (t) => t.chainId === chainId,
+    ).map((t) => ({
+      info: t,
+      source: 'default',
+    }));
 
     tokenList.set([...defaultTokens, ...customTokens]);
 

--- a/src/lib/stores/tokens/tokens.store.ts
+++ b/src/lib/stores/tokens/tokens.store.ts
@@ -1,4 +1,6 @@
 import uniswapTokenList from '@uniswap/default-token-list';
+import additionalTokens from './additional-tokens.json';
+
 import type { TokenInfo } from '@uniswap/token-lists';
 import { get, writable } from 'svelte/store';
 import * as storedTokens from './stored-custom-tokens';
@@ -19,6 +21,8 @@ export interface CustomTokenInfoWrapper {
 
 export type TokenInfoWrapper = DefaultTokenInfoWrapper | CustomTokenInfoWrapper;
 
+const TOKEN_LIST = [...uniswapTokenList.tokens, ...additionalTokens.tokens];
+
 export default (() => {
   let chainId: number | undefined;
   const tokenList = writable<TokenInfoWrapper[] | undefined>();
@@ -36,12 +40,12 @@ export default (() => {
       ? storedTokens.readCustomTokensList().filter((t) => t.info.chainId === chainId)
       : [];
 
-    const defaultTokens: TokenInfoWrapper[] = uniswapTokenList.tokens
-      .filter((t) => t.chainId === chainId)
-      .map((t) => ({
+    const defaultTokens: TokenInfoWrapper[] = TOKEN_LIST.filter((t) => t.chainId === chainId).map(
+      (t) => ({
         info: t,
         source: 'default',
-      }));
+      }),
+    );
 
     tokenList.set([...defaultTokens, ...customTokens]);
 

--- a/src/lib/stores/tokens/tokens.store.unit.test.ts
+++ b/src/lib/stores/tokens/tokens.store.unit.test.ts
@@ -1,7 +1,7 @@
-import uniswapTokenList from '@uniswap/default-token-list';
 import { Utils } from 'radicle-drips';
 import { get } from 'svelte/store';
 import tokens from '.';
+import { DRIPS_DEFAULT_TOKEN_LIST } from './token-list';
 
 vi.mock('$app/environment', () => ({
   browser: true,
@@ -29,12 +29,10 @@ describe('tokens store', () => {
     tokens.connect(1);
 
     expect(get(tokens)).toStrictEqual(
-      uniswapTokenList.tokens
-        .filter((t) => t.chainId === 1)
-        .map((t) => ({
-          source: 'default',
-          info: t,
-        })),
+      DRIPS_DEFAULT_TOKEN_LIST.filter((t) => t.chainId === 1).map((t) => ({
+        source: 'default',
+        info: t,
+      })),
     );
   });
 


### PR DESCRIPTION
Updates default token list and adds a new `additional-tokens.json` file which we can use to manually add default tokens for the drips app on top of uniswap's default list.

Adds Glo Token, which is used by Funding the Commons.

Resolves #938 