### PR TITLE
sprinkler in dev env, fix testnet data retention, create drip list test, run headless tests against prod build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@ node_modules
 docs
 docker
 !docker/dev-entrypoint.sh
+!docker/e2e-entrypoint.sh
 Dockerfile
 Dockerfile.dev
 .git

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -20,5 +20,8 @@ RUN rm -rf .svelte-kit
 EXPOSE 5173
 
 COPY ./docker/dev-entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY ./docker/e2e-entrypoint.sh /usr/local/bin/e2e-entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/e2e-entrypoint.sh
+
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -9,7 +9,7 @@ services:
 
   testnet:
     volumes:
-      - anvil-data:/anvil-data
+      - anvil-data:/contracts/anvil-data
 
   pgadmin:
     image: dpage/pgadmin4

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -1,2 +1,3 @@
 services:
   app:
+    entrypoint: ["/usr/local/bin/e2e-entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,9 @@ services:
       - PUBLIC_USE_LOCAL_TESTNET_WALLET_STORE=${APP_USE_LOCAL_TESTNET_WALLET_STORE-false}
       - LOCAL_UID=${LOCAL_UID-root}
       - LOCAL_GID=${LOCAL_GID-root}
+      - PUBLIC_BASE_URL=http://localhost:5173
+      - PUBLIC_PORT=5173
+      - PUBLIC_SUPPRESS_MISSING_VAR_IN_PROD_ERRORS=true
     volumes:
     - .:/app
     - /app/node_modules/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,7 +93,7 @@ services:
       retries: 5
 
   testnet:
-    image: 'j537/contracts:${CONTRACTS_TAG-sha-501c7ff}-${ARCH}'
+    image: 'j537/contracts:${CONTRACTS_TAG-sha-7530976}-${ARCH}'
     pull_policy: always
     ports:
       - '8545:8545'

--- a/docker/e2e-entrypoint.sh
+++ b/docker/e2e-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+printf "\n   _____ __  __ \n"
+printf "  / ____|  \/  |\n"
+printf " | |  __| \  / |\n"
+printf " | | |_ | |\/| |\n"
+printf " | |__| | |  | |\n"
+printf "  \_____|_|  |_|\n\n"
+
+printf "\n🏗️ Building app...\n"
+npm run build
+
+npm run preview -- --host 0.0.0.0 --port 5173

--- a/docker/sprinkle.sh
+++ b/docker/sprinkle.sh
@@ -1,23 +1,2 @@
-
-while [ "$1" != "" ]; do
-  case $1 in
-    --rpcUrl )
-      shift
-      rpcUrl=$1
-      ;;
-    --privateKey )
-      shift
-      privateKey=$1
-      ;;
-    --chainId )
-      chainId=true
-      ;;
-    * )
-      echo "Invalid argument: $1"
-      exit 1
-  esac
-  shift
-done
-
 docker pull j537/sprinkler:main
 exec docker run --rm -e SHOULD_RUN=true -e CHAIN_ID=31337 -e WALLET_PRIVATE_KEY=2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6 -e RPC_URL=http://localhost:8545 -e POSTGRES_CONNECTION_STRING=postgresql://user:admin@localhost:54320/dripsdb --network host j537/sprinkler:main

--- a/docker/sprinkle.sh
+++ b/docker/sprinkle.sh
@@ -1,0 +1,23 @@
+
+while [ "$1" != "" ]; do
+  case $1 in
+    --rpcUrl )
+      shift
+      rpcUrl=$1
+      ;;
+    --privateKey )
+      shift
+      privateKey=$1
+      ;;
+    --chainId )
+      chainId=true
+      ;;
+    * )
+      echo "Invalid argument: $1"
+      exit 1
+  esac
+  shift
+done
+
+docker pull j537/sprinkler:main
+exec docker run --rm -e SHOULD_RUN=true -e CHAIN_ID=31337 -e WALLET_PRIVATE_KEY=2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6 -e RPC_URL=http://localhost:8545 -e POSTGRES_CONNECTION_STRING=postgresql://user:admin@localhost:54320/dripsdb --network host j537/sprinkler:main

--- a/docker/start-e2e.sh
+++ b/docker/start-e2e.sh
@@ -2,6 +2,7 @@
 set -eu
 
 UI=false
