### PR TITLE
1102 populate maintainer dependency splits for projects from csv

### DIFF
--- a/src/lib/flows/claim-project-flow/claim-project-flow.ts
+++ b/src/lib/flows/claim-project-flow/claim-project-flow.ts
@@ -23,6 +23,7 @@ import type { Items, Weights } from '$lib/components/list-editor/types';
 import ChooseNetwork from './steps/choose-network/choose-network.svelte';
 import type { FundingJson } from '$lib/utils/github/GitHub';
 import type { TemplateHighlight } from './steps/add-ethereum-address/drips-json-template';
+import type { AddItemError } from '$lib/components/list-editor/errors';
 
 export const CLAIM_PROJECT_FLOW_PROJECT_FRAGMENT = gql`
   ${ENTER_GIT_URL_STEP_PROJECT_FRAGMENT}
@@ -74,6 +75,7 @@ export interface State {
     object: FundingJson;
     highlight: TemplateHighlight;
   };
+  recipientErrors: Array<AddItemError>;
 }
 
 export const state = () =>
@@ -104,6 +106,7 @@ export const state = () =>
       object: {},
       highlight: [null, null],
     },
+    recipientErrors: [],
   });
 
 export function slotsTemplate(state: State, stepIndex: number): Slots {

--- a/src/lib/flows/claim-project-flow/steps/configure-dependencies/configure-dependencies.svelte
+++ b/src/lib/flows/claim-project-flow/steps/configure-dependencies/configure-dependencies.svelte
@@ -14,6 +14,7 @@
   import ArrowDown from '$lib/components/icons/ArrowDown.svelte';
   import type { ListEditorItem, AccountId } from '$lib/components/list-editor/types';
   import importFromCSVSteps, {
+    DEFAULT_MAX_ENTRIES,
     WEIGHT_FACTOR,
   } from '$lib/flows/import-from-csv/import-from-csv-steps';
 
@@ -107,7 +108,7 @@
         [$context.project?.account.accountId, ...maintainerKeys],
         (v) => v,
       )}
-      maxItems={200 - maintainerKeys.length}
+      maxItems={DEFAULT_MAX_ENTRIES - maintainerKeys.length}
     />
     <svelte:fragment slot="action">
       <Button variant="ghost" icon={ArrowDown} on:click={handleImportCSV}>Import from CSV</Button>

--- a/src/lib/flows/claim-project-flow/steps/configure-dependencies/configure-dependencies.svelte
+++ b/src/lib/flows/claim-project-flow/steps/configure-dependencies/configure-dependencies.svelte
@@ -71,6 +71,15 @@
       return c;
     });
   }
+
+  function goBackward() {
+    dispatch('goForward', {
+      by: $context.highLevelPercentages['maintainers'] === 0 ? -2 : -1,
+    });
+    // dismiss any errors on this step, since they're shared
+    // with the next step
+    handleErrorDismissed();
+  }
 </script>
 
 <StandaloneFlowStepLayout
@@ -105,13 +114,7 @@
     </svelte:fragment>
   </FormField>
   <svelte:fragment slot="left-actions">
-    <Button
-      icon={ArrowLeftIcon}
-      on:click={() =>
-        dispatch('goForward', {
-          by: $context.highLevelPercentages['maintainers'] === 0 ? -2 : -1,
-        })}>Back</Button
-    >
+    <Button icon={ArrowLeftIcon} on:click={goBackward}>Back</Button>
   </svelte:fragment>
   <svelte:fragment slot="actions">
     <Button

--- a/src/lib/flows/claim-project-flow/steps/configure-maintainers/configure-maintainers.svelte
+++ b/src/lib/flows/claim-project-flow/steps/configure-maintainers/configure-maintainers.svelte
@@ -10,6 +10,7 @@
   import ListEditor from '$lib/components/list-editor/list-editor.svelte';
   import CustodialWarning from '$lib/components/annotation-box/custodial-warning.svelte';
   import importFromCSVSteps, {
+    DEFAULT_MAX_ENTRIES,
     WEIGHT_FACTOR,
   } from '$lib/flows/import-from-csv/import-from-csv-steps';
   import mapFilterUndefined from '$lib/utils/map-filter-undefined';
@@ -99,7 +100,7 @@
       bind:valid={formValid}
       bind:inputErrors={$context.recipientErrors}
       on:errorDismissed={handleErrorDismissed}
-      maxItems={200 - dependencyKeys.length}
+      maxItems={DEFAULT_MAX_ENTRIES - dependencyKeys.length}
       allowProjects={false}
       allowDripLists={false}
       blockedAccountIds={dependencyKeys}

--- a/src/lib/flows/claim-project-flow/steps/configure-maintainers/configure-maintainers.svelte
+++ b/src/lib/flows/claim-project-flow/steps/configure-maintainers/configure-maintainers.svelte
@@ -76,6 +76,13 @@
       return c;
     });
   }
+
+  function goForward() {
+    dispatch('goForward');
+    // dismiss any errors on this step, since they're shared
+    // with the next step
+    handleErrorDismissed();
+  }
 </script>
 
 <StandaloneFlowStepLayout
@@ -105,11 +112,8 @@
     <Button icon={ArrowLeftIcon} on:click={() => dispatch('goBackward')}>Back</Button>
   </svelte:fragment>
   <svelte:fragment slot="actions">
-    <Button
-      disabled={!formValid}
-      icon={ArrowRightIcon}
-      variant="primary"
-      on:click={() => dispatch('goForward')}>Continue</Button
+    <Button disabled={!formValid} icon={ArrowRightIcon} variant="primary" on:click={goForward}
+      >Continue</Button
     >
   </svelte:fragment>
 </StandaloneFlowStepLayout>

--- a/src/lib/flows/claim-project-flow/steps/configure-maintainers/configure-maintainers.svelte
+++ b/src/lib/flows/claim-project-flow/steps/configure-maintainers/configure-maintainers.svelte
@@ -9,6 +9,14 @@
   import type { State } from '../../claim-project-flow';
   import ListEditor from '$lib/components/list-editor/list-editor.svelte';
   import CustodialWarning from '$lib/components/annotation-box/custodial-warning.svelte';
+  import importFromCSVSteps, {
+    WEIGHT_FACTOR,
+  } from '$lib/flows/import-from-csv/import-from-csv-steps';
+  import mapFilterUndefined from '$lib/utils/map-filter-undefined';
+  import network from '$lib/stores/wallet/network';
+  import type { ListEditorItem, AccountId } from '$lib/components/list-editor/types';
+  import FormField from '$lib/components/form-field/form-field.svelte';
+  import ArrowDown from '$lib/components/icons/ArrowDown.svelte';
 
   const dispatch = createEventDispatcher<StepComponentEvents>();
 
@@ -17,6 +25,57 @@
   let formValid: boolean;
 
   $: dependencyKeys = Object.keys($context.dependencySplits.items);
+
+  function handleImportCSV() {
+    dispatch(
+      'sidestep',
+      importFromCSVSteps({
+        headline: 'Import maintainers from CSV',
+        description:
+          'Your CSV file should be formatted by first listing the recipient, then listing the percentage allocation. For example:',
+        exampleTableCaption:
+          'A recipient can be a wallet address or ENS name if supported by the network. Maximum 200 recipients. Any previously configured recipients will be overwritten with the CSV contents.',
+        exampleTableData: mapFilterUndefined(
+          [
+            ['0xa404a9258A2240d6f2FDa871a7Fbd71bb6523570', 20],
+            ['0x38493bA0F8a15D81985bF5438bc6f90C6C5418C1', 75],
+            network.ensSupported ? ['vitalik.eth', 5] : undefined,
+          ],
+          (v) => v,
+        ),
+        allowProjects: false,
+        allowDripLists: false,
+        addItem(key: AccountId, item: ListEditorItem, weight: number | undefined) {
+          context.update((c) => {
+            c.maintainerSplits.items = {
+              ...c.maintainerSplits.items,
+              [key]: item,
+            };
+
+            if (weight) {
+              c.maintainerSplits.weights[key] = weight * WEIGHT_FACTOR;
+            }
+
+            return c;
+          });
+        },
+        clearItems() {
+          context.update((c) => {
+            c.maintainerSplits.items = {};
+            c.maintainerSplits.weights = {};
+            return c;
+          });
+        },
+      }),
+    );
+  }
+
+  function handleErrorDismissed() {
+    context.update((c) => {
+      c.recipientErrors = [];
+      return c;
+    });
+  }
 </script>
 
 <StandaloneFlowStepLayout
@@ -26,15 +85,22 @@
   ]}% split to your project’s maintainers. In total, you can add up to 200 maintainers and dependencies, and change this list later anytime."
 >
   <CustodialWarning dismissableId="custodial-warning-claim-project" />
-  <ListEditor
-    bind:weights={$context.maintainerSplits.weights}
-    bind:items={$context.maintainerSplits.items}
-    bind:valid={formValid}
-    maxItems={200 - dependencyKeys.length}
-    allowProjects={false}
-    allowDripLists={false}
-    blockedAccountIds={dependencyKeys}
-  />
+  <FormField title="Maintainers*">
+    <ListEditor
+      bind:weights={$context.maintainerSplits.weights}
+      bind:items={$context.maintainerSplits.items}
+      bind:valid={formValid}
+      bind:inputErrors={$context.recipientErrors}
+      on:errorDismissed={handleErrorDismissed}
+      maxItems={200 - dependencyKeys.length}
+      allowProjects={false}
+      allowDripLists={false}
+      blockedAccountIds={dependencyKeys}
+    />
+    <svelte:fragment slot="action">
+      <Button variant="ghost" icon={ArrowDown} on:click={handleImportCSV}>Import from CSV</Button>
+    </svelte:fragment>
+  </FormField>
   <svelte:fragment slot="left-actions">
     <Button icon={ArrowLeftIcon} on:click={() => dispatch('goBackward')}>Back</Button>
   </svelte:fragment>

--- a/src/lib/flows/create-drip-list-flow/steps/build-list/build-list.svelte
+++ b/src/lib/flows/create-drip-list-flow/steps/build-list/build-list.svelte
@@ -11,11 +11,11 @@
   import FormField from '$lib/components/form-field/form-field.svelte';
   import ListEditor from '$lib/components/list-editor/list-editor.svelte';
   import ArrowDown from '$lib/components/icons/ArrowDown.svelte';
-  import importFromCSVSteps from '$lib/flows/import-from-csv/import-from-csv-steps';
+  import importFromCSVSteps, {
+    WEIGHT_FACTOR,
+  } from '$lib/flows/import-from-csv/import-from-csv-steps';
   import type { ListEditorItem, AccountId } from '$lib/components/list-editor/types';
   import CustodialWarning from '$lib/components/annotation-box/custodial-warning.svelte';
-
-  const WEIGHT_FACTOR = 10_000;
 
   const dispatch = createEventDispatcher<StepComponentEvents>();
 

--- a/src/lib/flows/edit-project-splits/edit-project-splits-steps.ts
+++ b/src/lib/flows/edit-project-splits/edit-project-splits-steps.ts
@@ -19,6 +19,7 @@ import {
   SPLIT_RECEIVERS_TO_LIST_EDITOR_CONFIG_DRIP_LIST_RECEIVER_FRAGMENT,
   SPLIT_RECEIVERS_TO_LIST_EDITOR_CONFIG_PROJECT_RECEIVER_FRAGMENT,
 } from '$lib/components/list-editor/utils/split-receivers-to-list-editor-config';
+import type { AddItemError } from '$lib/components/list-editor/errors';
 
 export const EDIT_PROJECT_SPLITS_FLOW_ADDRESS_RECEIVER_FRAGMENT = gql`
   ${SPLIT_RECEIVERS_TO_LIST_EDITOR_CONFIG_ADDRESS_RECEIVER_FRAGMENT}
