### PR TITLE
Fix borked project icons in supporter piles

### DIFF
--- a/src/lib/components/drip-list-card/methods/get-supporters-pile.ts
+++ b/src/lib/components/drip-list-card/methods/get-supporters-pile.ts
@@ -6,6 +6,7 @@ import mapFilterUndefined from '$lib/utils/map-filter-undefined';
 import { gql } from 'graphql-request';
 import type { SupporterPileFragment } from './__generated__/gql.generated';
 import type { ComponentProps } from 'svelte';
+import filterCurrentChainData from '$lib/utils/filter-current-chain-data';
 
 export const SUPPORTER_PILE_FRAGMENT = gql`
   ${PROJECT_AVATAR_FRAGMENT}
@@ -87,7 +88,7 @@ export default function getSupportersPile(
           return {
             component: ProjectAvatar,
             props: {
-              project: s.project.chainData[0],
+              project: filterCurrentChainData(s.project.chainData),
               size: COMPONENT_SIZES[size]['ProjectAvatar'] as ComponentProps<ProjectAvatar>['size'],
             },
           };

--- a/src/lib/components/drip-list-card/methods/get-supporters-pile.ts
+++ b/src/lib/components/drip-list-card/methods/get-supporters-pile.ts
@@ -52,6 +52,17 @@ type SupporterPileItem =
       props: ComponentProps<ProjectAvatar>;
     };
 
+type ComponentSizes = {
+  tiny: {
+    IdentityBadge: ComponentProps<IdentityBadge>['size'];
+    ProjectAvatar: ComponentProps<ProjectAvatar>['size'];
+  };
+  normal: {
+    IdentityBadge: ComponentProps<IdentityBadge>['size'];
+    ProjectAvatar: ComponentProps<ProjectAvatar>['size'];
+  };
+};
+
 export default function getSupportersPile(
   support: SupporterPileFragment[],
   size: 'tiny' | 'normal' = 'normal',
@@ -59,14 +70,14 @@ export default function getSupportersPile(
   let result: SupporterPileItem[] = [];
 
   // Component sizes are unfortunately a mess so we need to do this
-  const COMPONENT_SIZES = {
+  const COMPONENT_SIZES: ComponentSizes = {
     tiny: {
       IdentityBadge: 'normal',
       ProjectAvatar: 'tiny',
     },
     normal: {
       IdentityBadge: 'medium',
-      ProjectAvatar: 'normal',
+      ProjectAvatar: 'small',
     },
   };
 
@@ -79,7 +90,7 @@ export default function getSupportersPile(
             props: {
               address: s.dripList.owner.address,
               showIdentity: false,
-              size: COMPONENT_SIZES[size]['IdentityBadge'] as ComponentProps<IdentityBadge>['size'],
+              size: COMPONENT_SIZES[size]['IdentityBadge'],
               disableTooltip: true,
               disableLink: true,
             },
@@ -89,7 +100,7 @@ export default function getSupportersPile(
             component: ProjectAvatar,
             props: {
               project: filterCurrentChainData(s.project.chainData),
-              size: COMPONENT_SIZES[size]['ProjectAvatar'] as ComponentProps<ProjectAvatar>['size'],
+              size: COMPONENT_SIZES[size]['ProjectAvatar'],
             },
           };
         case 'OneTimeDonationSupport':
@@ -98,7 +109,7 @@ export default function getSupportersPile(
             props: {
               address: s.account.address,
               showIdentity: false,
-              size: COMPONENT_SIZES[size]['IdentityBadge'] as ComponentProps<IdentityBadge>['size'],
+              size: COMPONENT_SIZES[size]['IdentityBadge'],
               disableTooltip: true,
               disableLink: true,
             },
@@ -109,7 +120,7 @@ export default function getSupportersPile(
             props: {
               address: s.stream.sender.account.address,
               showIdentity: false,
-              size: COMPONENT_SIZES[size]['IdentityBadge'] as ComponentProps<IdentityBadge>['size'],
+              size: COMPONENT_SIZES[size]['IdentityBadge'],
               disableTooltip: true,
               disableLink: true,
             },

--- a/src/lib/components/project-avatar/project-avatar.svelte
+++ b/src/lib/components/project-avatar/project-avatar.svelte
@@ -15,6 +15,9 @@
           }
         }
       }
+      ... on UnClaimedProjectData {
+        chain
+      }
     }
   `;
 </script>

--- a/src/lib/components/search-bar/components/result.svelte
+++ b/src/lib/components/search-bar/components/result.svelte
@@ -40,6 +40,7 @@
     } else {
       return {
         __typename: 'UnClaimedProjectData' as const,
+        chain: network.gqlName,
       };
     }
   }
@@ -80,7 +81,7 @@
   >
     {#if avatarConfig.__typename === 'ClaimedProjectData'}
       <div style:margin-right="-1.25rem">
-        <ProjectAvatar project={{ __typename: 'UnClaimedProjectData' }} />
+        <ProjectAvatar project={{ __typename: 'UnClaimedProjectData', chain: network.gqlName }} />
       </div>
     {/if}
     <ProjectAvatar project={avatarConfig} />


### PR DESCRIPTION
and more stringently links types to the components used to render the piles.
[staging link to affected project](https://drips-mainnet-app-staging.up.railway.app/app/projects/github/Byron/gitoxide?exact)

<img width="984" height="371" alt="Screenshot 2025-09-30 at 17 57 51" src="https://github.com/user-attachments/assets/93d94a17-b9c1-4f6c-b154-ef13187c5f7a" />
