### PR TITLE
add elimu.ai token to default tokens

### DIFF
--- a/src/lib/stores/tokens/additional-tokens.json
+++ b/src/lib/stores/tokens/additional-tokens.json
@@ -10,6 +10,14 @@
   "tokens": [
     {
       "chainId": 1,
+      "address": "0xe29797910D413281d2821D5d9a989262c8121CC2",
+      "name": "elimu.ai",
+      "symbol": "ELIMU",
+      "decimals": 18,
+      "logoURI": "https://etherscan.io/token/images/elimuai_32.png"
+    },
+    {
+      "chainId": 1,
       "address": "0x4F604735c1cF31399C6E711D5962b2B3E0225AD3",
       "name": "Glo Dollar",
       "symbol": "USDGLO",

--- a/src/lib/stores/tokens/tokens.store.ts
+++ b/src/lib/stores/tokens/tokens.store.ts
@@ -39,16 +39,18 @@ export default (() => {
     // Clean any custom tokens that are already part of the default list
     // This could happen if someone added a token, and the custom token list
     // was later amended.
-    for (const [index, customToken] of customTokens.entries()) {
+    const tokensToRemove: CustomTokenInfoWrapper[] = [];
+    for (const customToken of customTokens) {
       const matchingDefaultToken = defaultTokens.find(
         (t) => t.info.address.toLowerCase() === customToken.info.address.toLowerCase(),
       );
 
       if (matchingDefaultToken) {
         storedTokens.deleteCustomToken(customToken);
-        customTokens = customTokens.splice(index, 1);
+        tokensToRemove.push(customToken);
       }
     }
+    customTokens = customTokens.filter((token) => !tokensToRemove.includes(token));
 
     tokenList.set([...defaultTokens, ...customTokens]);
   }

--- a/src/lib/stores/tokens/tokens.store.ts
+++ b/src/lib/stores/tokens/tokens.store.ts
@@ -34,7 +34,23 @@ export default (() => {
       source: 'default',
     }));
 
-    tokenList.set([...defaultTokens, ...(browser ? storedTokens.readCustomTokensList() : [])]);
+    let customTokens = browser ? storedTokens.readCustomTokensList() : [];
+
+    // Clean any custom tokens that are already part of the default list
+    // This could happen if someone added a token, and the custom token list
+    // was later amended.
+    for (const [index, customToken] of customTokens.entries()) {
+      const matchingDefaultToken = defaultTokens.find(
+        (t) => t.info.address.toLowerCase() === customToken.info.address.toLowerCase(),
+      );
+
+      if (matchingDefaultToken) {
+        storedTokens.deleteCustomToken(customToken);
+        customTokens = customTokens.splice(index, 1);
+      }
+    }
+
+    tokenList.set([...defaultTokens, ...customTokens]);
   }
   init();
 

--- a/src/lib/stores/tokens/tokens.store.unit.test.ts
+++ b/src/lib/stores/tokens/tokens.store.unit.test.ts
@@ -161,7 +161,27 @@ describe('tokens store', () => {
         'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png',
     };
 
+    const uniswapTokenInfo = {
+      name: 'Uniswap',
+      address: '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984',
+      symbol: 'UNI',
+      decimals: 18,
+      chainId: 11155111,
+      logoURI: '',
+    };
+
+    const anotherTokenInfo = {
+      name: 'Another Token',
+      address: '0x7705ea2afD095d898f73023C30fC49490799A730',
+      symbol: 'AT',
+      decimals: 18,
+      chainId: 11155111,
+      logoURI: '',
+    };
+
     createCustomToken(wrappedEtherTokenInfo);
+    createCustomToken(uniswapTokenInfo);
+    createCustomToken(anotherTokenInfo);
 
     const storedValueForWrappedEther = {
       source: 'custom',
@@ -169,12 +189,32 @@ describe('tokens store', () => {
       info: wrappedEtherTokenInfo,
     };
 
+    const storedValueForUniswap = {
+      source: 'custom',
+      banned: false,
+      info: uniswapTokenInfo,
+    };
+
+    const storedValueForAnotherToken = {
+      source: 'custom',
+      banned: false,
+      info: anotherTokenInfo,
+    };
+
     expect(readCustomTokensList()).toContainEqual(storedValueForWrappedEther);
+    expect(readCustomTokensList()).toContainEqual(storedValueForUniswap);
+    expect(readCustomTokensList()).toContainEqual(storedValueForAnotherToken);
 
     tokens.init();
 
     expect(readCustomTokensList()).not.toContainEqual(storedValueForWrappedEther);
     expect(tokens.getByAddress(wrappedEtherTokenInfo.address)?.source).toBe('default');
+
+    expect(readCustomTokensList()).not.toContainEqual(storedValueForUniswap);
+    expect(tokens.getByAddress(uniswapTokenInfo.address)?.source).toBe('default');
+
+    expect(readCustomTokensList()).toContainEqual(storedValueForAnotherToken);
+    expect(tokens.getByAddress(anotherTokenInfo.address)?.source).toBe('custom');
   });
 });
 


### PR DESCRIPTION
Lots of activity for this token on Drips so finally adding it as a default token, so ppl no longer need to add it to their custom tokens to see it.

Also adds logic for clearing the stored custom tokens of any tokens that are now part of the default list.

cc @nya-elimu