### PR TITLE
fix empty state of projects section if all projects hidden

### DIFF
--- a/src/lib/components/projects-section/projects-section.svelte
+++ b/src/lib/components/projects-section/projects-section.svelte
@@ -61,7 +61,7 @@
   skeleton={{
     horizontalScroll: false,
     loaded: true,
-    empty: visibleProjects?.length === 0,
+    empty: showVisibilityToggle ? projects.length === 0 : visibleProjects.length === 0,
     error,
     emptyStateEmoji: '🫙',
     emptyStateHeadline: 'No claimed projects',


### PR DESCRIPTION
Previously, the /projects route would show the empty state if you had _only_ hidden projects, and wouldn't allow displaying those.