### PR TITLE
refactor: allow pasting Drip List URLs when setting streams

### DIFF
--- a/src/routes/app/(app)/[accountId]/tokens/[token]/streams/[dripId]/+page.svelte
+++ b/src/routes/app/(app)/[accountId]/tokens/[token]/streams/[dripId]/+page.svelte
@@ -74,7 +74,8 @@
   $: {
     if (stream) {
       streamName =
-        stream.receiver.driver === 'nft' ? 'Continuous donation' : stream.name ?? 'Unnamed stream';
+        stream.name ||
+        (stream.receiver.driver === 'nft' ? 'Continuous donation' : 'Unnamed stream');
     }
   }
 

--- a/src/routes/app/(app)/funds/sections/streams.section.svelte
+++ b/src/routes/app/(app)/funds/sections/streams.section.svelte
@@ -94,7 +94,8 @@
 
       // TODO: Donʼt presume that any stream to an NFT subaccount is going to a Drip List.
       const streamName =
-        stream.receiver.driver === 'nft' ? 'Continuous donation' : stream.name ?? 'Unnamed stream';
+        stream.name ||
+        (stream.receiver.driver === 'nft' ? 'Continuous donation' : 'Unnamed stream');
 
       return {
         streamId: stream.id,


### PR DESCRIPTION
Resolves: https://github.com/drips-network/app/issues/852

Also adds the ability to name streams to Drip Lists and fixes an issue that does not allow users to update a stream's name.

The only thing I am not really happy about is when you paste the Drip List URL while setting the stream receiver, it resolves directly to the Drip List ID. It might be a bit confusing but the card at the top of the modal showing the stream from => to clearly shows the resolved drip list name. Making it to resolve to something else by reusing what's already there and not introducing more changes, is not so easy, unless I am missing something. We can do it if needed, of course.