### PR TITLE
explicit errors if gasless owner update fails

### DIFF
--- a/src/lib/flows/claim-project-flow/claim-project-flow.ts
+++ b/src/lib/flows/claim-project-flow/claim-project-flow.ts
@@ -55,6 +55,7 @@ export interface State {
   maintainerSplits: ListEditorConfig;
   dependencySplits: ListEditorConfig;
   dependenciesAutoImported: boolean;
+  gaslessOwnerUpdateTaskId: string | undefined;
   avatar:
     | {
         type: 'emoji';
@@ -84,6 +85,7 @@ export const state = () =>
       weights: {},
     },
     dependenciesAutoImported: false,
+    gaslessOwnerUpdateTaskId: undefined,
     avatar: {
       type: 'emoji',
       emoji: '💧',


### PR DESCRIPTION
Currently, if the gasless owner update in the project claim flow fails to kick off (e.g. Gelato Relay down) or the task fails to conclude (e.g. we ran out of balance to sponsor gas with), the user is just left sitting on the "Waiting for verification to finalize..." screen while the app polls the API in anticipation of the owner updating. Which of course will never happen in those cases. This adds explicit checks for a successful gasless owner update call, and checks the task state on Gelato for failures. In both cases, the user will see "friendly" errors asking for them to either try again or reach out to us on Discord.