@@ -68,6 +69,7 @@ export interface State {
   highLevelPercentages: { [key: string]: number };
   maintainerSplits: ListEditorConfig;
   dependencySplits: ListEditorConfig;
+  recipientErrors: Array<AddItemError>;
 }
 
 const state = (projectAccountId: string, representationalSplits: Splits) => {
@@ -105,6 +107,7 @@ const state = (projectAccountId: string, representationalSplits: Splits) => {
     highLevelPercentages,
     maintainerSplits,
     dependencySplits,
+    recipientErrors: [],
   });
 };
 

--- a/src/lib/flows/edit-project-splits/steps/edit-dependency-list.svelte
+++ b/src/lib/flows/edit-project-splits/steps/edit-dependency-list.svelte
@@ -64,10 +64,6 @@
     });
   }
 
-  function goForward() {
-    dispatch('goForward');
-  }
-
   function goBackward() {
     dispatch('goBackward');
     // dismiss any errors on this step, since they're shared
@@ -105,8 +101,11 @@
     <Button icon={ArrowLeft} on:click={goBackward}>Back</Button>
   </svelte:fragment>
   <svelte:fragment slot="actions">
-    <Button disabled={!formValid} icon={ArrowRight} variant="primary" on:click={goForward}
-      >Continue</Button
+    <Button
+      disabled={!formValid}
+      icon={ArrowRight}
+      variant="primary"
+      on:click={() => dispatch('goForward')}>Continue</Button
     >
   </svelte:fragment>
 </StepLayout>

--- a/src/lib/flows/edit-project-splits/steps/edit-dependency-list.svelte
+++ b/src/lib/flows/edit-project-splits/steps/edit-dependency-list.svelte
@@ -57,8 +57,6 @@
     );
   }
 
