### PR TITLE
Highlighted section incorrect for claim on further networks

### DIFF
--- a/src/lib/flows/claim-project-flow/steps/add-ethereum-address/drips-json-template.ts
+++ b/src/lib/flows/claim-project-flow/steps/add-ethereum-address/drips-json-template.ts
@@ -17,6 +17,9 @@ export const getChangedTemplate = (
   // object string keys are iterated in insertion order, so when we add the new network here, it will
   // always appear last in the JSON representation.
   const existingJsonCopy = JSON.parse(JSON.stringify(existingJson));
+  // if there's already an entry for this network, delete it
+  // and replace it with the current value.
+  delete existingJsonCopy.drips[network];
   existingJsonCopy.drips[network] = {
     ownedBy: address,
   };


### PR DESCRIPTION
This PR fixes a bug with the highlighting of additional FUNDING.json stanzas that happen to already exist in the source.

Given this existing FUNDING.json:
![Screenshot 2024-12-16 at 19 12 33](https://github.com/user-attachments/assets/ac33f0c3-4404-4ad0-99dd-fe9670bad3d1)

Produces:
![Screenshot 2024-12-16 at 19 12 06](https://github.com/user-attachments/assets/bf536982-8449-42ac-a52d-2bdb2bd80cc5)
