### PR TITLE
Jason/total dripped update

### DIFF
--- a/src/lib/components/aggregate-fiat-estimate/aggregate-fiat-estimate.ts
+++ b/src/lib/components/aggregate-fiat-estimate/aggregate-fiat-estimate.ts
@@ -15,7 +15,7 @@ export default function aggregateFiatEstimate(prices: Prices, amounts: Amount[])
     fiatEstimateCents = 'pending';
   } else {
     fiatEstimateCents = amounts.reduce((sum, { tokenAddress, amount }) => {
-      const token = tokensStore.getByAddress(tokenAddress);
+      const token = tokensStore.getByAddress(tokenAddress, 'any');
 
       if (!token) {
         includesUnknownPrice = true;

--- a/src/lib/components/code-box/code-box.svelte
+++ b/src/lib/components/code-box/code-box.svelte
@@ -7,9 +7,9 @@
   import sanitize from 'sanitize-html';
   import insertTextAtIndices from '$lib/utils/insert-text-at-indicies';
 
-  export let path: string;
+  export let path: string = 'Code';
   export let code: string;
-  export let repoUrl: string;
+  export let repoUrl: string | undefined = undefined;
   export let defaultBranch = 'main';
   export let highlight: [number | null, number | null] = [null, null];
   export let editing: boolean = false;
@@ -66,7 +66,7 @@
       {@html displayCode}
     </code>
   </div>
-  {#if repoUrl.includes('github')}
+  {#if repoUrl && repoUrl.includes('github')}
     <footer class="absolute bottom-4 right-4">
       <Button variant="primary" icon={ArrowBoxUpRight} href={gitHubProposalUrl} target="_blank">
         {ctaText}</Button

--- a/src/lib/components/developer-section/stream-developer.section.svelte
+++ b/src/lib/components/developer-section/stream-developer.section.svelte
@@ -4,10 +4,14 @@
   import developerModeStore from '$lib/stores/developer-mode/developer-mode.store';
   import Copyable from '../copyable/copyable.svelte';
   import contractConstants from '$lib/utils/sdk/utils/contract-constants';
+  import CodeBox from '../code-box/code-box.svelte';
 
   export let amtPerSec: bigint | undefined = undefined;
   export let tokenAddress: string | undefined = undefined;
   export let tokenDecimals: number | undefined = undefined;
+  export let startDate: Date | undefined = undefined;
+  export let createdAt: Date | undefined = undefined;
+  export let rawTimeline: string | undefined = undefined;
 </script>
 
 {#if $developerModeStore}
@@ -56,6 +60,31 @@
           <Copyable value={amtPerSecondWei} alwaysVisible>
             <span class="value">{amtPerSecondWei}</span>
           </Copyable>
+        </div>
+      {/if}
+
+      {#if createdAt}
+        <div class="key-value">
+          <h5 class="key">Created at (unix)</h5>
+          <Copyable value={String(createdAt.getTime() / 1000)} alwaysVisible>
+            <span class="value">{createdAt.getTime() / 1000}</span>
+          </Copyable>
+        </div>
+      {/if}
+
+      {#if startDate}
+        <div class="key-value">
+          <h5 class="key">Start date (unix)</h5>
+          <Copyable value={String(startDate.getTime() / 1000)} alwaysVisible>
+            <span class="value">{startDate.getTime() / 1000}</span>
+          </Copyable>
+        </div>
+      {/if}
+
+      {#if rawTimeline}
+        <div class="key-value">
+          <h5 class="key">Raw stream timeline</h5>
+          <CodeBox code={rawTimeline} />
         </div>
       {/if}
     </div>

--- a/src/lib/utils/fiat-estimates/fiat-estimates.ts
+++ b/src/lib/utils/fiat-estimates/fiat-estimates.ts
@@ -42,7 +42,7 @@ const SUBSTITUTIONS: Record<string, string> = {
  * For alt L1/L2 tokens that don't have an equivalent value token on Eth Mainnet.
  * Keys are token contract addresses on the L1/L2, values are coinmarket cap unique asset IDs to map to.
  * */
-const MANUAL_IDS: Record<string, string> = {
+export const MANUAL_IDS: Record<string, string> = {
   /* Map Wrapped Filecoin to Filecoin */
   '0x60E1773636CF5E4A227d9AC24F20fEca034ee25A': '2280',
 };

--- a/src/lib/utils/total-dripped-approx.ts
+++ b/src/lib/utils/total-dripped-approx.ts
@@ -1,5 +1,4 @@
 import cached from './cache/remote/cached';
-import isTest from './is-test';
 import type { RedisClientType } from '../../routes/api/redis';
 import { getCmcPrices } from './cmc';
 import mergeAmounts from './amounts/merge-amounts';
@@ -10,10 +9,24 @@ import cacheKey from './cache/remote/cache-key';
 const STREAMS: {
   token: { address: string };
   started: number;
+  endsAt: number;
   amtPerSec: string;
-}[] = [];
+}[] = [
+  // Filecoin RPGF-2 PG donation https://filecoin.drips.network/app/976822925357514561093139105352740088169738576235/tokens/0x60E1773636CF5E4A227d9AC24F20fEca034ee25A/streams/4192296931
+  {
+    token: { address: '0x60E1773636CF5E4A227d9AC24F20fEca034ee25A' },
+    started: 1738347480000,
+    endsAt: 1740939492000,
+    amtPerSec: '70062152777777777777777777',
+  },
+];
 
 const GIVES = [
+  // Radworks Grant https://www.drips.network/app/drip-lists/40866246603895578971810925870326321539836543960399385681839516039553
+  {
+    tokenAddress: '0x31c8EAcBFFdD875c74b94b077895Bd78CF1E64A3',
+    amount: '500000000000000000000',
+  },
   // ENS USDC (total of the completed stream) https://www.drips.network/app/219944633562831898862545170897344561225692372227/tokens/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/streams/465197764
   {
     tokenAddress: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
@@ -60,7 +73,6 @@ const GIVES = [
     tokenAddress: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
     amount: '10000000000',
   },
-
   // First FTC list WETH (they have two for some reason) https://drips.network/app/drip-lists/36167722434539895740687283110259945938004377627588501179309095983174
   // Total of the stream which is now stopped
   {
@@ -71,7 +83,8 @@ const GIVES = [
 
 export default function totalDrippedApproximation() {
   const streamedAmounts = STREAMS.map((stream) => {
-    const duration = (Date.now() - stream.started) / 1000;
+    const calcUntil = Math.min(Date.now(), stream.endsAt);
+    const duration = (calcUntil - stream.started) / 1000;
 
     return {
       tokenAddress: stream.token.address.toLowerCase(),
@@ -90,9 +103,6 @@ export default function totalDrippedApproximation() {
 `${network.name}:total-dripped-prices`;
 
 export const totalDrippedPrices = (fetch = window.fetch) => {
-  // In test env, we can't fetch prices from CMC, so we don't.
-  if (isTest()) return {};
-
   const tokenAddresses = totalDrippedApproximation().map((a) => a.tokenAddress.toLowerCase());
   return getCmcPrices(tokenAddresses, fetch);
 };

--- a/src/routes/(pages)/app/(app)/[accountId]/tokens/[token]/streams/[dripId]/+page.svelte
+++ b/src/routes/(pages)/app/(app)/[accountId]/tokens/[token]/streams/[dripId]/+page.svelte
@@ -329,7 +329,10 @@
       <StreamDeveloper
         amtPerSec={BigInt(stream.config.amountPerSecond.amount)}
         {tokenAddress}
+        createdAt={new Date(stream.createdAt)}
+        startDate={stream.config.startDate ? new Date(stream.config.startDate) : undefined}
         tokenDecimals={token?.info.decimals}
+        rawTimeline={JSON.stringify(stream.timeline, null, 4)}
       />
     </div>
   {/if}


### PR DESCRIPTION
Update the total dripped approx with latest streams and gives.

To make this easier in the future, adds some additional data to stream page developer section, including full timeline payload: 

<img width="921" alt="Screenshot 2025-02-05 at 15 24 17" src="https://github.com/user-attachments/assets/06ab3009-af10-45f0-86a9-1c5edfe62364" />

Also adds:
- Ability to set an end date for a stream in the total dripped approx so that we don't have to manually make a change here to prevent overshooting of the approximation. Can be set to either the date the stream is expected to run out of funds, or a set end date, if any.
- Ability to use tokens that belong to a network other than the one the app is connected to for approximations.

...... We really need to start calculating this value dynamically at some point!