### PR TITLE
Fix typo in footer for the github repository

### DIFF
--- a/src/routes/(pages)/(lp)/components/lp-footer.svelte
+++ b/src/routes/(pages)/(lp)/components/lp-footer.svelte
@@ -8,7 +8,7 @@
   <div class="column">
     <h5>Drips</h5>
     <a rel="noreferrer" target="_blank" href="https://docs.drips.network">Docs</a>
-    <a rel="noreferrer" target="_blank" href="https://github.com/dripsnetwork">Code on GitHub</a>
+    <a rel="noreferrer" target="_blank" href="https://github.com/drips-network">Code on GitHub</a>
     <a rel="noreferrer" target="_blank" href="https://github.com/drips-network/app/issues/new"
       >Report a bug</a
     >


### PR DESCRIPTION
Found this small typo while looking at your cool project.