### PR TITLE
fix: #1276

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -47,6 +47,3 @@ PUBLIC_BASE_URL=string
 # URL of the Drips Multiplayer API deployment to use. Set to the defaults below to use public Sepolia deployment.
 MULTIPLAYER_API_URL=string # Default for sepolia https://multiplayer-sepolia.up.railway.app
 MULTIPLAYER_API_ACCESS_TOKEN=string # Default for sepolia 992b2122-9a09-4a97-b2cc-2292d3dd23aa
-
-# Optional, defaults to `false`. Setting this to `true` will redirect any requests from `/` to `/app` and any '/legal/**/*' requests to 'drips.network/legal/**/*'.
-PUBLIC_ALTERNATIVE_CHAIN_MODE=boolean

--- a/src/lib/stores/wallet/__test__/wallet.store.ts
+++ b/src/lib/stores/wallet/__test__/wallet.store.ts
@@ -36,6 +36,7 @@ const NETWORK = {
     nextSettlementDate: nextMainnetSettlementDate,
     explainerText: '',
   },
+  alternativeChainMode: false,
 };
 
 const provider = new JsonRpcProvider('http://127.0.0.1:8545', NETWORK, {

--- a/src/lib/stores/wallet/network.ts
+++ b/src/lib/stores/wallet/network.ts
@@ -51,6 +51,11 @@ export type Network = {
     NFT_DRIVER: string;
     NATIVE_TOKEN_UNWRAPPER: string | undefined;
   };
+  /**
+   * If enabled, LP, blog, and legal routes are redirected to https://drips.network/<path>.
+   * This will be obsolete once the app goes fully multi-chain, without separate deployments per network.
+   */
+  alternativeChainMode: boolean;
 };
 
 export type ValueForEachSupportedChain<T> = Record<(typeof SUPPORTED_CHAIN_IDS)[number], T>;
@@ -94,6 +99,7 @@ export const NETWORK_CONFIG: ValueForEachSupportedChain<Network> = {
       explainerText:
         'Funds from projects, streams and Drip Lists settle and become collectable on the last Thursday of each month.',
     },
+    alternativeChainMode: false,
   },
   [80002]: {
     chainId: 80002,
@@ -128,6 +134,7 @@ export const NETWORK_CONFIG: ValueForEachSupportedChain<Network> = {
       explainerText:
         'Funds from projects, streams and Drip Lists settle and become collectable on the last Thursday of each month.',
     },
+    alternativeChainMode: true,
   },
   [11155420]: {
     chainId: 11155420,
@@ -162,6 +169,7 @@ export const NETWORK_CONFIG: ValueForEachSupportedChain<Network> = {
       explainerText:
         'Funds from projects, streams and Drip Lists settle and become collectable on the last Thursday of each month.',
     },
+    alternativeChainMode: true,
   },
   [11155111]: {
     chainId: 11155111,
@@ -196,6 +204,7 @@ export const NETWORK_CONFIG: ValueForEachSupportedChain<Network> = {
       explainerText:
         'Funds from projects, streams and Drip Lists settle and become collectable on the last Thursday of each month.',
     },
+    alternativeChainMode: false,
   },
   [84532]: {
     chainId: 84532,
@@ -230,6 +239,7 @@ export const NETWORK_CONFIG: ValueForEachSupportedChain<Network> = {
       explainerText:
         'Funds from projects, streams and Drip Lists settle and become collectable on the last Thursday of each month.',
     },
+    alternativeChainMode: true,
   },
   [314]: {
     chainId: 314,
@@ -263,6 +273,7 @@ export const NETWORK_CONFIG: ValueForEachSupportedChain<Network> = {
       explainerText:
         'Funds from projects, streams and Drip Lists settle and become collectable daily.',
     },
+    alternativeChainMode: true,
   },
 };
 

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -18,13 +18,10 @@ const FEATURED_DRIP_LISTS =
       '30178668158349445547603108732480118476541651095408979232800331391215',
     ],
   }[PUBLIC_NETWORK] ?? [];
-import getOptionalEnvVar from '$lib/utils/get-optional-env-var/public';
 import network from '$lib/stores/wallet/network';
 
 export const load = (async ({ fetch, request }) => {
   const isIframe = request.headers.get('Sec-Fetch-Dest') === 'iframe';
-
-  const isAlternativeChain = getOptionalEnvVar('PUBLIC_ALTERNATIVE_CHAIN_MODE');
 
   if (isIframe) {
     // Only valid use for iFrame is running the app as a Safe App within the Safe UI.
@@ -35,7 +32,7 @@ export const load = (async ({ fetch, request }) => {
   }
 
   // TODO: Remove when we go full multi-chain.
-  if (isAlternativeChain) {
+  if (network.alternativeChainMode) {
     return redirect(308, '/app');
   }
 

--- a/src/routes/blog/+page.server.ts
+++ b/src/routes/blog/+page.server.ts
@@ -1,7 +1,14 @@
+import network from '$lib/stores/wallet/network';
 import assert from '$lib/utils/assert';
+import { redirect } from '@sveltejs/kit';
 import { metadataSchema } from '../api/blog/posts/schema';
 
-export const load = async () => {
+export const load = async ({ route }) => {
+  if (network.alternativeChainMode) {
+    // Serve from the `mainnet` instance
+    return redirect(308, `https://drips.network${route.id}`);
+  }
+
   const posts = await Promise.all(
     Object.entries(import.meta.glob('/src/blog-posts/*.md')).map(async ([path, resolver]) => {
       const resolved = await resolver();

--- a/src/routes/blog/posts/[slug]/+page.ts
+++ b/src/routes/blog/posts/[slug]/+page.ts
@@ -1,6 +1,12 @@
-import { error } from '@sveltejs/kit';
+import network from '$lib/stores/wallet/network';
+import { error, redirect } from '@sveltejs/kit';
 
-export const load = async ({ params }) => {
+export const load = async ({ url, params }) => {
+  if (network.alternativeChainMode) {
+    // Serve from the `mainnet` instance
+    return redirect(308, `https://drips.network${url.pathname}`);
+  }
+
   try {
     const post = await import(`../../../../blog-posts/${params.slug}.md`);
 

--- a/src/routes/legal/+layout.ts
+++ b/src/routes/legal/+layout.ts
@@ -1,12 +1,11 @@
 import { redirect } from '@sveltejs/kit';
-import getOptionalEnvVar from '$lib/utils/get-optional-env-var/public';
+import network from '$lib/stores/wallet/network.js';
 
 export const prerender = true;
 
 export async function load({ route }) {
   // TODO: Remove when we go full multi-chain.
-  const isAlternativeChain = getOptionalEnvVar('PUBLIC_ALTERNATIVE_CHAIN_MODE');
-  if (isAlternativeChain) {
+  if (network.alternativeChainMode) {
     // Serve from the `mainnet` instance
     return redirect(308, `https://drips.network${route.id}`);
   }


### PR DESCRIPTION
While we have one deployment per chain, we don't want to create duplicates of the LP, privacy pages, and blog (incl posts). They should be exclusively served by the main deployment. This was already implemented, but not yet for blog routes.

- Move `alternativeChainMode` config from env to static network config
- Make it so that when someone tries to access blog posts on a deployment in `alternativeChainMode`, the request gets rewritten to the main (`https://drips.network`) deployment

Resolves #1276