### PR TITLE
fix: possible to schedule stream in the past

### DIFF
--- a/src/lib/flows/create-stream-flow/input-details.svelte
+++ b/src/lib/flows/create-stream-flow/input-details.svelte
@@ -192,6 +192,7 @@
     !setStartAndEndDate ||
     (combinedStartDate &&
       combinedEndDate &&
+      combinedStartDate.getTime() > new Date().getTime() &&
       combinedStartDate?.getTime() < combinedEndDate?.getTime());
 
   $: formValid =


### PR DESCRIPTION
It was possible to schedule a stream start & theoretically end dates because the check for the date being in the future was only applied on the date & time field levels, not on the overall combined date. Meaning that e.g. on the 1st of Jan at 1AM, you could schedule a stream to start on the 1st of Jan at midnight, and theoretically even end a second later.

Even though our estimation logic can handle it, this is strange, so this fixes it.