-  // TODO: shouldn't this be:
-  // $: maintainerKeys = Object.keys($context.dependencySplits.items);
   $: maintainerKeys = Object.keys($context.maintainerSplits.items);
 </script>
 

--- a/src/lib/flows/edit-project-splits/steps/edit-dependency-list.svelte
+++ b/src/lib/flows/edit-project-splits/steps/edit-dependency-list.svelte
@@ -57,6 +57,24 @@
     );
   }
 
+  function handleErrorDismissed() {
+    context.update((c) => {
+      c.recipientErrors = [];
+      return c;
+    });
+  }
+
+  function goForward() {
+    dispatch('goForward');
+  }
+
+  function goBackward() {
+    dispatch('goBackward');
+    // dismiss any errors on this step, since they're shared
+    // with the next step
+    handleErrorDismissed();
+  }
+
   $: maintainerKeys = Object.keys($context.maintainerSplits.items);
 </script>
 
@@ -72,6 +90,8 @@
       bind:weights={$context.dependencySplits.weights}
       bind:items={$context.dependencySplits.items}
       bind:valid={formValid}
+      bind:inputErrors={$context.recipientErrors}
+      on:errorDismissed={handleErrorDismissed}
       blockedAccountIds={$context.projectAccountId
         ? [$context.projectAccountId, ...maintainerKeys]
         : maintainerKeys}
