### PR TITLE
add featured lists section to distribution explore page, feature 2nd round of FIL distribution

### DIFF
--- a/src/lib/utils/filter-falseish.ts
+++ b/src/lib/utils/filter-falseish.ts
@@ -1,0 +1,8 @@
+/**
+ * Takes an array of any type, null or undefined, and filters out all non-truthy values.
+ * @param input
+ * @returns input without any false-ish values.
+ */
+export default function filterFalseish<T>(input: (T | null | undefined | false)[]): T[] {
+  return input.filter((v): v is T => Boolean(v));
+}

--- a/src/lib/utils/filter-falsy.ts
+++ b/src/lib/utils/filter-falsy.ts
@@ -1,8 +1,8 @@
 /**
  * Takes an array of any type, null or undefined, and filters out all non-truthy values.
  * @param input
- * @returns input without any false-ish values.
+ * @returns input without any falsey values.
  */
-export default function filterFalseish<T>(input: (T | null | undefined | false)[]): T[] {
+export default function filterFalsy<T>(input: (T | null | undefined | false)[]): T[] {
   return input.filter((v): v is T => Boolean(v));
 }

--- a/src/routes/(pages)/app/(app)/+page.server.ts
+++ b/src/routes/(pages)/app/(app)/+page.server.ts
@@ -53,7 +53,10 @@ const EXPLORE_PAGE_CONFIG: ValueForEachSupportedChain<ExplorePageConfig> = {
     variant: 'distribution',
     loadFn: (f) =>
       loadDistributionExplorePageData(f, {
-        featuredListId: '45193817480599985262554974973835763972521255481357121508020698376704',
+        featuredListIds: [
+          '45193817480599985262554974973835763972521255481355516335980315118301',
+          '45193817480599985262554974973835763972521255481357121508020698376704',
+        ],
         welcomeCardConfig: {
           title: 'Welcome to Drips on Filecoin',
           description:
@@ -70,7 +73,7 @@ const EXPLORE_PAGE_CONFIG: ValueForEachSupportedChain<ExplorePageConfig> = {
     variant: 'distribution',
     loadFn: (f) =>
       loadDistributionExplorePageData(f, {
-        featuredListId: null,
+        featuredListIds: [],
         welcomeCardConfig: {
           title: 'Welcome to Drips on Metis',
           description: "Drips on Metis is where rewards from Metis' RetroPGF will be distributed.",

--- a/src/routes/(pages)/app/(app)/+page.server.ts
+++ b/src/routes/(pages)/app/(app)/+page.server.ts
@@ -54,8 +54,8 @@ const EXPLORE_PAGE_CONFIG: ValueForEachSupportedChain<ExplorePageConfig> = {
     loadFn: (f) =>
       loadDistributionExplorePageData(f, {
         featuredListIds: [
-          '45193817480599985262554974973835763972521255481355516335980315118301',
-          '45193817480599985262554974973835763972521255481357121508020698376704',
+          '45193817480599985262554974973835763972521255481355516335980315118301', // 2nd RPGF-2 FIL distribution
+          '45193817480599985262554974973835763972521255481357121508020698376704', // 1st RPGF-2 FIL distribution
         ],
         welcomeCardConfig: {
           title: 'Welcome to Drips on Filecoin',
@@ -85,7 +85,7 @@ const EXPLORE_PAGE_CONFIG: ValueForEachSupportedChain<ExplorePageConfig> = {
     loadFn: (f) =>
       loadDefaultExplorePageData(f, {
         featuredDripListIds: [
-          '46441013481627019632859175771245733399752255312769848791334977723541',
+          '46441013481627019632859175771245733399752255312769848791334977723541', // Web3PrivacyNow list
         ],
       }),
   },

--- a/src/routes/(pages)/app/(app)/components/default-explore-page.svelte
+++ b/src/routes/(pages)/app/(app)/components/default-explore-page.svelte
@@ -12,7 +12,6 @@
   import tickStore from '$lib/stores/tick/tick.store';
   import Box from '$lib/components/icons/Box.svelte';
   import DripList from '$lib/components/icons/DripList.svelte';
-  import DripListCard from '$lib/components/drip-list-card/drip-list-card.svelte';
   import type {
     DefaultExplorePageFeaturedProjectFragment,
     ExplorePageFeaturedDripListsFragment,
@@ -24,6 +23,7 @@
   import RecentlyClaimedProjects from './recently-claimed-projects.svelte';
   import ProjectsGrid from './projects-grid.svelte';
   import { NETWORK_CONFIG } from '$lib/stores/wallet/network';
+  import DripListsGrid from './drip-lists-grid.svelte';
 
   export let projects: DefaultExplorePageFeaturedProjectFragment[];
   export let featuredProjectIds: string[] | undefined = undefined;
@@ -151,11 +151,7 @@
         loaded: true,
       }}
     >
-      <div class="drip-list-cards-grid">
-        {#each featuredDripLists as dripList}
-          <DripListCard listingMode data={{ dripList: dripList }} />
-        {/each}
-      </div>
+      <DripListsGrid dripLists={featuredDripLists} />
     </Section>
   {/if}
 
@@ -251,18 +247,5 @@
 
   .horizontal-scroll {
     overflow-x: auto;
-  }
-
-  .drip-list-cards-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(28rem, 1fr));
-    gap: 1rem;
-    padding: 4px 2px;
-  }
-
-  @media (max-width: 767px) {
-    .drip-list-cards-grid {
-      grid-template-columns: 1fr;
-    }
   }
 </style>

--- a/src/routes/(pages)/app/(app)/components/distribution-explore-page.svelte
+++ b/src/routes/(pages)/app/(app)/components/distribution-explore-page.svelte
@@ -8,13 +8,15 @@
   import walletStore from '$lib/stores/wallet/wallet.store';
   import type { DefaultExplorePageFeaturedProjectFragment } from './__generated__/gql.generated';
   import RecentlyClaimedProjects from './recently-claimed-projects.svelte';
-  import type { DripListCardFragment } from '$lib/components/drip-list-card/__generated__/gql.generated';
-  import DripListCard from '$lib/components/drip-list-card/drip-list-card.svelte';
   import network from '$lib/stores/wallet/network';
+  import Section from '$lib/components/section/section.svelte';
+  import DripListIcon from '$lib/components/icons/DripList.svelte';
+  import DripListsGrid from './drip-lists-grid.svelte';
+  import type { ComponentProps } from 'svelte';
 
   export let blogPosts: z.infer<typeof postsListingSchema>;
   export let projects: DefaultExplorePageFeaturedProjectFragment[] | null | undefined;
-  export let dripList: DripListCardFragment | null | undefined;
+  export let featuredDripLists: ComponentProps<DripListsGrid['dripLists']>;
   export let welcomeCard: {
     title: string;
     description: string;
@@ -26,36 +28,52 @@
 </script>
 
 <div class="explore">
-  {#if welcomeCard || dripList}
+  {#if welcomeCard}
     <div class="hero">
-      {#if welcomeCard}
-        <div class="welcome-card">
-          <div class="illustration">
-            <div class="background" />
-            <div class="filecoin-logo-wrapper">
-              <svelte:component this={network.icon} style="height: 3rem; width: 3rem;" />
-            </div>
-          </div>
-          <div class="content">
-            <div style:display="flex" style:flex-direction="column" style:gap="1rem">
-              <h1>{welcomeCard.title}</h1>
-              <p>{welcomeCard.description}</p>
-            </div>
-            {#if welcomeCard.docsButton}
-              {@const docsButton = welcomeCard.docsButton}
-              <div>
-                <Button href={docsButton.href} target="_blank" icon={ArrowBoxUpRight}
-                  >{docsButton.label}</Button
-                >
-              </div>
-            {/if}
+      <div class="welcome-card">
+        <div class="illustration">
+          <div class="background" />
+          <div class="filecoin-logo-wrapper">
+            <svelte:component this={network.icon} style="height: 3rem; width: 3rem;" />
           </div>
         </div>
-      {/if}
-      {#if dripList}
-        <DripListCard listingMode={true} data={{ dripList }} maxSplitRows={5} />
-      {/if}
+        <div class="content">
+          <div style:display="flex" style:flex-direction="column" style:gap="1rem">
+            <h1>{welcomeCard.title}</h1>
+            <p>{welcomeCard.description}</p>
+          </div>
+          {#if welcomeCard.docsButton}
+            {@const docsButton = welcomeCard.docsButton}
+            <div>
+              <Button href={docsButton.href} target="_blank" icon={ArrowBoxUpRight}
+                >{docsButton.label}</Button
+              >
+            </div>
+          {/if}
+        </div>
+      </div>
     </div>
+  {/if}
+
+  {#if featuredDripLists.length > 0}
+    <Section
+      header={{
+        icon: DripListIcon,
+        label: 'Featured Drip Lists',
+        actions: [
+          {
+            label: 'See all',
+            href: '/app/drip-lists/all',
+            icon: DripListIcon,
+          },
+        ],
+      }}
+      skeleton={{
+        loaded: true,
+      }}
+    >
+      <DripListsGrid dripLists={featuredDripLists} />
+    </Section>
   {/if}
 
   {#if projects}

--- a/src/routes/(pages)/app/(app)/components/distribution-explore-page.svelte
+++ b/src/routes/(pages)/app/(app)/components/distribution-explore-page.svelte
@@ -16,7 +16,7 @@
 
   export let blogPosts: z.infer<typeof postsListingSchema>;
   export let projects: DefaultExplorePageFeaturedProjectFragment[] | null | undefined;
-  export let featuredDripLists: ComponentProps<DripListsGrid['dripLists']>;
+  export let featuredDripLists: ComponentProps<DripListsGrid>['dripLists'];
   export let welcomeCard: {
     title: string;
     description: string;

--- a/src/routes/(pages)/app/(app)/components/drip-lists-grid.svelte
+++ b/src/routes/(pages)/app/(app)/components/drip-lists-grid.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import DripListCard from '$lib/components/drip-list-card/drip-list-card.svelte';
+  import type { ComponentProps } from 'svelte';
+
+  export let dripLists: ComponentProps<DripListCard>['data']['dripList'][];
+</script>
+
+<div class="drip-list-cards-grid">
+  {#each dripLists as dripList}
+    <DripListCard listingMode data={{ dripList: dripList }} />
+  {/each}
+</div>
+
+<style>
+  .drip-list-cards-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(28rem, 1fr));
+    gap: 1rem;
+    padding: 4px 2px;
+  }
+
+  @media (max-width: 767px) {
+    .drip-list-cards-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/src/routes/(pages)/app/(app)/components/load-distribution-explore-page-data.ts
+++ b/src/routes/(pages)/app/(app)/components/load-distribution-explore-page-data.ts
@@ -6,7 +6,7 @@ import { createFetchProjectsParameters, fetchProjects, fetchProjectsQuery } from
 import { featuredDripListQuery, fetchList } from './load-drip-list';
 import type { ComponentProps } from 'svelte';
 import type DistributionExplorePage from './distribution-explore-page.svelte';
-import filterFalseish from '$lib/utils/filter-falseish';
+import filterFalsy from '$lib/utils/filter-falsy';
 
 type PageProps = ComponentProps<DistributionExplorePage>;
 
@@ -42,7 +42,7 @@ export default async function loadDistributionExplorePageData(
   return {
     blogPosts,
     projects,
-    featuredDripLists: filterFalseish(featuredDripLists),
+    featuredDripLists: filterFalsy(featuredDripLists),
     welcomeCard: welcomeCardConfig,
   };
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "sourceMap": true,
     "strict": true,
     "types": ["vitest/globals", "@testing-library/jest-dom"]
-  }
+  },
   // Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias
   //
   // If you want to overwrite includes/excludes, make sure to copy over the relevant includes/excludes


### PR DESCRIPTION
Removes the right-hand single featured list on the distribution explore page variant and replaces it with the standard "Featured Drip Lists" section.

Features both RGPF distribution lists on Filecoin that exist at the moment.