### PR TITLE
1295 add a warning not to send funds to exchange managed addresses

### DIFF
--- a/src/lib/components/annotation-box/annotation-box.svelte
+++ b/src/lib/components/annotation-box/annotation-box.svelte
@@ -25,7 +25,7 @@
     </div>
   </div>
   {#if $$slots.actions}
-    <div class="flex-1 flex justify-end">
+    <div class="flex-1 gap-1 flex justify-end">
       <slot name="actions" />
     </div>
   {/if}

--- a/src/lib/components/annotation-box/custodial-warning.svelte
+++ b/src/lib/components/annotation-box/custodial-warning.svelte
@@ -8,15 +8,11 @@
 
   export let dismissableId: string = 'custodial';
 
-  let dismissed = browser ? dismissablesStore.isDismissed(dismissableId) : false;
+  $: dismissed = browser ? $dismissablesStore.includes(dismissableId) : false;
 
   async function handleDismiss() {
     dismissablesStore.dismiss(dismissableId);
   }
-
-  dismissablesStore.subscribe(() => {
-    dismissed = dismissablesStore.isDismissed(dismissableId);
-  });
 </script>
 
 {#if !dismissed}

--- a/src/lib/components/annotation-box/custodial-warning.svelte
+++ b/src/lib/components/annotation-box/custodial-warning.svelte
@@ -22,7 +22,7 @@
 {#if !dismissed}
   <div transition:fly={{ y: 8 }}>
     <AnnotationBox type="error">
-      <span class="typo-text"
+      <span class="warning-text typo-text"
         >Please ensure all addresses are self-custodial. Any funds sent to exchange-managed
         addresses (e.g. Coinbase or Binance) <strong class="typo-text-bold">will be lost</strong
         ></span
@@ -37,8 +37,9 @@
 {/if}
 
 <style>
-  strong {
-    /* TODO? */
-    /* color: var(--color-negative); */
+  /* re-align with icon because of larger font size */
+  .warning-text {
+    position: relative;
+    top: -3px;
   }
 </style>

--- a/src/lib/components/annotation-box/custodial-warning.svelte
+++ b/src/lib/components/annotation-box/custodial-warning.svelte
@@ -6,7 +6,7 @@
   import { browser } from '$app/environment';
   import { slide } from 'svelte/transition';
 
-  export let dismissableId: string = 'custodial';
+  export let dismissableId: string;
 
   $: dismissed = browser ? $dismissablesStore.includes(dismissableId) : false;
 

--- a/src/lib/components/annotation-box/custodial-warning.svelte
+++ b/src/lib/components/annotation-box/custodial-warning.svelte
@@ -2,26 +2,43 @@
   import AnnotationBox from './annotation-box.svelte';
   import ThumbsUpIcon from '$lib/components/icons/ThumbsUp.svelte';
   import Button from '../button/button.svelte';
+  import dismissablesStore from '$lib/stores/dismissables/dismissables.store';
+  import { browser } from '$app/environment';
+  import { fly } from 'svelte/transition';
 
-  function handleUnderstanding() {
-    // eslint-disable-next-line no-console
-    console.log('I understand');
+  export let dismissableId: string = 'custodial';
+
+  let dismissed = browser ? dismissablesStore.isDismissed(dismissableId) : false;
+
+  async function handleDismiss() {
+    dismissablesStore.dismiss(dismissableId);
   }
+
+  dismissablesStore.subscribe(() => {
+    dismissed = dismissablesStore.isDismissed(dismissableId);
+  });
 </script>
 
-<AnnotationBox type="error">
-  <span class="typo-text"
-    >Please ensure all addresses are self-custodial. Any funds sent to exchange-managed addresses
-    (e.g. Coinbase or Binance) <strong class="typo-text-bold">will be lost</strong></span
-  >.
-  <svelte:fragment slot="actions">
-    <Button icon={ThumbsUpIcon} variant="destructive" on:click={handleUnderstanding}
-      >I understand</Button
-    >
-  </svelte:fragment>
-</AnnotationBox>
+{#if !dismissed}
+  <div transition:fly={{ y: 8 }}>
+    <AnnotationBox type="error">
+      <span class="typo-text"
+        >Please ensure all addresses are self-custodial. Any funds sent to exchange-managed
+        addresses (e.g. Coinbase or Binance) <strong class="typo-text-bold">will be lost</strong
+        ></span
+      >.
+      <svelte:fragment slot="actions">
+        <Button icon={ThumbsUpIcon} variant="destructive" on:click={handleDismiss}
+          >I understand</Button
+        >
+      </svelte:fragment>
+    </AnnotationBox>
+  </div>
+{/if}
 
 <style>
   strong {
+    /* TODO? */
+    /* color: var(--color-negative); */
   }
 </style>

--- a/src/lib/components/annotation-box/custodial-warning.svelte
+++ b/src/lib/components/annotation-box/custodial-warning.svelte
@@ -24,9 +24,9 @@
     <AnnotationBox type="error">
       <span class="warning-text typo-text"
         >Please ensure all addresses are self-custodial. Any funds sent to exchange-managed
-        addresses (e.g. Coinbase or Binance) <strong class="typo-text-bold">will be lost</strong
+        addresses (e.g. Coinbase or Binance) <strong class="typo-text-bold">will be lost.</strong
         ></span
-      >.
+      >
       <svelte:fragment slot="actions">
         <Button icon={ThumbsUpIcon} variant="destructive" on:click={handleDismiss}
           >I understand</Button

--- a/src/lib/components/annotation-box/custodial-warning.svelte
+++ b/src/lib/components/annotation-box/custodial-warning.svelte
@@ -16,11 +16,15 @@
   <div transition:slide={{ duration: 300 }}>
     <AnnotationBox type="error">
       <span class="warning-text typo-text"
-        >Please ensure all addresses are self-custodial. Any funds sent to exchange-managed
-        addresses (e.g. Coinbase or Binance) <strong class="typo-text-bold">will be lost.</strong
-        ></span
+        >Please ensure you only split funds to self-custodial ETH addresses. Funds sent to
+        custodial, exchange-managed addresses (e.g. Coinbase or Binance) will be lost.</span
       >
       <svelte:fragment slot="actions">
+        <Button
+          variant="ghost"
+          href="https://docs.drips.network/faq/#can-i-split-or-stream-funds-directly-to-exchange-managed-ethereum-addresses"
+          target="_blank">Learn more</Button
+        >
         <Button icon={ThumbsUpIcon} variant="destructive" on:click={handleDismiss}
           >I understand</Button
         >

--- a/src/lib/components/annotation-box/custodial-warning.svelte
+++ b/src/lib/components/annotation-box/custodial-warning.svelte
@@ -16,8 +16,8 @@
   <div transition:slide={{ duration: 300 }}>
     <AnnotationBox type="error">
       <span class="warning-text typo-text"
-        >Please ensure you only split funds to self-custodial ETH addresses. Funds sent to
-        custodial, exchange-managed addresses (e.g. Coinbase or Binance) will be lost.</span
+        >Please ensure you only split funds to self-custodial ETH addresses. Funds sent directly to
+        exchange-managed addresses (e.g. Coinbase) may be lost.</span
       >
       <svelte:fragment slot="actions">
         <Button

--- a/src/lib/components/annotation-box/custodial-warning.svelte
+++ b/src/lib/components/annotation-box/custodial-warning.svelte
@@ -4,7 +4,7 @@
   import Button from '../button/button.svelte';
   import dismissablesStore from '$lib/stores/dismissables/dismissables.store';
   import { browser } from '$app/environment';
-  import { fly } from 'svelte/transition';
+  import { slide } from 'svelte/transition';
 
   export let dismissableId: string = 'custodial';
 
@@ -20,7 +20,7 @@
 </script>
 
 {#if !dismissed}
-  <div transition:fly={{ y: 8 }}>
+  <div transition:slide={{ duration: 300 }}>
     <AnnotationBox type="error">
       <span class="warning-text typo-text"
         >Please ensure all addresses are self-custodial. Any funds sent to exchange-managed

--- a/src/lib/components/annotation-box/custodial-warning.svelte
+++ b/src/lib/components/annotation-box/custodial-warning.svelte
@@ -7,14 +7,12 @@
 
   export let dismissableId: string;
 
-  $: dismissed = $dismissablesStore.includes(dismissableId);
-
   async function handleDismiss() {
     dismissablesStore.dismiss(dismissableId);
   }
 </script>
 
-{#if !dismissed}
+{#if !$dismissablesStore.includes(dismissableId)}
   <div transition:slide={{ duration: 300 }}>
     <AnnotationBox type="error">
       <span class="warning-text typo-text"

--- a/src/lib/components/annotation-box/custodial-warning.svelte
+++ b/src/lib/components/annotation-box/custodial-warning.svelte
@@ -3,12 +3,11 @@
   import ThumbsUpIcon from '$lib/components/icons/ThumbsUp.svelte';
   import Button from '../button/button.svelte';
   import dismissablesStore from '$lib/stores/dismissables/dismissables.store';
-  import { browser } from '$app/environment';
   import { slide } from 'svelte/transition';
 
   export let dismissableId: string;
 
-  $: dismissed = browser ? $dismissablesStore.includes(dismissableId) : false;
+  $: dismissed = $dismissablesStore.includes(dismissableId);
 
   async function handleDismiss() {
     dismissablesStore.dismiss(dismissableId);

--- a/src/lib/components/annotation-box/custodial-warning.svelte
+++ b/src/lib/components/annotation-box/custodial-warning.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import AnnotationBox from './annotation-box.svelte';
+  import ThumbsUpIcon from '$lib/components/icons/ThumbsUp.svelte';
+  import Button from '../button/button.svelte';
+
+  function handleUnderstanding() {
+    // eslint-disable-next-line no-console
+    console.log('I understand');
+  }
+</script>
+
+<AnnotationBox type="error">
+  <span class="typo-text"
+    >Please ensure all addresses are self-custodial. Any funds sent to exchange-managed addresses
+    (e.g. Coinbase or Binance) <strong class="typo-text-bold">will be lost</strong></span
+  >.
+  <svelte:fragment slot="actions">
+    <Button icon={ThumbsUpIcon} variant="destructive" on:click={handleUnderstanding}
+      >I understand</Button
+    >
+  </svelte:fragment>
+</AnnotationBox>
+
+<style>
+  strong {
+  }
+</style>

--- a/src/lib/components/drip-list-editor/drip-list-editor.svelte
+++ b/src/lib/components/drip-list-editor/drip-list-editor.svelte
@@ -53,7 +53,7 @@
     <TextArea bind:value={description} resizable={true} validationState={textAreaValidationState} />
   </FormField>
 
-  <CustodialWarning dismissableId="custodial-drip-list" />
+  <CustodialWarning dismissableId="custodial-warning-drip-list" />
   <FormField title="Recipients*">
     <ListEditor
       bind:weights

--- a/src/lib/components/drip-list-editor/drip-list-editor.svelte
+++ b/src/lib/components/drip-list-editor/drip-list-editor.svelte
@@ -16,6 +16,7 @@
   import TextArea from '../text-area/text-area.svelte';
   import type { TextInputValidationState } from '$lib/components/text-input/text-input';
   import type { AddItemError } from '../list-editor/errors';
+  import CustodialWarning from '../annotation-box/custodial-warning.svelte';
 
   export let name: string;
   export let description: string | undefined;
@@ -52,6 +53,7 @@
     <TextArea bind:value={description} resizable={true} validationState={textAreaValidationState} />
   </FormField>
 
+  <CustodialWarning dismissableId="custodial-drip-list" />
   <FormField title="Recipients*">
     <ListEditor
       bind:weights

--- a/src/lib/flows/claim-project-flow/steps/configure-dependencies/configure-dependencies.svelte
+++ b/src/lib/flows/claim-project-flow/steps/configure-dependencies/configure-dependencies.svelte
@@ -38,7 +38,7 @@
       : ''
     : ''} In total, you can add up to 200 maintainers and dependencies, and change this list later anytime."
 >
-  <CustodialWarning dismissableId="custodial-claim-project" />
+  <CustodialWarning dismissableId="custodial-warning-claim-project" />
   <!-- TODO: Prevent splitting to the same project we're trying to claim. -->
   <ListEditor
     bind:weights={$context.dependencySplits.weights}

--- a/src/lib/flows/claim-project-flow/steps/configure-dependencies/configure-dependencies.svelte
+++ b/src/lib/flows/claim-project-flow/steps/configure-dependencies/configure-dependencies.svelte
@@ -9,6 +9,7 @@
   import type { State } from '../../claim-project-flow';
   import ListEditor from '$lib/components/list-editor/list-editor.svelte';
   import mapFilterUndefined from '$lib/utils/map-filter-undefined';
+  import CustodialWarning from '$lib/components/annotation-box/custodial-warning.svelte';
 
   const dispatch = createEventDispatcher<StepComponentEvents>();
 
@@ -37,6 +38,7 @@
       : ''
     : ''} In total, you can add up to 200 maintainers and dependencies, and change this list later anytime."
 >
+  <CustodialWarning dismissableId="custodial-claim-project" />
   <!-- TODO: Prevent splitting to the same project we're trying to claim. -->
   <ListEditor
     bind:weights={$context.dependencySplits.weights}

--- a/src/lib/flows/claim-project-flow/steps/configure-maintainers/configure-maintainers.svelte
+++ b/src/lib/flows/claim-project-flow/steps/configure-maintainers/configure-maintainers.svelte
@@ -25,7 +25,7 @@
     'maintainers'
   ]}% split to your project’s maintainers. In total, you can add up to 200 maintainers and dependencies, and change this list later anytime."
 >
-  <CustodialWarning dismissableId="custodial-claim-project" />
+  <CustodialWarning dismissableId="custodial-warning-claim-project" />
   <ListEditor
     bind:weights={$context.maintainerSplits.weights}
     bind:items={$context.maintainerSplits.items}

--- a/src/lib/flows/claim-project-flow/steps/configure-maintainers/configure-maintainers.svelte
+++ b/src/lib/flows/claim-project-flow/steps/configure-maintainers/configure-maintainers.svelte
@@ -8,6 +8,7 @@
   import type { Writable } from 'svelte/store';
   import type { State } from '../../claim-project-flow';
   import ListEditor from '$lib/components/list-editor/list-editor.svelte';
+  import CustodialWarning from '$lib/components/annotation-box/custodial-warning.svelte';
 
   const dispatch = createEventDispatcher<StepComponentEvents>();
 
@@ -24,6 +25,7 @@
     'maintainers'
   ]}% split to your project’s maintainers. In total, you can add up to 200 maintainers and dependencies, and change this list later anytime."
 >
+  <CustodialWarning dismissableId="custodial-claim-project" />
   <ListEditor
     bind:weights={$context.maintainerSplits.weights}
     bind:items={$context.maintainerSplits.items}

--- a/src/lib/flows/create-drip-list-flow/steps/build-list/build-list.svelte
+++ b/src/lib/flows/create-drip-list-flow/steps/build-list/build-list.svelte
@@ -72,7 +72,7 @@
   headline="Create a Drip List"
   description="What projects, individuals, organizations, or other Drip Lists would you like to support with your Drip List?"
 >
-  <CustodialWarning dismissableId="custodial-drip-list" />
+  <CustodialWarning dismissableId="custodial-warning-drip-list" />
   <FormField title="Recipients*">
     <ListEditor
       bind:weights={$context.dripList.weights}

--- a/src/lib/flows/create-drip-list-flow/steps/build-list/build-list.svelte
+++ b/src/lib/flows/create-drip-list-flow/steps/build-list/build-list.svelte
@@ -13,6 +13,7 @@
   import ArrowDown from '$lib/components/icons/ArrowDown.svelte';
   import importFromCSVSteps from '$lib/flows/import-from-csv/import-from-csv-steps';
   import type { ListEditorItem, AccountId } from '$lib/components/list-editor/types';
+  import CustodialWarning from '$lib/components/annotation-box/custodial-warning.svelte';
 
   const WEIGHT_FACTOR = 10_000;
 
@@ -71,6 +72,7 @@
   headline="Create a Drip List"
   description="What projects, individuals, organizations, or other Drip Lists would you like to support with your Drip List?"
 >
+  <CustodialWarning></CustodialWarning>
   <FormField title="Recipients*">
     <ListEditor
       bind:weights={$context.dripList.weights}

--- a/src/lib/flows/create-drip-list-flow/steps/build-list/build-list.svelte
+++ b/src/lib/flows/create-drip-list-flow/steps/build-list/build-list.svelte
@@ -72,7 +72,7 @@
   headline="Create a Drip List"
   description="What projects, individuals, organizations, or other Drip Lists would you like to support with your Drip List?"
 >
-  <CustodialWarning></CustodialWarning>
+  <CustodialWarning dismissableId="custodial-drip-list" />
   <FormField title="Recipients*">
     <ListEditor
       bind:weights={$context.dripList.weights}

--- a/src/lib/flows/create-drip-list-flow/steps/configure-voting-round/configure-voting-round.svelte
+++ b/src/lib/flows/create-drip-list-flow/steps/configure-voting-round/configure-voting-round.svelte
@@ -93,7 +93,7 @@
   headline="Collaborative list"
   description="Configure who should be able to vote on your list's recipients."
 >
-  <CustodialWarning dismissableId="custodial-drip-list" />
+  <CustodialWarning dismissableId="custodial-warning-drip-list" />
   <FormField title="Collaborators*">
     <ListEditor
       allowProjects={false}

--- a/src/lib/flows/create-drip-list-flow/steps/configure-voting-round/configure-voting-round.svelte
+++ b/src/lib/flows/create-drip-list-flow/steps/configure-voting-round/configure-voting-round.svelte
@@ -18,7 +18,6 @@
   import { slide } from 'svelte/transition';
   import mapFilterUndefined from '$lib/utils/map-filter-undefined';
   import network from '$lib/stores/wallet/network';
-  import CustodialWarning from '$lib/components/annotation-box/custodial-warning.svelte';
 
   const dispatch = createEventDispatcher<StepComponentEvents>();
 
@@ -93,7 +92,6 @@
   headline="Collaborative list"
   description="Configure who should be able to vote on your list's recipients."
 >
-  <CustodialWarning dismissableId="custodial-warning-drip-list" />
   <FormField title="Collaborators*">
     <ListEditor
       allowProjects={false}

--- a/src/lib/flows/create-drip-list-flow/steps/configure-voting-round/configure-voting-round.svelte
+++ b/src/lib/flows/create-drip-list-flow/steps/configure-voting-round/configure-voting-round.svelte
@@ -130,7 +130,6 @@
     </svelte:fragment>
   </FormField>
 
-  <CustodialWarning dismissableId="custodial-drip-list" />
   <FormField
     title="Restrict to specific recipients"
     description="By default, any collaborator can suggest any recipient. Enable this to configure a list of ETH addresses, GitHub repos, or other Drip Lists that can be voted for."

--- a/src/lib/flows/create-drip-list-flow/steps/configure-voting-round/configure-voting-round.svelte
+++ b/src/lib/flows/create-drip-list-flow/steps/configure-voting-round/configure-voting-round.svelte
@@ -18,6 +18,7 @@
   import { slide } from 'svelte/transition';
   import mapFilterUndefined from '$lib/utils/map-filter-undefined';
   import network from '$lib/stores/wallet/network';
+  import CustodialWarning from '$lib/components/annotation-box/custodial-warning.svelte';
 
   const dispatch = createEventDispatcher<StepComponentEvents>();
 
@@ -92,6 +93,7 @@
   headline="Collaborative list"
   description="Configure who should be able to vote on your list's recipients."
 >
+  <CustodialWarning dismissableId="custodial-drip-list" />
   <FormField title="Collaborators*">
     <ListEditor
       allowProjects={false}
@@ -128,6 +130,7 @@
     </svelte:fragment>
   </FormField>
 
+  <CustodialWarning dismissableId="custodial-drip-list" />
   <FormField
     title="Restrict to specific recipients"
     description="By default, any collaborator can suggest any recipient. Enable this to configure a list of ETH addresses, GitHub repos, or other Drip Lists that can be voted for."

--- a/src/lib/flows/edit-project-splits/steps/edit-dependency-list.svelte
+++ b/src/lib/flows/edit-project-splits/steps/edit-dependency-list.svelte
@@ -9,6 +9,7 @@
   import Button from '$lib/components/button/button.svelte';
   import ListEditor from '$lib/components/list-editor/list-editor.svelte';
   import ArrowLeft from '$lib/components/icons/ArrowLeft.svelte';
+  import CustodialWarning from '$lib/components/annotation-box/custodial-warning.svelte';
 
   const dispatch = createEventDispatcher<StepComponentEvents>();
 
@@ -25,6 +26,7 @@
     description="Decide which GitHub projects, Ethereum addresses, and other Drip Lists should receive the {$context
       .highLevelPercentages['dependencies']}% you assigned to your project’s dependencies."
   />
+  <CustodialWarning dismissableId="custodial-project-splits" />
   <ListEditor
     bind:weights={$context.dependencySplits.weights}
     bind:items={$context.dependencySplits.items}

--- a/src/lib/flows/edit-project-splits/steps/edit-dependency-list.svelte
+++ b/src/lib/flows/edit-project-splits/steps/edit-dependency-list.svelte
@@ -26,7 +26,7 @@
     description="Decide which GitHub projects, Ethereum addresses, and other Drip Lists should receive the {$context
       .highLevelPercentages['dependencies']}% you assigned to your project’s dependencies."
   />
-  <CustodialWarning dismissableId="custodial-project-splits" />
+  <CustodialWarning dismissableId="custodial-warning-project-splits" />
   <ListEditor
     bind:weights={$context.dependencySplits.weights}
     bind:items={$context.dependencySplits.items}

--- a/src/lib/flows/edit-project-splits/steps/edit-maintainer-list.svelte
+++ b/src/lib/flows/edit-project-splits/steps/edit-maintainer-list.svelte
@@ -36,7 +36,7 @@
       'maintainers'
     ]}% you assigned to your project’s maintainers."
   />
