### PR TITLE
remove excessive error logs

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,27 +1,5 @@
-import { sequence } from '@sveltejs/kit/hooks';
-import { sentryHandle } from '@sentry/sveltekit';
-import * as Sentry from '@sentry/sveltekit';
-import { nodeProfilingIntegration } from '@sentry/profiling-node';
-import getOptionalEnvVar from '$lib/utils/get-optional-env-var/public';
 import { PuppeteerManager } from '$lib/utils/puppeteer';
-
-const dsn = getOptionalEnvVar('PUBLIC_SENTRY_DSN', false, null);
-
-if (dsn) {
-  Sentry.init({
-    dsn,
-    tracesSampleRate: 0.1,
-    profilesSampleRate: 0.1,
-    integrations: [nodeProfilingIntegration()],
-  });
-}
 
 PuppeteerManager.launch({
   args: ['--no-sandbox', '--disable-setuid-sandbox'],
-});
-
-export const handle = sequence(sentryHandle());
-export const handleError = Sentry.handleErrorWithSentry(function (error: unknown) {
-  // eslint-disable-next-line no-console
-  console.error('Uncaught error', error);
 });


### PR DESCRIPTION
SvelteKit already logs unexpected uncaught errors to the console by default. We don't need to log all errors, as this will cause e.g. 404s to result in a large trace being printed to console.

Also removes the Sentry integration (temporalily?) as we don't use it ATM.