### PR TITLE
fix some ecosystems spec flakiness

### DIFF
--- a/src/routes/(pages)/app/(app)/ecosystems/components/ecosystem-card.svelte
+++ b/src/routes/(pages)/app/(app)/ecosystems/components/ecosystem-card.svelte
@@ -31,7 +31,11 @@
   $: projectsCountFormatted = formatNumber(ecosystem.nodeCount ?? 0);
 </script>
 
-<a class="ecosystem-card-wrapper" href={`/app/ecosystems/${ecosystem.id}`}>
+<a
+  data-testid="ecosystem-card-{ecosystem.id}"
+  class="ecosystem-card-wrapper"
+  href={`/app/ecosystems/${ecosystem.id}`}
+>
   <div class="ecosystem-card" class:hidden-project={isHidden}>
     <div class="background" />
     {#if $$slots.banner}


### PR DESCRIPTION
Fixes some sources of flakiness that i identified & fixed on `rpgf` branch. Not all fixes from that branch are included due to cross-dependency on some larger E2E-related improvements. Specifically, the spec still fails on repeated runs without a full state-reset in-between, whereas it works with any amount of prior runs on `rpgf`.