### PR TITLE
add splits to application view

### DIFF
--- a/src/lib/components/rpgf-application-splits-card/rpgf-application-splits-card.svelte
+++ b/src/lib/components/rpgf-application-splits-card/rpgf-application-splits-card.svelte
@@ -1,0 +1,64 @@
+<script lang="ts" context="module">
+  import { gql } from 'graphql-request';
+
+  export const RPGF_APPLICATION_SPLITS_CARD_PROJECT_FRAGMENT = gql`
+    ${SPLITS_COMPONENT_PROJECT_SPLITS_FRAGMENT}
+    ${PROJECT_BADGE_FRAGMENT}
+    fragment RpgfApplicationSplitsCardProject on Project {
+      ...ProjectBadge
+      chainData {
+        ...SplitsComponentProjectSplits
+        ... on ClaimedProjectData {
+          chain
+        }
+        ... on UnClaimedProjectData {
+          chain
+        }
+      }
+    }
+  `;
+</script>
+
+<script lang="ts">
+  import Splits from '../splits/splits.svelte';
+  import { SPLITS_COMPONENT_PROJECT_SPLITS_FRAGMENT } from '../splits/types';
+  import type { RpgfApplicationSplitsCardProjectFragment } from './__generated__/gql.generated';
+  import isClaimed from '$lib/utils/project/is-claimed';
+  import filterCurrentChainData from '$lib/utils/filter-current-chain-data';
+  import RpgfApplicationDetailsCard from '../rpgf-application-details-card/rpgf-application-details-card.svelte';
+  import PaddedHorizontalScroll from '../padded-horizontal-scroll/padded-horizontal-scroll.svelte';
+  import ProjectBadge, { PROJECT_BADGE_FRAGMENT } from '../project-badge/project-badge.svelte';
+  import AnnotationBox from '../annotation-box/annotation-box.svelte';
+
+  export let project: RpgfApplicationSplitsCardProjectFragment;
+  $: currentChainData = filterCurrentChainData(project.chainData);
+</script>
+
+{#if isClaimed(currentChainData)}
+  <RpgfApplicationDetailsCard key="project-splits" title="Project Splits">
+    <div style:display="flex" style:flex-direction="column" style:gap="2rem">
+      <p>The Drips Project linked to this application is currently splitting funds as follows.</p>
+      <div style:display="flex" style:flex-direction="column" style:gap="1rem">
+        <ProjectBadge {project} />
+        <PaddedHorizontalScroll>
+          <Splits
+            disableLinks={false}
+            list={[
+              {
+                __typename: 'SplitGroup',
+                name: 'Maintainers',
+                list: currentChainData.splits.maintainers,
+              },
+              {
+                __typename: 'SplitGroup',
+                name: 'Dependencies',
+                list: currentChainData.splits.dependencies,
+              },
+            ]}
+          />
+        </PaddedHorizontalScroll>
+      </div>
+      <AnnotationBox type="info">Drips Project splits may change over time.</AnnotationBox>
+    </div>
+  </RpgfApplicationDetailsCard>
+{/if}

--- a/src/lib/components/splits/types.ts
+++ b/src/lib/components/splits/types.ts
@@ -1,5 +1,4 @@
 import { gql } from 'graphql-request';
-import { DRIP_LIST_BADGE_FRAGMENT } from '../drip-list-badge/drip-list-badge.svelte';
 import { PROJECT_AVATAR_FRAGMENT } from '../project-avatar/project-avatar.svelte';
 import { PROJECT_BADGE_FRAGMENT } from '../project-badge/project-badge.svelte';
 import type {
@@ -9,52 +8,7 @@ import type {
   SplitsComponentEcosystemReceiverFragment,
   SplitsComponentSubListReceiverFragment,
 } from './__generated__/gql.generated';
-
-export const SPLITS_COMPONENT_PROJECT_SPLITS_FRAGMENT = gql`
-  ${PROJECT_AVATAR_FRAGMENT}
-  ${DRIP_LIST_BADGE_FRAGMENT}
-  fragment SplitsComponentProjectSplits on ProjectData {
-    ... on ClaimedProjectData {
-      splits {
-        dependencies {
-          ... on AddressReceiver {
-            account {
-              address
-              driver
-            }
-            driver
-          }
-          ... on ProjectReceiver {
-            project {
-              chainData {
-                ...ProjectAvatar
-              }
-            }
-          }
-          ... on DripListReceiver {
-            dripList {
-              ...DripListBadge
-            }
-            account {
-              accountId
-              driver
-            }
-            driver
-          }
-        }
-        maintainers {
-          ... on AddressReceiver {
-            account {
-              address
-              driver
-            }
-            driver
-          }
-        }
-      }
-    }
-  }
-`;
+import { DRIP_LIST_BADGE_FRAGMENT } from '../drip-list-badge/drip-list-badge.svelte';
 
 export const SPLITS_COMPONENT_PROJECT_FRAGMENT = gql`
   ${PROJECT_BADGE_FRAGMENT}
@@ -78,7 +32,9 @@ export const SPLITS_COMPONENT_PROJECT_FRAGMENT = gql`
 `;
 
 export const SPLITS_COMPONENT_DRIP_LIST_FRAGMENT = gql`
+  ${DRIP_LIST_BADGE_FRAGMENT}
   fragment SplitsComponentDripList on DripList {
+    ...DripListBadge
     account {
       accountId
     }
@@ -137,6 +93,43 @@ export const SPLITS_COMPONENT_SUB_LIST_RECEIVER_FRAGMENT = gql`
     subList {
       account {
         accountId
+      }
+    }
+  }
+`;
+
+export const SPLITS_COMPONENT_PROJECT_SPLITS_FRAGMENT = gql`
+  ${PROJECT_AVATAR_FRAGMENT}
+  ${SPLITS_COMPONENT_PROJECT_RECEIVER_FRAGMENT}
+  ${SPLITS_COMPONENT_DRIP_LIST_RECEIVER_FRAGMENT}
+  ${SPLITS_COMPONENT_ADDRESS_RECEIVER_FRAGMENT}
+  ${SPLITS_COMPONENT_ECOSYSTEM_RECEIVER_FRAGMENT}
+  ${SPLITS_COMPONENT_SUB_LIST_RECEIVER_FRAGMENT}
+  fragment SplitsComponentProjectSplits on ProjectData {
+    ... on ClaimedProjectData {
+      splits {
+        dependencies {
+          ... on AddressReceiver {
+            ...SplitsComponentAddressReceiver
+          }
+          ... on ProjectReceiver {
+            ...SplitsComponentProjectReceiver
+          }
+          ... on DripListReceiver {
+            ...SplitsComponentDripListReceiver
+          }
+          ... on EcosystemMainAccountReceiver {
+            ...SplitsComponentEcosystemReceiver
+          }
+          ... on SubListReceiver {
+            ...SplitsComponentSubListReceiver
+          }
+        }
+        maintainers {
+          ... on AddressReceiver {
+            ...SplitsComponentAddressReceiver
+          }
+        }
       }
     }
   }

--- a/src/routes/(pages)/app/(app)/rpgf/rounds/[slugOrId]/applications/[id]/+page.svelte
+++ b/src/routes/(pages)/app/(app)/rpgf/rounds/[slugOrId]/applications/[id]/+page.svelte
@@ -16,6 +16,7 @@
   import ArrowCounterClockwiseHeart from '$lib/components/icons/ArrowCounterClockwiseHeart.svelte';
   import RpgfApplicationFormAnswersCard from '$lib/components/rpgf-application-form-answers-card/rpgf-application-form-answers-card.svelte';
   import RpgfApplicationSubmissionDetailsCard from '$lib/components/rpgf-application-submission-details-card/rpgf-application-submission-details-card.svelte';
+  import RpgfApplicationSplitsCard from '$lib/components/rpgf-application-splits-card/rpgf-application-splits-card.svelte';
 
   export let data;
   $: round = data.round;
@@ -99,18 +100,20 @@
     />
   {/if}
 
-  <RpgfApplicationMetricsCard keyMetrics={data.osoCoreMetrics} />
-
   <RpgfApplicationFormAnswersCard
     {canSeePrivateFields}
     applicationVersion={application.latestVersion}
   />
+
+  <RpgfApplicationSplitsCard project={data.dripsProject} />
 
   <RpgfApplicationSubmissionDetailsCard
     applicationVersion={latestVersion}
     submitterWalletAddress={application.submitter.walletAddress}
     project={data.dripsProject}
   />
+
+  <RpgfApplicationMetricsCard keyMetrics={data.osoCoreMetrics} />
 </div>
 
 <style>

--- a/src/routes/(pages)/app/(app)/rpgf/rounds/[slugOrId]/applications/[id]/shared/fetch-project-for-application.ts
+++ b/src/routes/(pages)/app/(app)/rpgf/rounds/[slugOrId]/applications/[id]/shared/fetch-project-for-application.ts
@@ -6,12 +6,15 @@ import type {
   ApplicationPageDripsProjectQuery,
   ApplicationPageDripsProjectQueryVariables,
 } from './__generated__/gql.generated';
+import { RPGF_APPLICATION_SPLITS_CARD_PROJECT_FRAGMENT } from '$lib/components/rpgf-application-splits-card/rpgf-application-splits-card.svelte';
 
 const dripsProjectQuery = gql`
   ${PROJECT_BADGE_FRAGMENT}
+  ${RPGF_APPLICATION_SPLITS_CARD_PROJECT_FRAGMENT}
   query ApplicationPageDripsProject($id: ID!, $chains: [SupportedChain!]) {
     projectById(id: $id, chains: $chains) {
       ...ProjectBadge
+      ...RpgfApplicationSplitsCardProject
     }
   }
 `;


### PR DESCRIPTION
Filecoin requested being able to see splits for a linked project on its application view

<img width="1337" height="1355" alt="image" src="https://github.com/user-attachments/assets/8b541620-76af-4817-88fb-f2a80d45e09d" />