@@ -82,14 +102,11 @@
     </svelte:fragment>
   </FormField>
   <svelte:fragment slot="left-actions">
-    <Button icon={ArrowLeft} on:click={() => dispatch('goBackward')}>Back</Button>
+    <Button icon={ArrowLeft} on:click={goBackward}>Back</Button>
   </svelte:fragment>
   <svelte:fragment slot="actions">
-    <Button
-      disabled={!formValid}
-      icon={ArrowRight}
-      variant="primary"
-      on:click={() => dispatch('goForward')}>Continue</Button
+    <Button disabled={!formValid} icon={ArrowRight} variant="primary" on:click={goForward}
+      >Continue</Button
     >
   </svelte:fragment>
 </StepLayout>

--- a/src/lib/flows/edit-project-splits/steps/edit-dependency-list.svelte
+++ b/src/lib/flows/edit-project-splits/steps/edit-dependency-list.svelte
@@ -10,6 +10,12 @@
   import ListEditor from '$lib/components/list-editor/list-editor.svelte';
   import ArrowLeft from '$lib/components/icons/ArrowLeft.svelte';
   import CustodialWarning from '$lib/components/annotation-box/custodial-warning.svelte';
+  import ArrowDown from '$lib/components/icons/ArrowDown.svelte';
+  import FormField from '$lib/components/form-field/form-field.svelte';
+  import type { ListEditorItem, AccountId } from '$lib/components/list-editor/types';
+  import importFromCSVSteps, {
+    WEIGHT_FACTOR,
+  } from '$lib/flows/import-from-csv/import-from-csv-steps';
 
   const dispatch = createEventDispatcher<StepComponentEvents>();
 
@@ -17,6 +23,42 @@
 
   let formValid: boolean;
 
