### PR TITLE
fix: #1233

### DIFF
--- a/src/lib/components/input-address/input-stream-receiver.svelte
+++ b/src/lib/components/input-address/input-stream-receiver.svelte
@@ -7,6 +7,7 @@
   import { BASE_URL } from '$lib/utils/base-url';
   import assert from '$lib/utils/assert';
   import { extractDriverNameFromAccountId } from '$lib/utils/sdk/utils/extract-driver-from-accountId';
+  import network from '$lib/stores/wallet/network';
 
   export let value: string | undefined = undefined;
   export let validatedValue: string | undefined = undefined;
@@ -60,7 +61,7 @@
           message: 'Unable to resolve Drip List URL',
         };
       }
-    } else if (input.endsWith('.eth')) {
+    } else if (network.ensSupported && input.endsWith('.eth')) {
       // lookup ENS
       inputValidationState = {
         type: 'pending',
@@ -107,7 +108,7 @@
       validatedValue = undefined;
       inputValidationState = {
         type: 'invalid',
-        message: 'Enter a valid Ethereum address, ENS name, or Drip List URL.',
+        message: `Enter a valid Ethereum address${network.ensSupported ? ', ENS name,' : ''} or Drip List URL.`,
       };
     }
   }
@@ -128,5 +129,5 @@
   showSuccessCheck
   validationState={inputValidationState}
   bind:value
-  placeholder="Ethereum address, ENS name, or Drip List URL"
+  placeholder="Ethereum address{network.ensSupported ? ', ENS name,' : ''} or Drip List URL"
 />

--- a/src/lib/components/list-editor/components/list-editor-input.svelte
+++ b/src/lib/components/list-editor/components/list-editor-input.svelte
@@ -17,6 +17,7 @@
   import { AddItemError } from '../errors';
   import { classifyRecipient } from '$lib/components/list-editor/classifiers';
   import { isAddress } from 'ethers';
