### PR TITLE
fix: #1252

### DIFF
--- a/robots-filecoin.txt
+++ b/robots-filecoin.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Disallow: /
+Allow: /app/drip-lists/*


### PR DESCRIPTION
Adds new special robots.txt file for `filecoin.drips.network` deployment. It blocks indexing of everything except for everything under the `app/drip-lists` route. Once merged, the deploy script for `filecoin` app needs to be updated on Railway to copy this new robots.txt file to `/static/robots.txt`.

Resolves #1252