### PR TITLE
Jason/drip list actions improvements

### DIFF
--- a/src/lib/flows/create-drip-list-flow/steps/review/review.svelte
+++ b/src/lib/flows/create-drip-list-flow/steps/review/review.svelte
@@ -32,6 +32,8 @@
   import OneTimeDonationReviewCard from './components/one-time-donation-review-card.svelte';
   import Heart from '$lib/components/icons/Heart.svelte';
   import network from '$lib/stores/wallet/network';
+  import { invalidateAll } from '$lib/stores/fetched-data-cache/invalidate';
+  import invalidateAccountCache from '$lib/utils/cache/remote/invalidate-account-cache';
 
   const dispatch = createEventDispatcher<StepComponentEvents>();
 
@@ -116,7 +118,8 @@
             1000,
           );
 
-          // TODO(streams): invalidate appropriate load function
+          await invalidateAccountCache(dripListId);
+          await invalidateAll();
 
           $context.dripListId = dripListId;
         },

--- a/src/lib/flows/create-drip-list-flow/steps/review/review.svelte
+++ b/src/lib/flows/create-drip-list-flow/steps/review/review.svelte
@@ -93,6 +93,7 @@
                 account {
                   accountId
                 }
+                isVisible
               }
             }
           `;
@@ -113,7 +114,8 @@
 
           await expect(
             () => tryFetchList(dripListId),
-            (result) => (typeof result === 'boolean' ? result : Boolean(result.dripList)),
+            (result) =>
+              typeof result === 'boolean' ? result : Boolean(result.dripList?.isVisible),
             120000,
             1000,
           );

--- a/src/lib/flows/edit-drip-list/edit-members/edit-drip-list-steps.ts
+++ b/src/lib/flows/edit-drip-list/edit-members/edit-drip-list-steps.ts
@@ -59,7 +59,7 @@ export default (dripList: EditDripListFlowDripListFragment) => {
         component: SuccessStep,
         props: {
           safeAppMode: Boolean(get(walletStore).safe),
-          message: 'Your Drip List has been updated. Please refresh the page to see the changes.',
+          message: 'Your Drip List has been updated.',
         },
       }),
     ],


### PR DESCRIPTION
Some minor fixes:
- we weren't properly invalidating caches after creating a new drip list, this does that
- there appears to have been a tiny chance for the drip list creation flow to resolve before the DB entry for the drip list is fully populated. this checks for a key that should always be there (`isVisible`) to be populated before resolving the creation flow.
- we were telling users they need to refresh the page after editing a drip list, which they actually don't 