### PR TITLE
web3privacynow short URL

### DIFF
--- a/src/routes/(pages)/[path]/+page.ts
+++ b/src/routes/(pages)/[path]/+page.ts
@@ -1,0 +1,17 @@
+import { redirect } from '@sveltejs/kit';
+import type { PageLoad } from './$types';
+
+// Manually hardcoded short URL redirects for campaigns.
+// We want to move to a dynamic ENS-based solution long-term
+const SHORT_URLS: Record<string, string> = {
+  privacyproof24:
+    'https://optimism.drips.network/app/drip-lists/46441013481627019632859175771245733399752255312769848791334977723541',
+};
+
+export const load: PageLoad = ({ params }) => {
+  if (params.path in SHORT_URLS) {
+    return redirect(301, SHORT_URLS[params.path]);
+  }
+
+  redirect(308, `/app/${params.path}`);
+};

--- a/src/routes/(pages)/[userId]/+page.ts
+++ b/src/routes/(pages)/[userId]/+page.ts
@@ -1,6 +1,0 @@
-import { redirect } from '@sveltejs/kit';
-import type { PageLoad } from './$types';
-
-export const load: PageLoad = ({ params }) => {
-  redirect(308, `/app/${params.userId}`);
-};


### PR DESCRIPTION
Adds a crude way of setting up short URLs for campaigns, before we move to a dynamic ENS-based approach.

Configures first redirect for web3privacynow campaign.