### PR TITLE
simplify ens store provider connection handling

### DIFF
--- a/src/lib/components/drip-list-badge/drip-list-badge.svelte
+++ b/src/lib/components/drip-list-badge/drip-list-badge.svelte
@@ -29,10 +29,8 @@
   export let disabled = false;
   export let outline = false;
 
-  const ensConnected = ensStore.connected;
-
   // lookup ens name if owner is provided
-  $: showOwner && dripList && $ensConnected && ensStore.lookup(dripList.owner.address);
+  $: showOwner && dripList && ensStore.lookup(dripList.owner.address);
   $: ens = showOwner && dripList ? $ensStore[dripList.owner.address] : {};
   $: username =
     ens?.name ?? (dripList && showOwner && formatAddress(dripList.owner.address)) ?? undefined;

--- a/src/lib/components/identity-badge/identity-badge.svelte
+++ b/src/lib/components/identity-badge/identity-badge.svelte
@@ -22,9 +22,7 @@
   export let isReverse = false;
   export let tag: string | undefined = undefined;
 
-  const ensConnected = ensStore.connected;
-
-  $: $ensConnected && ensStore.lookup(address);
+  $: ensStore.lookup(address);
   $: ens = $ensStore[address];
 
   $: blockyUrl = `/api/blockies/${address}`;

--- a/src/lib/utils/decode-universal-account-id.ts
+++ b/src/lib/utils/decode-universal-account-id.ts
@@ -2,7 +2,6 @@ import ens from '$lib/stores/ens';
 import { getAddressDriverClient } from '$lib/utils/get-drips-clients';
 import { isAddress } from 'ethers/lib/utils';
 import { AddressDriverClient, Utils } from 'radicle-drips';
-import { get } from 'svelte/store';
 
 interface AddressDriverResult {
   driver: 'address';
@@ -41,21 +40,6 @@ export default async function (
       dripsAccountId,
     };
   } else if (universalAcccountIdentifier.endsWith('.eth')) {
-    // Subscribe to ens.connected store and wait until it's true
-
-    const ensConnected = ens.connected;
-
-    if (!get(ensConnected)) {
-      await new Promise((resolve) => {
-        const unsubscribe = ensConnected.subscribe((connected) => {
-          if (connected) {
-            unsubscribe();
-            resolve(undefined);
-          }
-        });
-      });
-    }
-
     const lookup = await ens.reverseLookup(universalAcccountIdentifier);
     if (lookup) {
       const dripsAccountId = await (await getAddressDriverClient()).getAccountIdByAddress(lookup);

--- a/src/routes/app/(app)/[accountId]/tokens/[token]/+page.svelte
+++ b/src/routes/app/(app)/[accountId]/tokens/[token]/+page.svelte
@@ -39,7 +39,6 @@
   import checkIsUser from '$lib/utils/check-is-user';
   import decodeAccountId from '$lib/utils/decode-universal-account-id';
   import LargeEmptyState from '$lib/components/large-empty-state/large-empty-state.svelte';
-  // import collectFlowSteps from '$lib/flows/collect-flow/collect-flow-steps';
   import getWithdrawSteps from '$lib/flows/withdraw-flow/withdraw-flow-steps';
   import topUpFlowSteps from '$lib/flows/top-up-flow/top-up-flow-steps';
   import addCustomTokenFlowSteps from '$lib/flows/add-custom-token/add-custom-token-flow-steps';

--- a/src/routes/app/+layout.svelte
+++ b/src/routes/app/+layout.svelte
@@ -33,9 +33,7 @@
     await wallet.initialize();
     loaded = true;
 
-    const { connected, network, provider, address, safe } = $wallet;
-
-    ens.connect(provider);
+    const { connected, network, address, safe } = $wallet;
 
     themeStore.subscribe((v) => {
       const onboardTheme = v.currentTheme === 'h4x0r' ? 'dark' : v.currentTheme;


### PR DESCRIPTION
Removes need to explicitly `connect` the `ens.store` with a provider. It just uses the `provider` from `wallet.store` now.