### PR TITLE
fix: unable to claim projects with wrong casing that have funds

### DIFF
--- a/src/lib/flows/claim-project-flow/steps/enter-git-url/enter-git-url.svelte
+++ b/src/lib/flows/claim-project-flow/steps/enter-git-url/enter-git-url.svelte
@@ -175,11 +175,11 @@
       const project = response.projectByUrl;
 
       if (!project) {
-        throw new Error("Repo doesn't exist or is private");
+        throw new InvalidUrlError("Repo doesn't exist or is private");
       }
 
       if (project.__typename === 'ClaimedProject') {
-        throw new Error('Project already claimed');
+        throw new InvalidUrlError('Project already claimed');
       }
 
       if (

--- a/src/lib/flows/claim-project-flow/steps/enter-git-url/enter-git-url.svelte
+++ b/src/lib/flows/claim-project-flow/steps/enter-git-url/enter-git-url.svelte
@@ -1,4 +1,7 @@
 <script lang="ts" context="module">
+  import { UNCLAIMED_PROJECT_CARD_FRAGMENT } from '$lib/components/unclaimed-project-card/unclaimed-project-card.svelte';
+  import { gql } from 'graphql-request';
+
   export const ENTER_GIT_URL_STEP_PROJECT_FRAGMENT = gql`
     ${UNCLAIMED_PROJECT_CARD_FRAGMENT}
     fragment EnterGitUrlStepProject on Project {
@@ -7,6 +10,9 @@
         verificationStatus
         account {
           accountId
+        }
+        withdrawableBalances {
+          tokenAddress
         }
       }
     }
@@ -24,20 +30,19 @@
   import { createEventDispatcher, onMount } from 'svelte';
   import type { StepComponentEvents } from '$lib/components/stepper/types';
   import type { TextInputValidationState } from '$lib/components/text-input/text-input';
-  import UnclaimedProjectCard, {
-    UNCLAIMED_PROJECT_CARD_FRAGMENT,
-  } from '$lib/components/unclaimed-project-card/unclaimed-project-card.svelte';
+  import UnclaimedProjectCard from '$lib/components/unclaimed-project-card/unclaimed-project-card.svelte';
   import { isSupportedGitUrl, isValidGitUrl } from '$lib/utils/is-valid-git-url';
   import seededRandomElement from '$lib/utils/seeded-random-element';
   import { page } from '$app/stores';
   import possibleRandomEmoji from '$lib/utils/project/possible-random-emoji';
   import query from '$lib/graphql/dripsQL';
-  import { gql } from 'graphql-request';
   import type { ProjectQuery, ProjectQueryVariables } from './__generated__/gql.generated';
   import { ProjectVerificationStatus } from '$lib/graphql/__generated__/base-types';
   import AnnotationBox from '$lib/components/annotation-box/annotation-box.svelte';
   import possibleColors from '$lib/utils/project/possible-colors';
   import MagnifyingGlass from '$lib/components/icons/MagnifyingGlass.svelte';
+  import type { GetRepoResponse } from '../../../../../routes/api/github/[repoUrl]/+server';
+  import isClaimed from '$lib/utils/project/is-claimed';
 
   export let context: Writable<State>;
   export let projectUrl: string | undefined = undefined;
@@ -60,34 +65,101 @@
 
   let claimingRenamedRepoOriginalName: string | undefined;
 
+  const projectQuery = gql`
+    ${CLAIM_PROJECT_FLOW_PROJECT_FRAGMENT}
+    query Project($url: String!) {
+      projectByUrl(url: $url) {
+        ...ClaimProjectFlowProject
+      }
+    }
+  `;
+
+  class InvalidUrlError extends Error {}
+
+  function fixGitUrlFormat(gitUrl: string) {
+    let enteredUrlFixedFormat = gitUrl;
+
+    enteredUrlFixedFormat = enteredUrlFixedFormat.trim();
+
+    // format URL with "https://" (add, or replace "http://" since API error)
+    if (!/^https:\/\//.test(enteredUrlFixedFormat)) {
+      enteredUrlFixedFormat = 'https://' + enteredUrlFixedFormat.replace(/^http:\/\//, '');
+    }
+
+    // if url ends with /, remove it
+    if (enteredUrlFixedFormat.endsWith('/')) {
+      enteredUrlFixedFormat = enteredUrlFixedFormat.slice(0, -1);
+    }
+
+    return enteredUrlFixedFormat;
+  }
+
+  async function fetchRepoFromGitHub(gitUrl: string): Promise<GetRepoResponse> {
+    const repoInfoRes = await fetch(`/api/github/${encodeURIComponent(gitUrl)}`);
+
+    if (!repoInfoRes.ok) {
+      throw new InvalidUrlError(
+        'Repo not found. Make sure you enter a link to a public GitHub repository.',
+      );
+    }
+
+    return await repoInfoRes.json();
+  }
+
+  async function normalizeGitUrl(
+    gitUrl: string,
+    repoInfo: GetRepoResponse,
+  ): Promise<{ result: string; newRepoName?: string }> {
+    const { url: realUrl } = repoInfo;
+
+    if (realUrl === gitUrl) {
+      // Everything checks out.
+      return { result: gitUrl };
+    }
+
+    if (realUrl.toLowerCase() === gitUrl.toLowerCase()) {
+      // The casing is different. Normally, it should correct the casing, except in rare cases
+      // where the wrongly-cased project actually has some funds on Drips. This can happen if a split
+      // to the project was established before the Drips app properly fixed casing of projects.
+
+      const wronglyCasedProject = (
+        await query<ProjectQuery, ProjectQueryVariables>(projectQuery, {
+          url: gitUrl,
+        })
+      ).projectByUrl;
+
+      if (!wronglyCasedProject) {
+        return { result: realUrl };
+      }
+
+      if (isClaimed(wronglyCasedProject)) {
+        return { result: realUrl };
+      }
+
+      const wronglyCasedProjectHasFunds = wronglyCasedProject.withdrawableBalances.length > 0;
+
+      return wronglyCasedProjectHasFunds ? { result: gitUrl } : { result: realUrl };
+    }
+
+    // The URL is different. Can happen if the repo was renamed on GitHub. In this case, we want to let
+    // the user claim the "old" project, but warn them about it.
+    return { result: gitUrl, newRepoName: `${repoInfo.ownerName}/${repoInfo.repoName}` };
+  }
+
   async function fetchProject() {
     $context.linkedToRepo = false;
 
     try {
       validationState = { type: 'pending' };
 
-      // format URL with "https://" (add, or replace "http://" since API error)
-      if (!/^https:\/\//.test($context.gitUrl)) {
-        $context.gitUrl = 'https://' + $context.gitUrl.replace(/^http:\/\//, '');
-      }
+      const fixedGitUrl = fixGitUrlFormat($context.gitUrl);
 
-      // if url ends with /, remove it
-      if ($context.gitUrl.endsWith('/')) {
-        $context.gitUrl = $context.gitUrl.slice(0, -1);
-      }
+      const repoInfo = await fetchRepoFromGitHub(fixedGitUrl);
 
-      const repoInfoRes = await fetch(`/api/github/${encodeURIComponent($context.gitUrl)}`);
-      const repoInfo = await repoInfoRes.json();
-      const normalizedUrl = repoInfo.url;
+      const { result, newRepoName } = await normalizeGitUrl(fixedGitUrl, repoInfo);
 
-      // If the normalized URL is different from the original URL in lowercase, it means that the repo has likely
-      // been renamed on GitHub. In this case, we should let the user claim the outdated project too.
-      // In all other cases, we use the normalized URL to fix casing mismatches.
-      if (normalizedUrl?.toLowerCase() === $context.gitUrl.toLowerCase()) {
-        $context.gitUrl = normalizedUrl;
-      } else {
-        claimingRenamedRepoOriginalName = normalizedUrl;
-      }
+      $context.gitUrl = result;
+      if (newRepoName) claimingRenamedRepoOriginalName = newRepoName;
 
       $context.projectMetadata = {
         starCount: repoInfo.stargazersCount,
@@ -95,15 +167,6 @@
         description: repoInfo.description ?? undefined,
         defaultBranch: repoInfo.defaultBranch ?? undefined,
       };
-
-      const projectQuery = gql`
-        ${CLAIM_PROJECT_FLOW_PROJECT_FRAGMENT}
-        query Project($url: String!) {
-          projectByUrl(url: $url) {
-            ...ClaimProjectFlowProject
-          }
-        }
-      `;
 
       const response = await query<ProjectQuery, ProjectQueryVariables>(projectQuery, {
         url: $context.gitUrl,
@@ -135,9 +198,18 @@
       $context.projectColor = seededRandomElement(possibleColors, project.account.accountId);
 
       validationState = { type: 'valid' };
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (error: any) {
-      validationState = { type: 'invalid', message: error.message };
+    } catch (error: unknown) {
+      // eslint-disable-next-line no-console
+      console.error(error);
+
+      if (error instanceof InvalidUrlError) {
+        validationState = { type: 'invalid', message: error.message };
+      } else {
+        validationState = {
+          type: 'invalid',
+          message: 'An unexpected error occured. There may be more details in the console.',
+        };
+      }
     }
   }
 

--- a/src/routes/api/github/[repoUrl]/+server.ts
+++ b/src/routes/api/github/[repoUrl]/+server.ts
@@ -51,3 +51,5 @@ export const GET: RequestHandler = async ({ params }) => {
     error(status);
   }
 };
+
+export type GetRepoResponse = ReturnType<typeof mapGhResponse>;


### PR DESCRIPTION
Fixes an issue where it's impossible to claim funds for a project associated with a GH repo under different casing.