+PROD_BUILD=false
 
 cleanup() {
     docker compose -f docker-compose.yml rm -fsv
@@ -12,6 +13,10 @@ touch .env
 
 if [[ $* == *--start-playwright-ui* ]]; then
     UI=true
+fi
+
+if [[ $* == *--prod-build* ]]; then
+    PROD_BUILD=true
 fi
 
 ARCH=$(uname -m)
@@ -31,7 +36,13 @@ export ARCH
 
 export LOCAL_UID=$(id -u)
 export LOCAL_GID=$(id -g)
-docker compose build && APP_USE_LOCAL_TESTNET_WALLET_STORE=true docker compose -f docker-compose.yml up --renew-anon-volumes --detach
+
+if [ $PROD_BUILD = true ]; then
+  docker compose build && APP_USE_LOCAL_TESTNET_WALLET_STORE=true docker compose -f docker-compose.yml -f docker-compose.e2e.yml up --renew-anon-volumes --detach
+else
+  docker compose build && APP_USE_LOCAL_TESTNET_WALLET_STORE=true docker compose -f docker-compose.yml up --renew-anon-volumes --detach
+fi
+
 
 printf "⏳ Waiting for the app to start..."
 

--- a/docker/start-e2e.sh
+++ b/docker/start-e2e.sh
@@ -44,7 +44,7 @@ printf "\n✅ The app is ready!\n"
 printf "\n🚀 Running tests..."
 
 if [ $UI = true ]; then
-  npx playwright test --ui &
+  npx playwright test --ui-port 0 &
   docker compose logs app --follow
 else
   npx playwright test

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -52,6 +52,10 @@ To claim a project during local dev mode:
 - Right after, run `npm run dev:docker:update-repo-owner`. You will be prompted to submit the account ID of the project you want to claim, and the address that should be set as its owner. Enter the address you previously configured in `FUNDING.json` for `localtestnet`.
 - Submit, and the fake oracle will update the owner of the project to the address you specified. The claim flow will continue.
 
+### 💦 Triggering a settlement event
+
+On production networks, funds on Drips donated to projects and Drip Lists are automatically `split` with recipients using (Sprinkler)[https://github.com/drips-network/sprinkler]. You can manually trigger settlement on your local environment by running `npm run dev:docker:sprinkle`. It will automatically detect TEST sitting Drip Lists or projects, and split them to recipients.
+
 ## 🥸 Inspecting databases with PGAdmin
 
 The docker-compose file also spins up pgadmin for you, running at port 5050. Simply open http://localhost:5050 and open the database you're interested in (either the event-processor DB or multiplayer DB). When prompted for the password, enter `admin`.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "preview": "vite preview",
     "test:unit": "vitest run unit",
     "test:e2e": "./docker/start-e2e.sh --start-playwright-ui",
-    "test:e2e:headless": "./docker/start-e2e.sh",
+    "test:e2e:headless": "./docker/start-e2e.sh --prod-build",
     "coverage": "vitest run --coverage",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev:docker": "./docker/start-dev.sh",
     "dev:docker:clear": "docker compose -f docker-compose.yml -f docker-compose.dev.yml down -v",
     "dev:docker:update-repo-owner": "./docker/update-repo-owner.sh",
+    "dev:docker:sprinkle": "./docker/sprinkle.sh",
     "preview": "vite preview",
     "test:unit": "vitest run unit",
     "test:e2e": "./docker/start-e2e.sh --start-playwright-ui",

--- a/src/lib/components/date-picker/DateInput.svelte
+++ b/src/lib/components/date-picker/DateInput.svelte
@@ -173,6 +173,7 @@
 <!-- svelte-ignore a11y-no-static-element-interactions -->
 <div class="date-time-field {classes}" on:focusout={onFocusOut} on:keydown={keydown}>
   <TextInput
+    testId="date-time-field"
     bind:inputElement={InputElement}
     validationState={valid ? { type: 'valid' } : { type: 'invalid', message: 'Invalid date' }}
     value={text}

--- a/src/lib/components/list-editor/components/list-editor-input.svelte
+++ b/src/lib/components/list-editor/components/list-editor-input.svelte
@@ -230,6 +230,7 @@
     <List style="fill: var(--color-foreground)" />
   {/if}
   <input
+    data-testid="list-editor-input"
     bind:this={inputElem}
     on:keydown={handleKeydown}
     on:paste={handlePaste}

--- a/src/lib/components/text-input/text-input.svelte
+++ b/src/lib/components/text-input/text-input.svelte
@@ -24,6 +24,8 @@
   export let showSuccessCheck = false;
   export let showClearButton = false;
 
+  export let testId: string | undefined = undefined;
+
   export let icon: ComponentType | undefined = undefined;
 
   export let inputStyle: string | undefined = undefined;
@@ -102,6 +104,7 @@
     autocapitalize={autocapitalize ? 'on' : 'off'}
     autocorrect={autocorrect ? 'on' : 'off'}
     lang="en-001"
+    data-testid={testId}
   />
 
   <div class="right-container" bind:clientWidth={rightContainerWidth}>

--- a/src/lib/graphql/dripsQL.ts
+++ b/src/lib/graphql/dripsQL.ts
@@ -4,6 +4,9 @@ import { GraphQLClient, type RequestDocument, type Variables } from 'graphql-req
 import { addTypenameToDocument } from '@apollo/client/utilities';
 import { BASE_URL } from '$lib/utils/base-url';
 import { browser, dev } from '$app/environment';
+import getOptionalEnvVar from '$lib/utils/get-optional-env-var/public';
+
+const PORT = getOptionalEnvVar('PUBLIC_PORT', false, null);
 
 export default async function query<TResponse, TVariables extends Variables = Variables>(
   query: RequestDocument,
@@ -16,7 +19,8 @@ export default async function query<TResponse, TVariables extends Variables = Va
   // If we're on the server in prod, we use localhost in order for traffic to stay within the container
   // and avoid network overhead.
   // IMPORTANT: This assumes the app is running on port 8080 in the container, which should usually be the case.
-  const endpointLocation = browser || dev ? `${BASE_URL}/api/gql` : 'http://localhost:8080/api/gql';
+  const endpointLocation =
+    browser || dev ? `${BASE_URL}/api/gql` : `http://localhost:${PORT ?? '8080'}/api/gql`;
 
   const client = new GraphQLClient(endpointLocation, {
     fetch: customFetch,

--- a/src/lib/utils/get-optional-env-var/access-optional-env-var.ts
+++ b/src/lib/utils/get-optional-env-var/access-optional-env-var.ts
@@ -20,7 +20,9 @@ export default function accessOptionalEnvVar(
 
   const needProdEnvVars = !(dev || building);
 
-  const surpressMissingVarErrors = publicEnv.PUBLIC_SUPPRESS_MISSING_VAR_IN_PROD_ERRORS === 'true';
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const surpressMissingVarErrors =
+    (publicEnv as any).PUBLIC_SUPPRESS_MISSING_VAR_IN_PROD_ERRORS === 'true';
 
   if (needProdEnvVars && requiredInProd && !surpressMissingVarErrors && varMissing) {
     throw new Error(`${varName} env var is required in production! ${{ dev, building }}`);

--- a/src/lib/utils/get-optional-env-var/access-optional-env-var.ts
+++ b/src/lib/utils/get-optional-env-var/access-optional-env-var.ts
@@ -1,4 +1,5 @@
 import { building, dev } from '$app/environment';
+import * as publicEnv from '$env/static/public';
 
 /**
  * **DO NOT use this directly, instead import `getOptionalEnvVar` from either `private.ts` or `public.ts` in this dir.**
@@ -19,7 +20,9 @@ export default function accessOptionalEnvVar(
 
   const needProdEnvVars = !(dev || building);
 
-  if (needProdEnvVars && requiredInProd && varMissing) {
+  const surpressMissingVarErrors = publicEnv.PUBLIC_SUPPRESS_MISSING_VAR_IN_PROD_ERRORS === 'true';
+
+  if (needProdEnvVars && requiredInProd && !surpressMissingVarErrors && varMissing) {
     throw new Error(`${varName} env var is required in production! ${{ dev, building }}`);
   } else if (dev && varMissing) {
     const errorMessage = errorMessageIfMissingInDev

--- a/tests/claim-project.spec.ts
+++ b/tests/claim-project.spec.ts
@@ -10,20 +10,20 @@ test('claim project flow', async ({ page }) => {
   await page.getByRole('button', { name: 'Connect', exact: true }).click();
   await page.getByRole('link', { name: 'Projects' }).click();
   await page.getByRole('button', { name: 'Claim project' }).click();
-  await page.getByRole('button', { name: 'Continue' }).click();
+  await page.getByRole('button', { name: 'Continue' }).nth(0).click();
   await page.getByRole('textbox', { name: 'Paste your GitHub project URL' }).click();
   await page
     .getByRole('textbox', { name: 'Paste your GitHub project URL' })
     .fill('github.com/efstajas/drips-test-repo-10');
   await page.getByRole('textbox', { name: 'Paste your GitHub project URL' }).press('Enter');
-  await page.getByRole('button', { name: 'Continue' }).click();
+  await page.getByRole('button', { name: 'Continue' }).nth(0).click();
   await page.getByText('I edited the FUNDING.json file').click();
   await page.getByRole('button', { name: 'Verify now' }).click();
   await page.getByRole('textbox').first().click();
   await page.getByRole('textbox').first().fill('100');
   await page.getByRole('textbox').first().press('Enter');
-  await page.getByRole('button', { name: 'Continue' }).click();
-  await page.getByRole('button', { name: 'Continue' }).click();
+  await page.getByRole('button', { name: 'Continue' }).nth(0).click();
+  await page.getByRole('button', { name: 'Continue' }).nth(0).click();
   await page.getByRole('button', { name: 'Confirm in wallet' }).click();
 
   await expect(page.getByTestId('current-tx')).toContainText('Finalizing verification', {
@@ -34,7 +34,7 @@ test('claim project flow', async ({ page }) => {
 
   await expect(page.getByText('Set project splits and metadata')).toBeVisible();
 
-  await page.getByRole('button', { name: 'Continue' }).click({ timeout: 120_000 });
+  await page.getByRole('button', { name: 'Continue' }).nth(0).click({ timeout: 120_000 });
   await page.getByRole('button', { name: 'View project profile' }).click();
 
   await page.waitForURL(

--- a/tests/create-drip-list.spec.ts
+++ b/tests/create-drip-list.spec.ts
@@ -5,8 +5,7 @@ test('create a drip list', async ({ page }) => {
 
   page.emulateMedia({ reducedMotion: 'reduce' });
 
-  await page.goto('http://localhost:5173/');
-  await page.getByRole('link', { name: 'Open app' }).click();
+  await page.goto('http://localhost:5173/app');
   await page.getByRole('button', { name: 'Connect', exact: true }).click();
   await page.getByRole('link', { name: 'Drip Lists' }).click();
   await page.getByRole('button', { name: 'Create Drip List' }).click();
@@ -71,7 +70,7 @@ test('create collaborative drip list', async ({ page }) => {
 
   page.emulateMedia({ reducedMotion: 'reduce' });
 
-  await page.goto('http://localhost:5173/');
+  await page.goto('http://localhost:5173/app');
   await page.getByRole('link', { name: 'Open app' }).click();
   await page.getByRole('button', { name: 'Connect', exact: true }).click();
   await page.getByRole('link', { name: 'Drip Lists' }).click();

--- a/tests/create-drip-list.spec.ts
+++ b/tests/create-drip-list.spec.ts
@@ -21,7 +21,7 @@ test('create a drip list', async ({ page }) => {
       exact: true,
     })
     .click();
-  await page.getByRole('button', { name: 'Continue' }).click();
+  await page.getByRole('button', { name: 'Continue' }).nth(0).click();
   await page.getByRole('textbox').click();
   await page.getByRole('textbox').fill('github.com/efstajas/drips-test-repo-10');
   await page.getByRole('textbox').press('Enter');
@@ -50,10 +50,10 @@ test('create a drip list', async ({ page }) => {
     .getByTestId('item-80921553623925136102837120782793736893291544351678576578072673071408')
     .getByRole('spinbutton')
     .press('Enter');
-  await page.getByRole('button', { name: 'Continue' }).click();
+  await page.getByRole('button', { name: 'Continue' }).nth(0).click();
   await page.getByRole('button', { name: 'Support later' }).click();
   await page.getByRole('button', { name: 'Confirm in wallet' }).click();
-  await page.getByRole('button', { name: 'Continue' }).click({ timeout: 120_000 });
+  await page.getByRole('button', { name: 'Continue' }).nth(0).click({ timeout: 120_000 });
   await page.getByRole('button', { name: 'View your Drip List' }).click();
 
   await page.waitForURL('http://localhost:5173/app/drip-lists/*');
@@ -86,7 +86,7 @@ test('create collaborative drip list', async ({ page }) => {
       exact: true,
     })
     .click();
-  await page.getByRole('button', { name: 'Continue' }).click();
+  await page.getByRole('button', { name: 'Continue' }).nth(0).click();
   await page.getByRole('textbox', { name: 'Add Collaborators* Import' }).click();
   await page.getByRole('textbox', { name: 'Add Collaborators* Import' }).click();
   await page
@@ -105,7 +105,7 @@ test('create collaborative drip list', async ({ page }) => {
     .getByTestId('date-time-field')
     .fill(inCurrentTimezone.toISOString().slice(0, 19).replace('T', ' '));
 
-  await page.getByRole('button', { name: 'Continue' }).click();
+  await page.getByRole('button', { name: 'Continue' }).nth(0).click();
   await page.getByRole('button', { name: 'Confirm in wallet' }).click();
   await page.getByRole('button', { name: 'View your Drip List' }).click();
   await page.getByRole('button', { name: 'Cast your vote' }).click();
@@ -145,7 +145,7 @@ test('create collaborative drip list', async ({ page }) => {
 
   await page.getByRole('button', { name: 'Publish Drip List' }).nth(1).click({ timeout: 120_000 });
   await page.getByRole('button', { name: 'Confirm in wallet' }).click();
-  await page.getByRole('button', { name: 'Continue' }).click({ timeout: 120_000 });
+  await page.getByRole('button', { name: 'Continue' }).nth(0).click({ timeout: 120_000 });
   await page.getByRole('button', { name: 'Got it' }).click();
 
   await expect(page.getByText('this list is in voting').nth(0)).not.toBeVisible();

--- a/tests/create-drip-list.spec.ts
+++ b/tests/create-drip-list.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from '@playwright/test';
+
+test('create a drip list', async ({ page }) => {
+  test.setTimeout(240_000);
+
+  page.emulateMedia({ reducedMotion: 'reduce' });
+
+  await page.goto('http://localhost:5173/');
+  await page.getByRole('link', { name: 'Open app' }).click();
+  await page.getByRole('button', { name: 'Connect', exact: true }).click();
+  await page.getByRole('link', { name: 'Drip Lists' }).click();
+  await page.getByRole('button', { name: 'Create Drip List' }).click();
+  await page.getByRole('textbox', { name: 'Title*' }).press('ControlOrMeta+a');
+  await page.getByRole('textbox', { name: 'Title*' }).fill('E2E test list');
+  await page.getByRole('textbox', { name: 'Description' }).click();
+  await page
+    .getByRole('textbox', { name: 'Description' })
+    .fill('This is the description right here!');
+  await page
+    .getByRole('radio', {
+      name: 'Collaborate on recipients Invite collaborators to decide together Set a voting period Publish your list after voting Recipients*',
+      exact: true,
+    })
+    .click();
+  await page.getByRole('button', { name: 'Continue' }).click();
+  await page.getByRole('textbox').click();
+  await page.getByRole('textbox').fill('github.com/efstajas/drips-test-repo-10');
+  await page.getByRole('textbox').press('Enter');
+  await page.getByRole('textbox').click();
+  await page.getByRole('textbox').fill('0x70997970C51812dc3A010C7d01b50e0d17dc79C8');
+  await page.getByRole('textbox').press('Enter');
+  await page.getByRole('button', { name: 'Clear' }).click();
+  await page
+    .getByTestId('item-642829559307850963015472508762062935916233390536')
+    .getByText('0', { exact: true })
+    .click();
+  await page
+    .getByTestId('item-642829559307850963015472508762062935916233390536')
+    .getByRole('spinbutton')
+    .fill('60');
+  await page
+    .getByTestId('item-642829559307850963015472508762062935916233390536')
+    .getByRole('spinbutton')
+    .press('Enter');
+  await page.getByText('0', { exact: true }).click();
+  await page
+    .getByTestId('item-80921553623925136102837120782793736893291544351678576578072673071408')
+    .getByRole('spinbutton')
+    .fill('40');
+  await page
+    .getByTestId('item-80921553623925136102837120782793736893291544351678576578072673071408')
+    .getByRole('spinbutton')
+    .press('Enter');
+  await page.getByRole('button', { name: 'Continue' }).click();
+  await page.getByRole('button', { name: 'Support later' }).click();
+  await page.getByRole('button', { name: 'Confirm in wallet' }).click();
+  await page.getByRole('button', { name: 'Continue' }).click({ timeout: 120_000 });
+  await page.getByRole('button', { name: 'View your Drip List' }).click();
+
+  await page.waitForURL('http://localhost:5173/app/drip-lists/*');
+
+  await expect(page.getByText('drips-test-repo-10').nth(0)).toBeVisible();
+  await expect(page.getByText('E2E test list').nth(0)).toBeVisible();
+  await expect(page.getByText('This is the description right here!').nth(0)).toBeVisible();
+  await expect(page.getByText('60%').nth(0)).toBeVisible();
+  await expect(page.getByText('40%').nth(0)).toBeVisible();
+});

--- a/tests/create-drip-list.spec.ts
+++ b/tests/create-drip-list.spec.ts
@@ -65,3 +65,92 @@ test('create a drip list', async ({ page }) => {
   await expect(page.getByText('60%').nth(0)).toBeVisible();
   await expect(page.getByText('40%').nth(0)).toBeVisible();
 });
+
+test('create collaborative drip list', async ({ page }) => {
+  test.setTimeout(240_000);
+
+  page.emulateMedia({ reducedMotion: 'reduce' });
+
+  await page.goto('http://localhost:5173/');
+  await page.getByRole('link', { name: 'Open app' }).click();
+  await page.getByRole('button', { name: 'Connect', exact: true }).click();
+  await page.getByRole('link', { name: 'Drip Lists' }).click();
+  await page.getByRole('button', { name: 'Create Drip List' }).click();
+  await page.getByRole('textbox', { name: 'Title*' }).press('ControlOrMeta+a');
+  await page.getByRole('textbox', { name: 'Title*' }).fill('Test collaborative list');
+  await page.getByRole('textbox', { name: 'Title*' }).press('Tab');
+  await page
+    .getByRole('textbox', { name: 'Description' })
+    .fill('This is a test for a collaborative drip list');
+  await page
+    .getByRole('radio', {
+      name: 'Collaborate on recipients Invite collaborators to decide together Set a voting period Publish your list after voting',
+      exact: true,
+    })
+    .click();
+  await page.getByRole('button', { name: 'Continue' }).click();
+  await page.getByRole('textbox', { name: 'Add Collaborators* Import' }).click();
+  await page.getByRole('textbox', { name: 'Add Collaborators* Import' }).click();
+  await page
+    .getByRole('textbox', { name: 'Add Collaborators* Import' })
+    .fill('0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266');
+  await page.getByRole('textbox', { name: 'Add Collaborators* Import' }).press('Enter');
+
+  const currentTime = new Date();
+  const in15Seconds = new Date(currentTime.getTime() + 15 * 1000);
+  const inCurrentTimezone = new Date(
+    in15Seconds.getTime() - in15Seconds.getTimezoneOffset() * 60000,
+  );
+
+  // fill in the date and time in `YYYY-MM-DD HH:MM:SS` format
+  await page
+    .getByTestId('date-time-field')
+    .fill(inCurrentTimezone.toISOString().slice(0, 19).replace('T', ' '));
+
+  await page.getByRole('button', { name: 'Continue' }).click();
+  await page.getByRole('button', { name: 'Confirm in wallet' }).click();
+  await page.getByRole('button', { name: 'View your Drip List' }).click();
+  await page.getByRole('button', { name: 'Cast your vote' }).click();
+  await page.getByRole('textbox', { name: 'Add' }).click();
+  await page.getByRole('textbox', { name: 'Add' }).fill('github.com/efstajas/drips-test-repo-10');
+  await page.getByRole('textbox', { name: 'Add' }).press('Enter');
+  await page
+    .getByRole('textbox', { name: 'Add' })
+    .fill('0x70997970C51812dc3A010C7d01b50e0d17dc79C8');
+  await page.getByRole('textbox', { name: 'Add' }).press('Enter');
+  await page.getByRole('button', { name: 'Clear' }).click();
+  await page
+    .getByTestId('item-642829559307850963015472508762062935916233390536')
+    .getByText('0', { exact: true })
+    .click();
+  await page
+    .getByTestId('item-642829559307850963015472508762062935916233390536')
+    .getByRole('spinbutton')
+    .fill('30');
+  await page
+    .getByTestId('item-80921553623925136102837120782793736893291544351678576578072673071408')
+    .getByText('0', { exact: true })
+    .click();
+  await page
+    .getByTestId('item-80921553623925136102837120782793736893291544351678576578072673071408')
+    .getByRole('spinbutton')
+    .fill('70');
+  await page
+    .getByTestId('item-80921553623925136102837120782793736893291544351678576578072673071408')
+    .getByRole('spinbutton')
+    .press('Enter');
+  await page.getByRole('button', { name: 'Confirm in wallet' }).click();
+  await page.getByRole('button', { name: 'Got it' }).click();
+  await page.getByRole('button', { name: 'Share with collaborators' }).click();
+  await page.getByRole('button', { name: 'Copy link' }).click();
+  await page.getByRole('button').filter({ hasText: /^$/ }).click();
+
+  await page.getByRole('button', { name: 'Publish Drip List' }).nth(1).click({ timeout: 120_000 });
+  await page.getByRole('button', { name: 'Confirm in wallet' }).click();
+  await page.getByRole('button', { name: 'Continue' }).click({ timeout: 120_000 });
+  await page.getByRole('button', { name: 'Got it' }).click();
+
+  await expect(page.getByText('this list is in voting').nth(0)).not.toBeVisible();
+  await expect(page.getByText('Test collaborative list').nth(0)).toBeVisible();
+  await expect(page.getByText('This is a test for a collaborative drip list').nth(0)).toBeVisible();
+});

--- a/tests/create-drip-list.spec.ts
+++ b/tests/create-drip-list.spec.ts
@@ -71,7 +71,6 @@ test('create collaborative drip list', async ({ page }) => {
   page.emulateMedia({ reducedMotion: 'reduce' });
 
   await page.goto('http://localhost:5173/app');
-  await page.getByRole('link', { name: 'Open app' }).click();
   await page.getByRole('button', { name: 'Connect', exact: true }).click();
   await page.getByRole('link', { name: 'Drip Lists' }).click();
   await page.getByRole('button', { name: 'Create Drip List' }).click();

--- a/tests/create-drip-list.spec.ts
+++ b/tests/create-drip-list.spec.ts
@@ -22,12 +22,12 @@ test('create a drip list', async ({ page }) => {
     })
     .click();
   await page.getByRole('button', { name: 'Continue' }).nth(0).click();
-  await page.getByRole('textbox').click();
-  await page.getByRole('textbox').fill('github.com/efstajas/drips-test-repo-10');
-  await page.getByRole('textbox').press('Enter');
-  await page.getByRole('textbox').click();
-  await page.getByRole('textbox').fill('0x70997970C51812dc3A010C7d01b50e0d17dc79C8');
-  await page.getByRole('textbox').press('Enter');
+  await page.getByTestId('list-editor-input').click();
+  await page.getByTestId('list-editor-input').fill('github.com/efstajas/drips-test-repo-10');
+  await page.getByTestId('list-editor-input').press('Enter');
+  await page.getByTestId('list-editor-input').click();
+  await page.getByTestId('list-editor-input').fill('0x70997970C51812dc3A010C7d01b50e0d17dc79C8');
+  await page.getByTestId('list-editor-input').press('Enter');
   await page.getByRole('button', { name: 'Clear' }).click();
   await page
     .getByTestId('item-642829559307850963015472508762062935916233390536')


### PR DESCRIPTION
Fixes a bug with the local docker env where testnet chain state would not be persisted between runs of the local env.

Also adds `npm run dev:docker:sprinkle` command, which runs `sprinkler` against the local env. This can be used for full e2e test including making donations & collecting earnings later.

also adds (basic) specs for creating drip lists (normal & collaborative)

AND ALSO it now runs the headless tests against a real production build of the app, rather than dev server.