### PR TITLE
automatically refresh supporters section after OTD

### DIFF
--- a/src/lib/flows/create-donation/input-details.svelte
+++ b/src/lib/flows/create-donation/input-details.svelte
@@ -96,6 +96,7 @@
     createDonation(
       dispatch,
       recipientAccountId,
+      receiver.__typename,
       selectedTokenAddress ?? unreachable(),
       amount ?? unreachable(),
       selectedTokenAllowance ?? unreachable(),


### PR DESCRIPTION
Makes it so that one-time donations immediately appear on a drip list / project page after being sent, no need to manually refresh