+  function handleImportCSV() {
+    dispatch(
+      'sidestep',
+      importFromCSVSteps({
+        headline: 'Import dependencies from CSV',
+        description:
+          'Your CSV file should be formatted by first listing the recipient, then listing the percentage allocation. For example:',
+        exampleTableCaption:
+          'A recipient can be a wallet address, GitHub repo URL, or Drip List URL. Maximum 200 recipients. Any previously configured recipients will be overwritten with the CSV contents.',
+        addItem(key: AccountId, item: ListEditorItem, weight: number | undefined) {
+          context.update((c) => {
+            c.dependencySplits.items = {
+              ...c.dependencySplits.items,
+              [key]: item,
+            };
+
+            if (weight) {
+              c.dependencySplits.weights[key] = weight * WEIGHT_FACTOR;
+            }
+
+            return c;
+          });
+        },
+        clearItems() {
+          context.update((c) => {
+            c.dependencySplits.items = {};
+            c.dependencySplits.weights = {};
+            return c;
+          });
+        },
+      }),
+    );
+  }
+
+  // TODO: shouldn't this be:
+  // $: maintainerKeys = Object.keys($context.dependencySplits.items);
   $: maintainerKeys = Object.keys($context.maintainerSplits.items);
 </script>
 
@@ -27,15 +69,20 @@
       .highLevelPercentages['dependencies']}% you assigned to your project’s dependencies."
   />
   <CustodialWarning dismissableId="custodial-warning-project-splits" />
-  <ListEditor
-    bind:weights={$context.dependencySplits.weights}
-    bind:items={$context.dependencySplits.items}
-    bind:valid={formValid}
-    blockedAccountIds={$context.projectAccountId
-      ? [$context.projectAccountId, ...maintainerKeys]
-      : maintainerKeys}
-    maxItems={200 - maintainerKeys.length}
-  />
+  <FormField title="Dependencies*">
+    <ListEditor
+      bind:weights={$context.dependencySplits.weights}
+      bind:items={$context.dependencySplits.items}
+      bind:valid={formValid}
+      blockedAccountIds={$context.projectAccountId
+        ? [$context.projectAccountId, ...maintainerKeys]
+        : maintainerKeys}
+      maxItems={200 - maintainerKeys.length}
+    />
+    <svelte:fragment slot="action">
+      <Button variant="ghost" icon={ArrowDown} on:click={handleImportCSV}>Import from CSV</Button>
+    </svelte:fragment>
+  </FormField>
   <svelte:fragment slot="left-actions">
     <Button icon={ArrowLeft} on:click={() => dispatch('goBackward')}>Back</Button>
   </svelte:fragment>

--- a/src/lib/flows/edit-project-splits/steps/edit-dependency-list.svelte
+++ b/src/lib/flows/edit-project-splits/steps/edit-dependency-list.svelte
@@ -14,6 +14,7 @@
   import FormField from '$lib/components/form-field/form-field.svelte';
   import type { ListEditorItem, AccountId } from '$lib/components/list-editor/types';
   import importFromCSVSteps, {
+    DEFAULT_MAX_ENTRIES,
     WEIGHT_FACTOR,
   } from '$lib/flows/import-from-csv/import-from-csv-steps';
 
@@ -91,7 +92,7 @@
       blockedAccountIds={$context.projectAccountId
         ? [$context.projectAccountId, ...maintainerKeys]
         : maintainerKeys}
-      maxItems={200 - maintainerKeys.length}
+      maxItems={DEFAULT_MAX_ENTRIES - maintainerKeys.length}
     />
     <svelte:fragment slot="action">
       <Button variant="ghost" icon={ArrowDown} on:click={handleImportCSV}>Import from CSV</Button>

--- a/src/lib/flows/edit-project-splits/steps/edit-maintainer-list.svelte
+++ b/src/lib/flows/edit-project-splits/steps/edit-maintainer-list.svelte
@@ -11,6 +11,7 @@
   import ArrowLeft from '$lib/components/icons/ArrowLeft.svelte';
   import CustodialWarning from '$lib/components/annotation-box/custodial-warning.svelte';
   import importFromCSVSteps, {
+    DEFAULT_MAX_ENTRIES,
     WEIGHT_FACTOR,
   } from '$lib/flows/import-from-csv/import-from-csv-steps';
   import ArrowDown from '$lib/components/icons/ArrowDown.svelte';
@@ -108,7 +109,7 @@
       bind:inputErrors={$context.recipientErrors}
       on:errorDismissed={handleErrorDismissed}
       blockedAccountIds={dependencyKeys}
