### PR TITLE
CSV import capitalization correction doesn't (always?) appear to be working

### DIFF
--- a/src/lib/components/list-editor/classifiers.ts
+++ b/src/lib/components/list-editor/classifiers.ts
@@ -28,8 +28,14 @@ export const classifyRecipient = (
     return {
       type: 'project',
       value: reformatUrl(input),
-      validate() {
-        return validateProject(this.value);
+      async validate() {
+        const validationOrUrl = await validateProject(this.value);
+        if (!validationOrUrl) {
+          return false;
+        }
+
+        this.value = reformatUrl(validationOrUrl);
+        return true;
       },
       fetch() {
         return getProject(this.value);
@@ -75,8 +81,8 @@ export const classifyRecipient = (
     return {
       type: 'project',
       value: buildRepositoryURL(input),
-      validate() {
-        return validateProject(this.value);
+      async validate() {
+        return !!(await validateProject(this.value));
       },
       fetch() {
         return getProject(this.value);

--- a/src/lib/components/list-editor/validators.ts
+++ b/src/lib/components/list-editor/validators.ts
@@ -14,14 +14,14 @@ export const reformatUrl = (url: string): string => {
   return url;
 };
 
-export const validateProject = async (url: string): Promise<boolean> => {
+export const validateProject = async (url: string): Promise<string | null> => {
   const formattedUrl = reformatUrl(url);
 
   const repoInfoRes = await fetch(`/api/github/${encodeURIComponent(formattedUrl)}`);
   const repoInfo = await repoInfoRes.json();
   const normalizedUrl = repoInfo.url;
 
-  return !!normalizedUrl;
+  return normalizedUrl;
 };
 
 export const getDripListId = (url: string): string => {


### PR DESCRIPTION
This PR ensures that Github repo identifiers are properly capitalised when loaded. 

Test Input:
```csv
recipient,percentage
0x79756b6C2f913271fc0ee29A877fbd98258972BF,20
https://github.com/celtd/voting_mechanism_design,20
https://github.com/celtd/builtin-actors,20
```