### PR TITLE
fix: #1276

### DIFF
--- a/src/lib/components/icons/Check.svelte
+++ b/src/lib/components/icons/Check.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
+  import type { ComponentProps } from 'svelte';
   import IconWrapper from './IconWrapper.svelte';
 
-  export let style: string | undefined = undefined;
+  export let iconWrapperProps: ComponentProps<IconWrapper>;
 </script>
 
-<IconWrapper on:click {style}>
+<IconWrapper on:click {...iconWrapperProps}>
   <path
     fill-rule="evenodd"
     clip-rule="evenodd"

--- a/src/lib/components/icons/IconWrapper.svelte
+++ b/src/lib/components/icons/IconWrapper.svelte
@@ -1,15 +1,16 @@
 <script lang="ts">
   export let style: string | undefined = undefined;
+  export let fill: string | undefined = undefined;
 </script>
 
 <!-- svelte-ignore a11y-no-static-element-interactions -->
 <svg
   on:click
   on:keydown
-  style={`flex-shrink: 0; ${style ? style : ''}`}
   width="24"
   height="24"
-  fill="var(--color-foreground-level-5)"
+  fill={fill ?? 'var(--color-foreground-level-5)'}
+  style={`flex-shrink: 0; ${style ? style : ''}`}
   viewBox={`0 0 24 24`}
   xmlns="http://www.w3.org/2000/svg"
 >

--- a/src/lib/components/list-editor/components/list-editor-pie.svelte
+++ b/src/lib/components/list-editor/components/list-editor-pie.svelte
@@ -61,7 +61,7 @@
         in:scale={{ duration: 300, start: 1.5 }}
         out:scale={{ duration: 300, start: 0.8 }}
       >
-        <Check style="fill: var(--color-background);" />
+        <Check iconWrapperProps={{ fill: 'var(--color-background);' }} />
       </div>
     {/if}
   </div>

--- a/src/lib/components/network-picker/components/network-list.svelte
+++ b/src/lib/components/network-picker/components/network-list.svelte
@@ -45,7 +45,7 @@
       </div>
       <span class="network-label">{label}</span>
       {#if chainId === selectedChainId}
-        <Check />
+        <Check iconWrapperProps={{ fill: 'var(--color-foreground)' }} />
       {/if}
     </a>
   {/each}
@@ -66,7 +66,7 @@
     justify-content: center;
     align-items: center;
     position: relative;
-    border: 2px solid transparent;
+    border: 1px solid transparent;
   }
 
   .network-icon.selected {
@@ -78,6 +78,7 @@
     white-space: nowrap;
     text-align: left;
     overflow: hidden;
+    color: var(--color-foreground);
     text-overflow: ellipsis;
   }
 


### PR DESCRIPTION
Minor visual tweaks for network picker.

- Fixes unstyled text color for network picker in mobile account bottom sheet
- Fixes width of border outline for currently selected network
- Fixes color of checkmark icon

Resolves #1276