### PR TITLE
fix(ui): rephrase "created by" to "owned by"

### DIFF
--- a/src/lib/components/drip-list-card/drip-list-card.svelte
+++ b/src/lib/components/drip-list-card/drip-list-card.svelte
@@ -244,7 +244,7 @@
       {/if}
       {#if !listingMode}
         <div class="flex gap-2">
-          Created by <IdentityBadge
+          Owned by <IdentityBadge
             showAvatar={true}
             showIdentity={true}
             address={listOwner?.address ?? votingRound?.publisherAddress ?? unreachable()}


### PR DESCRIPTION
Resolves #1225

<kbd>![](https://github.com/user-attachments/assets/5ef6dbd2-fc7b-4e9c-9e6b-701ebb410331)</kbd>
