### PR TITLE
fix dev server not updating sk dev types

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,11 +1,11 @@
 node_modules
 docs
 docker
+!docker/dev-entrypoint.sh
 Dockerfile
 Dockerfile.dev
 .git
 .gitignore
 .env
 build
-.svelte-kit
 docker-compose.*

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,7 +1,5 @@
 FROM node:22
 
-WORKDIR /app
-
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
 
@@ -9,18 +7,18 @@ RUN apt-get update \
  && apt-get install -y chromium \
     fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf libxss1 \
     --no-install-recommends
+RUN apt-get install -y gosu
+
+WORKDIR /app
 
 # Copies both package.json and package-lock.json
 COPY package*.json ./
 # Install dependencies
 RUN npm ci --ignore-scripts;
-
-COPY ./scripts ./scripts
-COPY ./static ./static
-COPY ./codegen.ts ./
-COPY ./generate-schema.codegen.ts ./
-RUN npm run postinstall
+RUN rm -rf .svelte-kit
 
 EXPOSE 5173
 
-CMD [ "bash", "-c", "npm run gql:build && npm run dev -- --host 0.0.0.0"]
+COPY ./docker/dev-entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,10 +18,11 @@ services:
       - MEILISEARCH_HOST=http://meilisearch:7700
       - MEILISEARCH_API_KEY=1234
       - PUBLIC_USE_LOCAL_TESTNET_WALLET_STORE=${APP_USE_LOCAL_TESTNET_WALLET_STORE-false}
+      - LOCAL_UID=1000
+      - LOCAL_GID=1000
     volumes:
     - .:/app
     - /app/node_modules/
-    - /app/.svelte-kit/
     ports:
     - 5173:5173
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,8 @@ services:
       - MEILISEARCH_HOST=http://meilisearch:7700
       - MEILISEARCH_API_KEY=1234
       - PUBLIC_USE_LOCAL_TESTNET_WALLET_STORE=${APP_USE_LOCAL_TESTNET_WALLET_STORE-false}
-      - LOCAL_UID=1000
-      - LOCAL_GID=1000
+      - LOCAL_UID=${LOCAL_UID-root}
+      - LOCAL_GID=${LOCAL_GID-root}
     volumes:
     - .:/app
     - /app/node_modules/

--- a/docker/dev-entrypoint.sh
+++ b/docker/dev-entrypoint.sh
@@ -12,10 +12,8 @@ printf "  \_____|_|  |_|\n\n"
                 
 echo "ℹ️ Starting with UID: $USER_ID, GID: $GROUP_ID"
 useradd -u $USER_ID -o -m drippy
-groupmod -g $GROUP_ID drippy
+groupmod -g $GROUP_ID drippy 2>/dev/null
 export HOME=/home/drippy
-
-ls -al | grep .svelte-kit
 
 /usr/sbin/gosu drippy npm run gql:build
 

--- a/docker/dev-entrypoint.sh
+++ b/docker/dev-entrypoint.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+USER_ID=${LOCAL_UID:-9001}
+GROUP_ID=${LOCAL_GID:-9001}
+
+printf "\n   _____ __  __ \n"
+printf "  / ____|  \/  |\n"
+printf " | |  __| \  / |\n"
+printf " | | |_ | |\/| |\n"
+printf " | |__| | |  | |\n"
+printf "  \_____|_|  |_|\n\n"
+                
+echo "ℹ️ Starting with UID: $USER_ID, GID: $GROUP_ID"
+useradd -u $USER_ID -o -m drippy
+groupmod -g $GROUP_ID drippy
+export HOME=/home/drippy
+
+ls -al | grep .svelte-kit
+
+/usr/sbin/gosu drippy npm run gql:build
+
+# chown node modules to drippy since it's an anon volume and owned by root
+if [ -d "node_modules" ]; then
+  chown -R drippy:drippy node_modules
+fi
+
+printf "\n🚀 Starting dev server...\n"
+exec /usr/sbin/gosu drippy npm run dev -- --host 0.0.0.0

--- a/docker/start-dev.sh
+++ b/docker/start-dev.sh
@@ -23,5 +23,4 @@ case "$ARCH" in
 esac
 export ARCH
 
-
 docker compose -f docker-compose.yml -f docker-compose.dev.yml build && docker compose -f docker-compose.yml -f docker-compose.dev.yml up --renew-anon-volumes --attach app

--- a/docker/start-dev.sh
+++ b/docker/start-dev.sh
@@ -23,4 +23,6 @@ case "$ARCH" in
 esac
 export ARCH
 
+export LOCAL_UID=$(id -u)
+export LOCAL_GID=$(id -g)
 docker compose -f docker-compose.yml -f docker-compose.dev.yml build && docker compose -f docker-compose.yml -f docker-compose.dev.yml up --renew-anon-volumes --attach app

--- a/docker/start-e2e.sh
+++ b/docker/start-e2e.sh
@@ -29,6 +29,8 @@ case "$ARCH" in
 esac
 export ARCH
 
+export LOCAL_UID=$(id -u)
+export LOCAL_GID=$(id -g)
 docker compose build && APP_USE_LOCAL_TESTNET_WALLET_STORE=true docker compose -f docker-compose.yml up --renew-anon-volumes --detach
 
 printf "⏳ Waiting for the app to start..."

--- a/scripts/build-gql-types.sh
+++ b/scripts/build-gql-types.sh
@@ -8,7 +8,6 @@ if [ ! -f ./schema.graphql ]; then
   exit 1
 fi
 
-
 start_time=$(date +%s)
 end_time=$((start_time + 300))  # 5 minutes = 300 seconds
 


### PR DESCRIPTION
`.svelte-kit` dir, which includes dynamically created types for development (such as route params, page data types etc.) was being mounted in the dev container as an anonymous volume, causing it to not be written on the host. This means that types would never by updated during dev unless runing the dev server or svelte-kit sync on the host, outside of Docker.

This makes it so that the dev server running within Docker also updates the .svelte-kit dir on the host.

It also adds logic for always running the dev server as the same user that ran `npm run dev:docker` to fix permission issues.

Also adds an ASCII `GM` log 🌈 