### PR TITLE
More resilient FUNDING.json Comparison

### DIFF
--- a/src/lib/utils/github/GitHub.ts
+++ b/src/lib/utils/github/GitHub.ts
@@ -49,7 +49,7 @@ export default class GitHub {
 
     const fundingJson = JSON.parse(fileContent);
 
-    if (JSON.stringify(fundingJson).replace(/\s/g, '') !== template.replace(/\s/g, '')) {
+    if (JSON.stringify(fundingJson).replace(/\s/g, '').toLowerCase() !== template.replace(/\s/g, '').toLowerCase()) {
       throw new Error('Invalid FUNDING.json file. Does it have the correct Ethereum address?');
     }
 


### PR DESCRIPTION
Hi there,
I just wanted to claim funds for the EthereumJS monorepo and couldn't get the `FUNDING.json` file to get accepted.

After some digging I realized that I had created a lower-case address which I then imported into MetaMask, and MetaMask had transformed this to a partly-capitalized address (which is ok since Ethereum addresses are case insensitive and this can be used for additional check-summing).

So I guess it is more resilient and less error-prone for `FUNDING.json` comparison to compare the lower-case versions of the file.