-      maxItems={200 - dependencyKeys.length}
+      maxItems={DEFAULT_MAX_ENTRIES - dependencyKeys.length}
       allowProjects={false}
       allowDripLists={false}
     />

--- a/src/lib/flows/edit-project-splits/steps/edit-maintainer-list.svelte
+++ b/src/lib/flows/edit-project-splits/steps/edit-maintainer-list.svelte
@@ -10,6 +10,12 @@
   import ListEditor from '$lib/components/list-editor/list-editor.svelte';
   import ArrowLeft from '$lib/components/icons/ArrowLeft.svelte';
   import CustodialWarning from '$lib/components/annotation-box/custodial-warning.svelte';
+  import importFromCSVSteps, {
+    WEIGHT_FACTOR,
+  } from '$lib/flows/import-from-csv/import-from-csv-steps';
+  import ArrowDown from '$lib/components/icons/ArrowDown.svelte';
+  import FormField from '$lib/components/form-field/form-field.svelte';
+  import type { ListEditorItem, AccountId } from '$lib/components/list-editor/types';
 
   const dispatch = createEventDispatcher<StepComponentEvents>();
 
@@ -26,6 +32,40 @@
     }
   }
 
+  function handleImportCSV() {
+    dispatch(
+      'sidestep',
+      importFromCSVSteps({
+        headline: 'Import maintainers from CSV',
+        description:
+          'Your CSV file should be formatted by first listing the recipient, then listing the percentage allocation. For example:',
+        exampleTableCaption:
+          'A recipient can be a wallet address, GitHub repo URL, or Drip List URL. Maximum 200 recipients. Any previously configured recipients will be overwritten with the CSV contents.',
+        addItem(key: AccountId, item: ListEditorItem, weight: number | undefined) {
+          context.update((c) => {
+            c.maintainerSplits.items = {
+              ...c.maintainerSplits.items,
+              [key]: item,
+            };
+
+            if (weight) {
+              c.maintainerSplits.weights[key] = weight * WEIGHT_FACTOR;
+            }
+
+            return c;
+          });
+        },
+        clearItems() {
+          context.update((c) => {
+            c.maintainerSplits.items = {};
+            c.maintainerSplits.weights = {};
+            return c;
+          });
+        },
+      }),
+    );
+  }
+
   $: dependencyKeys = Object.keys($context.dependencySplits.items);
 </script>
 
@@ -37,15 +77,20 @@
     ]}% you assigned to your project’s maintainers."
   />
   <CustodialWarning dismissableId="custodial-warning-project-splits" />
-  <ListEditor
-    bind:weights={$context.maintainerSplits.weights}
-    bind:items={$context.maintainerSplits.items}
-    bind:valid={formValid}
-    blockedAccountIds={dependencyKeys}
-    maxItems={200 - dependencyKeys.length}
-    allowProjects={false}
-    allowDripLists={false}
-  />
+  <FormField title="Maintainers*">
+    <ListEditor
+      bind:weights={$context.maintainerSplits.weights}
+      bind:items={$context.maintainerSplits.items}
+      bind:valid={formValid}
+      blockedAccountIds={dependencyKeys}
+      maxItems={200 - dependencyKeys.length}
+      allowProjects={false}
+      allowDripLists={false}
+    />
+    <svelte:fragment slot="action">
+      <Button variant="ghost" icon={ArrowDown} on:click={handleImportCSV}>Import from CSV</Button>
+    </svelte:fragment>
+  </FormField>
   <svelte:fragment slot="left-actions">
     <Button icon={ArrowLeft} on:click={() => dispatch('goBackward')}>Back</Button>
   </svelte:fragment>

--- a/src/lib/flows/edit-project-splits/steps/edit-maintainer-list.svelte
+++ b/src/lib/flows/edit-project-splits/steps/edit-maintainer-list.svelte
@@ -16,6 +16,8 @@
   import ArrowDown from '$lib/components/icons/ArrowDown.svelte';
   import FormField from '$lib/components/form-field/form-field.svelte';
   import type { ListEditorItem, AccountId } from '$lib/components/list-editor/types';
+  import mapFilterUndefined from '$lib/utils/map-filter-undefined';
+  import network from '$lib/stores/wallet/network';
 
   const dispatch = createEventDispatcher<StepComponentEvents>();
 
