### PR TITLE
feat: display up to two decimal places in splits

### DIFF
--- a/src/lib/utils/splits/get-split-percent.ts
+++ b/src/lib/utils/splits/get-split-percent.ts
@@ -2,21 +2,19 @@ const maxWeight = 1000000; // get from sdk/contract?
 
 export function getSplitPercent(weight: number | bigint = BigInt('0'), format = 'default'): string {
   const w = typeof weight === 'bigint' ? Number(weight) : weight;
-
   const percent = (Number((w * maxWeight) / maxWeight) / maxWeight) * 100;
 
   switch (format) {
     case 'pretty': {
-      const integer = Math.floor(percent);
+      const roundedPercent = Math.round(percent * 100) / 100;
 
-      return !integer && percent > 0
-        ? '<1%'
-        : integer === 99 && percent > integer
-        ? '>99%'
-        : `${integer}%`;
+      // Return with decimals if necessary
+      return roundedPercent === Math.floor(roundedPercent)
+        ? `${Math.floor(roundedPercent)}%`
+        : `${roundedPercent}%`;
     }
     default: {
-      return percent.toString();
+      return percent.toFixed(2);
     }
   }
 }


### PR DESCRIPTION
If necessary, splits items now show up to two decimal places. Check the example below. Previously, all those split items would just say "1%".

<img width="1075" alt="Screenshot 2024-03-13 at 10 13 01" src="https://github.com/drips-network/app/assets/1018218/b0b190a9-fdcc-44a2-ac6d-fd3dff91f778">

Resolves #556 