### PR TITLE
finalize network picker

### DIFF
--- a/src/lib/components/network-picker/components/network-list.svelte
+++ b/src/lib/components/network-picker/components/network-list.svelte
@@ -2,12 +2,17 @@
   import { page } from '$app/stores';
   import Check from '$lib/components/icons/Check.svelte';
   import TestnetFrame from '$lib/components/icons/networks/TestnetFrame.svelte';
-  import network, { getNetwork, SUPPORTED_CHAIN_IDS } from '$lib/stores/wallet/network';
+  import currentNetwork, {
+    getNetwork,
+    NETWORK_CONFIG,
+    SUPPORTED_CHAIN_IDS,
+  } from '$lib/stores/wallet/network';
   import hexToRgb from '$lib/utils/hex-to-rgb';
 
-  const networks = SUPPORTED_CHAIN_IDS.map(getNetwork);
+  const networks = Object.values(NETWORK_CONFIG);
+  const networksToShow = networks.filter((n) => (currentNetwork.isTestnet ? true : !n.isTestnet));
 
-  const selectedChainId = network.chainId;
+  const selectedChainId = currentNetwork.chainId;
 
   function getUrl(chainId: (typeof SUPPORTED_CHAIN_IDS)[number]) {
     const path = $page.url.pathname;
@@ -23,7 +28,7 @@
 </script>
 
 <div class="network-list">
-  {#each networks as { chainId, label, icon, color, isTestnet }}
+  {#each networksToShow as { chainId, label, icon, color, isTestnet }}
     {@const colorRgb = hexToRgb(color)}
     <a href={getUrl(chainId)} class="network-item">
       <div

--- a/src/lib/stores/wallet/network.ts
+++ b/src/lib/stores/wallet/network.ts
@@ -54,7 +54,7 @@ const etherscanLinkTemplate = (txHash: string, networkName: string) =>
     ? `https://etherscan.io/tx/${txHash}`
     : `https://${networkName}.etherscan.io/tx/${txHash}`;
 
-const NETWORK_CONFIG: ValueForEachSupportedChain<Network> = {
+export const NETWORK_CONFIG: ValueForEachSupportedChain<Network> = {
   [1]: {
     chainId: 1,
     name: 'homestead',

--- a/src/routes/app/(app)/[accountId]/+page.server.ts
+++ b/src/routes/app/(app)/[accountId]/+page.server.ts
@@ -140,6 +140,6 @@ export const load = async ({ params, fetch }) => {
       ...userRes.userByAddress,
       votingRounds: votingRoundsWithSplits,
     },
-    preservePathOnNetworkChange: false,
+    preservePathOnNetworkChange: true,
   };
 };

--- a/src/routes/app/(app)/drip-lists/+page.ts
+++ b/src/routes/app/(app)/drip-lists/+page.ts
@@ -69,7 +69,11 @@ export const load = async ({ fetch }) => {
     votingRounds: votingRoundsWithSplits,
   });
 
-  return { dripLists: dripListsRes.dripLists, votingRounds: votingRoundsWithSplits };
+  return {
+    dripLists: dripListsRes.dripLists,
+    votingRounds: votingRoundsWithSplits,
+    preservePathOnNetworkChange: true,
+  };
 };
 
 export const ssr = false;

--- a/src/routes/app/(app)/drip-lists/all/+page.server.ts
+++ b/src/routes/app/(app)/drip-lists/all/+page.server.ts
@@ -22,5 +22,6 @@ export const load = (async ({ fetch }) => {
       fetch,
     ),
     blockWhileInitializing: false,
+    preservePathOnNetworkChange: true,
   };
 }) satisfies PageServerLoad;

--- a/src/routes/app/(app)/projects/(forges)/github/[githubUsername]/[githubRepoName]/+page.server.ts
+++ b/src/routes/app/(app)/projects/(forges)/github/[githubUsername]/[githubRepoName]/+page.server.ts
@@ -141,5 +141,6 @@ export const load = (async ({ params, fetch, url }) => {
     newRepo,
     correctCasingRepo,
     blockWhileInitializing: false,
+    preservePathOnNetworkChange: true,
   };
 }) satisfies PageServerLoad;

--- a/src/routes/app/(app)/projects/+page.ts
+++ b/src/routes/app/(app)/projects/+page.ts
@@ -36,7 +36,7 @@ export const load = async ({ fetch }) => {
 
   fetchedDataCache.write(res);
 
-  return { projects: res.projects };
+  return { projects: res.projects, preservePathOnNetworkChange: true };
 };
 
 export const ssr = false;

--- a/src/routes/app/(app)/projects/all/+page.server.ts
+++ b/src/routes/app/(app)/projects/all/+page.server.ts
@@ -40,5 +40,6 @@ export const load = (async ({ fetch }) => {
       fetch,
     ),
     blockWhileInitializing: false,
+    preservePathOnNetworkChange: true,
   };
 }) satisfies PageServerLoad;

--- a/src/routes/app/(app)/settings/+page.ts
+++ b/src/routes/app/(app)/settings/+page.ts
@@ -1,0 +1,3 @@
+export const load = () => ({
+  preservePathOnNetworkChange: true,
+});

--- a/src/routes/app/(app)/settings/custom-tokens/+page.ts
+++ b/src/routes/app/(app)/settings/custom-tokens/+page.ts
@@ -1,0 +1,3 @@
+export const load = () => ({
+  preservePathOnNetworkChange: true,
+});


### PR DESCRIPTION
- Preserve URLs of address profiles, dashboard pages (drip lists, projects), project profiles, settings, and custom token settings when switching between networks
- Display all networks when app connected to testnet, only display mainnets if not