+  import network from '$lib/stores/wallet/network';
 
   const dispatch = createEventDispatcher<{
     addAddress: { accountId: string; address: string };
@@ -50,7 +51,8 @@
 
   $: validInput =
     (allowProjects && (isSupportedGitUrl(inputValue) || isDripsProjectUrl(inputValue))) ||
-    (allowAddresses && (inputValue.endsWith('.eth') || isAddress(inputValue))) ||
+    (allowAddresses &&
+      ((network.ensSupported && inputValue.endsWith('.eth')) || isAddress(inputValue))) ||
     (allowDripLists && inputValue.includes(`${BASE_URL}/app/drip-lists/`));
 
   function createInvalidMessage(type: string, value: string): string {

--- a/src/lib/components/list-editor/validators.ts
+++ b/src/lib/components/list-editor/validators.ts
@@ -1,5 +1,6 @@
 import { isAddress } from 'ethers';
 import ensStore from '../../stores/ens/ens.store';
+import network from '$lib/stores/wallet/network';
 
 export const reformatUrl = (url: string): string => {
   if (!url.startsWith('http://') && !url.startsWith('https://')) {
@@ -37,6 +38,10 @@ export const validateAddress = async (
 ): Promise<boolean | string | undefined> => {
   if (isAddress(addressValue)) {
     return true;
+  }
+
+  if (!network.ensSupported) {
+    return false;
   }
 
   try {

--- a/src/lib/components/search-bar/search.ts
+++ b/src/lib/components/search-bar/search.ts
@@ -6,6 +6,7 @@ import { get } from 'svelte/store';
 import { isValidGitUrl } from '$lib/utils/is-valid-git-url';
 import GitProjectService from '$lib/utils/project/GitProjectService';
 import { isAddress } from 'ethers';
+import network from '$lib/stores/wallet/network';
 
 export enum SearchItemType {
   PROFILE,
@@ -93,6 +94,7 @@ export default function search(input: string | undefined) {
 
   if (
     input?.endsWith('.eth') &&
+    network.ensSupported &&
     searchItems.findIndex((i) => i.type === SearchItemType.PROFILE && i.item.name === input) === -1
   ) {
     searchItems.push({

--- a/src/lib/flows/create-drip-list-flow/steps/configure-voting-round/configure-voting-round.svelte
+++ b/src/lib/flows/create-drip-list-flow/steps/configure-voting-round/configure-voting-round.svelte
@@ -16,6 +16,8 @@
   import type { ListEditorItem, AccountId } from '$lib/components/list-editor/types';
   import { AddItemError } from '$lib/components/list-editor/errors';
   import { slide } from 'svelte/transition';
+  import mapFilterUndefined from '$lib/utils/map-filter-undefined';
+  import network from '$lib/stores/wallet/network';
 
   const dispatch = createEventDispatcher<StepComponentEvents>();
 
@@ -40,11 +42,14 @@
         allowDripLists: false,
         csvMaxEntries: 5000,
         csvHeaders: ['collaborator'],
-        exampleTableData: [
-          ['0xa404a9258A2240d6f2FDa871a7Fbd71bb6523570'],
-          ['0x38493bA0F8a15D81985bF5438bc6f90C6C5418C1'],
-          ['vitalik.eth'],
-        ],
+        exampleTableData: mapFilterUndefined(
+          [
+            ['0xa404a9258A2240d6f2FDa871a7Fbd71bb6523570'],
+            ['0x38493bA0F8a15D81985bF5438bc6f90C6C5418C1'],
+            network.ensSupported ? ['vitalik.eth'] : undefined,
+          ],
+          (v) => v,
+        ),
         exampleTableCaption:
           'Importing a new CSV will overwrite any previously configured recipients.',
         addItem(key: AccountId, item: ListEditorItem) {

--- a/src/lib/stores/ens/ens.store.ts
+++ b/src/lib/stores/ens/ens.store.ts
@@ -1,6 +1,7 @@
 import { get, writable } from 'svelte/store';
 import assert from '$lib/utils/assert';
 import type { AbstractProvider } from 'ethers';
+import network from '../wallet/network';
 
 export interface ResolvedRecord {
   name?: string;
@@ -33,6 +34,8 @@ export default (() => {
    * @param address The address to attempt resolving.
    */
   async function lookup(address: string): Promise<ResolvedRecord | undefined> {
+    if (!network.ensSupported) return;
+
     const saved = get(state)[address];
     if (saved) return;
 
@@ -74,6 +77,8 @@ export default (() => {
    * name in the store state.
    */
   async function reverseLookup(name: string): Promise<string | undefined> {
+    if (!network.ensSupported) return;
+
     assert(
       provider,
       'You need to `connect` the store to a provider before being able to reverse lookup',

--- a/src/lib/stores/wallet/__test__/wallet.store.ts
+++ b/src/lib/stores/wallet/__test__/wallet.store.ts
@@ -37,6 +37,7 @@ const NETWORK = {
     explainerText: '',
   },
   alternativeChainMode: false,
+  ensSupported: false,
 };
 
 const provider = new JsonRpcProvider('http://127.0.0.1:8545', NETWORK, {

--- a/src/lib/stores/wallet/network.ts
+++ b/src/lib/stores/wallet/network.ts
@@ -56,6 +56,7 @@ export type Network = {
    * This will be obsolete once the app goes fully multi-chain, without separate deployments per network.
    */
   alternativeChainMode: boolean;
+  ensSupported: boolean;
 };
 
 export type ValueForEachSupportedChain<T> = Record<(typeof SUPPORTED_CHAIN_IDS)[number], T>;
@@ -100,6 +101,7 @@ export const NETWORK_CONFIG: ValueForEachSupportedChain<Network> = {
         'Funds from projects, streams and Drip Lists settle and become collectable on the last Thursday of each month.',
     },
     alternativeChainMode: false,
+    ensSupported: true,
   },
   [80002]: {
     chainId: 80002,
@@ -135,6 +137,7 @@ export const NETWORK_CONFIG: ValueForEachSupportedChain<Network> = {
         'Funds from projects, streams and Drip Lists settle and become collectable on the last Thursday of each month.',
     },
     alternativeChainMode: true,
+    ensSupported: false,
   },
   [11155420]: {
     chainId: 11155420,
@@ -170,6 +173,7 @@ export const NETWORK_CONFIG: ValueForEachSupportedChain<Network> = {
         'Funds from projects, streams and Drip Lists settle and become collectable on the last Thursday of each month.',
     },
     alternativeChainMode: true,
+    ensSupported: false,
   },
   [11155111]: {
     chainId: 11155111,
@@ -205,6 +209,7 @@ export const NETWORK_CONFIG: ValueForEachSupportedChain<Network> = {
         'Funds from projects, streams and Drip Lists settle and become collectable on the last Thursday of each month.',
     },
     alternativeChainMode: false,
+    ensSupported: true,
   },
   [84532]: {
     chainId: 84532,
@@ -240,6 +245,7 @@ export const NETWORK_CONFIG: ValueForEachSupportedChain<Network> = {
         'Funds from projects, streams and Drip Lists settle and become collectable on the last Thursday of each month.',
     },
     alternativeChainMode: true,
+    ensSupported: false,
   },
   [314]: {
     chainId: 314,
@@ -274,6 +280,7 @@ export const NETWORK_CONFIG: ValueForEachSupportedChain<Network> = {
         'Funds from projects, streams and Drip Lists settle and become collectable daily.',
     },
     alternativeChainMode: true,
+    ensSupported: false,
   },
 };
 

--- a/src/routes/app/(app)/[accountId]/+page.server.ts
+++ b/src/routes/app/(app)/[accountId]/+page.server.ts
@@ -83,7 +83,7 @@ export const load = async ({ params, fetch }) => {
 
   if (isAddress(universalAccountId)) {
     address = universalAccountId;
-  } else if ((universalAccountId as string).endsWith('.eth')) {
+  } else if ((universalAccountId as string).endsWith('.eth') && network.ensSupported) {
     const lookupRes = await provider.resolveName(universalAccountId);
 
     if (!lookupRes) {
@@ -100,12 +100,10 @@ export const load = async ({ params, fetch }) => {
         break;
       }
       case 'nft': {
-        redirect(301, `/app/drip-lists/${universalAccountId}`);
-        break;
+        return redirect(301, `/app/drip-lists/${universalAccountId}`);
       }
       case 'repo': {
         return { error: true, type: 'is-repo-driver-account-id' as const };
-        break;
       }
       default: {
         error(404, 'Not Found');


### PR DESCRIPTION
Adds new `ensSupported` value to static network config. If `false`, hides prompts to enter ens names in various places (stream creation modal, csv import) and stops treating `.eth` strings in address inputs as valid, and also stops trying to lookup ens names generally. Ensures attempts to load a profile by ens name results in a 404, and also removes `.eth` search results in search. Any attempts to `resolve` or `reverseLookup` an ens name from `ens.store` will result in `undefined`, and no longer throw an "ens not supported" error from Ethers.

Resolves #1233