-  <CustodialWarning dismissableId="custodial-project-splits" />
+  <CustodialWarning dismissableId="custodial-warning-project-splits" />
   <ListEditor
     bind:weights={$context.maintainerSplits.weights}
     bind:items={$context.maintainerSplits.items}

--- a/src/lib/flows/edit-project-splits/steps/edit-maintainer-list.svelte
+++ b/src/lib/flows/edit-project-splits/steps/edit-maintainer-list.svelte
@@ -9,6 +9,7 @@
   import Button from '$lib/components/button/button.svelte';
   import ListEditor from '$lib/components/list-editor/list-editor.svelte';
   import ArrowLeft from '$lib/components/icons/ArrowLeft.svelte';
+  import CustodialWarning from '$lib/components/annotation-box/custodial-warning.svelte';
 
   const dispatch = createEventDispatcher<StepComponentEvents>();
 
@@ -35,6 +36,7 @@
       'maintainers'
     ]}% you assigned to your project’s maintainers."
   />
+  <CustodialWarning dismissableId="custodial-project-splits" />
   <ListEditor
     bind:weights={$context.maintainerSplits.weights}
     bind:items={$context.maintainerSplits.items}

--- a/src/lib/flows/vote/vote.svelte
+++ b/src/lib/flows/vote/vote.svelte
@@ -14,6 +14,7 @@
   import type { State } from './vote-flow-steps';
   import { invalidateAll } from '$lib/stores/fetched-data-cache/invalidate';
   import type { VotingRound } from '$lib/utils/multiplayer/schemas';
+  import CustodialWarning from '$lib/components/annotation-box/custodial-warning.svelte';
 
   const dispatch = createEventDispatcher<StepComponentEvents>();
 
@@ -76,6 +77,7 @@
     description="Vote for which recipients of this Drip List should receive what percentage of funds."
   />
 
+  <CustodialWarning dismissableId="custodial-vote" />
   <FormField title="Recipients*">
     <ListEditor
       bind:valid

--- a/src/lib/flows/vote/vote.svelte
+++ b/src/lib/flows/vote/vote.svelte
@@ -77,7 +77,7 @@
     description="Vote for which recipients of this Drip List should receive what percentage of funds."
   />
 
-  <CustodialWarning dismissableId="custodial-vote" />
+  <CustodialWarning dismissableId="custodial-warning-vote" />
   <FormField title="Recipients*">
     <ListEditor
       bind:valid


### PR DESCRIPTION
This PR adds a warning for eth address entry situations telling the user to add only self-custodial addresses.
<img width="717" alt="Screenshot 2024-11-29 at 19 31 21" src="https://github.com/user-attachments/assets/c80cca8a-6e80-4814-b0d5-29ee37eab5cd">