@@ -40,7 +42,15 @@
         description:
           'Your CSV file should be formatted by first listing the recipient, then listing the percentage allocation. For example:',
         exampleTableCaption:
-          'A recipient can be a wallet address or ENS name. Maximum 200 recipients. Any previously configured recipients will be overwritten with the CSV contents.',
+          'A recipient can be a wallet address or ENS name if supported by the network. Maximum 200 recipients. Any previously configured recipients will be overwritten with the CSV contents.',
+        exampleTableData: mapFilterUndefined(
+          [
+            ['0xa404a9258A2240d6f2FDa871a7Fbd71bb6523570', 20],
+            ['0x38493bA0F8a15D81985bF5438bc6f90C6C5418C1', 75],
+            network.ensSupported ? ['vitalik.eth', 5] : undefined,
+          ],
+          (v) => v,
+        ),
         allowProjects: false,
         allowDripLists: false,
         addItem(key: AccountId, item: ListEditorItem, weight: number | undefined) {

--- a/src/lib/flows/edit-project-splits/steps/edit-maintainer-list.svelte
+++ b/src/lib/flows/edit-project-splits/steps/edit-maintainer-list.svelte
@@ -32,6 +32,10 @@
     } else {
       dispatch('goForward');
     }
+
+    // dismiss any errors on this step, since they're shared
+    // with the next step
+    handleErrorDismissed();
   }
 
   function handleImportCSV() {
@@ -78,6 +82,13 @@
     );
   }
 
+  function handleErrorDismissed() {
+    context.update((c) => {
+      c.recipientErrors = [];
+      return c;
+    });
+  }
+
   $: dependencyKeys = Object.keys($context.dependencySplits.items);
 </script>
 
@@ -94,6 +105,8 @@
       bind:weights={$context.maintainerSplits.weights}
       bind:items={$context.maintainerSplits.items}
       bind:valid={formValid}
+      bind:inputErrors={$context.recipientErrors}
+      on:errorDismissed={handleErrorDismissed}
       blockedAccountIds={dependencyKeys}
       maxItems={200 - dependencyKeys.length}
       allowProjects={false}

--- a/src/lib/flows/edit-project-splits/steps/edit-maintainer-list.svelte
+++ b/src/lib/flows/edit-project-splits/steps/edit-maintainer-list.svelte
@@ -40,7 +40,9 @@
         description:
           'Your CSV file should be formatted by first listing the recipient, then listing the percentage allocation. For example:',
         exampleTableCaption:
-          'A recipient can be a wallet address, GitHub repo URL, or Drip List URL. Maximum 200 recipients. Any previously configured recipients will be overwritten with the CSV contents.',
+          'A recipient can be a wallet address or ENS name. Maximum 200 recipients. Any previously configured recipients will be overwritten with the CSV contents.',
+        allowProjects: false,
+        allowDripLists: false,
         addItem(key: AccountId, item: ListEditorItem, weight: number | undefined) {
           context.update((c) => {
             c.maintainerSplits.items = {

--- a/src/lib/flows/import-from-csv/import-from-csv-steps.ts
+++ b/src/lib/flows/import-from-csv/import-from-csv-steps.ts
@@ -21,6 +21,7 @@ type UploadProps = {
 
 export const DEFAULT_CSV_HEADERS = ['recipient', 'percentage'];
 export const DEFAULT_MAX_ENTRIES = 200;
+export const WEIGHT_FACTOR = 10_000;
 
 export default (props: UploadProps) => ({
   context: undefined,

--- a/src/lib/utils/github/GitHub.ts
+++ b/src/lib/utils/github/GitHub.ts
@@ -55,6 +55,9 @@ export default class GitHub {
         request: {
           cache: 'reload',
         },
+        headers: {
+          'If-None-Match': '',
+        },
       }));
     } catch (error) {
       // eslint-disable-next-line no-console


### PR DESCRIPTION
This PR brings changes to allow users to edit their maintainers and dependencies by uploading a CSV file. It also brings the same to the project claim process. It fixes an issue where a cached version of the FUNDING.json would be returned during verification instead of the updated on.

**Flows Updated**
Claim Project
* Configure dependencies
* Configure maintainers

Edit project splits
* Edit dependency list
* Edit mantainters list
