### PR TITLE
improve health endpoint

### DIFF
--- a/src/lib/utils/FailoverJsonRpcProvider.ts
+++ b/src/lib/utils/FailoverJsonRpcProvider.ts
@@ -93,6 +93,7 @@ export default class FailoverJsonRpcProvider extends JsonRpcProvider {
         }
 
         request.body = JSON.stringify(payload);
+        request.timeout = 10000; // 10 seconds
         request.setHeader('content-type', 'application/json');
 
         const response = await request.send();

--- a/src/routes/api/health/+server.ts
+++ b/src/routes/api/health/+server.ts
@@ -1,24 +1,76 @@
+/* eslint-disable no-console */
+
 import query from '$lib/graphql/dripsQL';
+import network from '$lib/stores/wallet/network';
+import FailoverJsonRpcProvider from '$lib/utils/FailoverJsonRpcProvider';
+import mapFilterUndefined from '$lib/utils/map-filter-undefined';
 import { error } from '@sveltejs/kit';
 
-export const GET = async () => {
-  // simple ping endpoint for downtime-less deploys. railway will hit this and wait for 200
-  // before directing traffic to a newly built container
-  // checks whether the API can be reached. This is important because private IPV6 networking
-  // in Railway needs a few seconds to start up after a deploy
-
+async function checkGqlApi() {
   const testQuery = `
     query Test {
       __typename
     }
   `;
 
-  try {
-    await query(testQuery);
-    return new Response('OK');
-  } catch (e) {
-    // eslint-disable-next-line no-console
-    console.error('Health endpoint error', e);
-    return error(500);
+  await query(testQuery);
+}
+
+async function checkRpc() {
+  const provider = new FailoverJsonRpcProvider(
+    mapFilterUndefined([network.rpcUrl, network.fallbackRpcUrl], (url) => url),
+    undefined,
+    undefined,
+    {
+      logger: console,
+    },
+  );
+
+  await provider.getBlockNumber();
+}
+
+async function checkLp(f: typeof fetch) {
+  await f('/', { signal: AbortSignal.timeout(10000) });
+}
+
+async function checkExplore(f: typeof fetch) {
+  await f('/app', { signal: AbortSignal.timeout(10000) });
+}
+
+export const GET = async ({ fetch }) => {
+  console.log('Health check started');
+
+  const checks = [
+    { name: 'GraphQL API', fn: checkGqlApi },
+    { name: 'RPC', fn: checkRpc },
+    { name: 'Landing Page', fn: () => checkLp(fetch) },
+    { name: 'Explore', fn: () => checkExplore(fetch) },
+  ];
+
+  const results = await Promise.allSettled(
+    checks.map(async ({ name, fn }) => {
+      const start = performance.now();
+      try {
+        await fn();
+        const duration = performance.now() - start;
+        console.log(`- ${name} check completed in ${duration.toFixed(2)}ms`);
+        return { name, duration };
+      } catch (err) {
+        const duration = performance.now() - start;
+        console.error(`- ${name} check failed in ${duration.toFixed(2)}ms`, err);
+        throw { name, error: err, duration };
+      }
+    }),
+  );
+
+  const errors = results
+    .map((result) => (result.status === 'rejected' ? result.reason : null))
+    .filter((error) => error !== null);
+
+  if (errors.length > 0) {
+    console.error('Health endpoint request failed. Errors:', JSON.stringify(errors));
+    return error(500, JSON.stringify({ errors }));
   }
+
+  return new Response('OK');
 };

--- a/src/routes/api/health/+server.ts
+++ b/src/routes/api/health/+server.ts
@@ -17,6 +17,9 @@ async function checkGqlApi() {
 }
 
 async function checkRpc() {
+  // skip this check on localtestnet
+  if (network.chainId === 31337) return;
+
   const provider = new FailoverJsonRpcProvider(
     mapFilterUndefined([network.rpcUrl, network.fallbackRpcUrl], (url) => url),
     undefined,


### PR DESCRIPTION
improve the /api/health endpoint with additional checks:
- RPC provider successfully returns latest block
- explore page loads
- LP loads
- gqlApi responds

also sets a 10s max timeout before FailoverJsonRpcProvider will abort & retry with backup RPC.