### PR TITLE
Ensure /api/health checks ok response for lp and explore pages

### DIFF
--- a/src/routes/api/health/+server.ts
+++ b/src/routes/api/health/+server.ts
@@ -27,14 +27,14 @@ async function checkRpc() {
 async function checkLp(f: typeof fetch) {
   const response = await f('/', { signal: AbortSignal.timeout(10000) });
   if (!response.ok) {
-    throw new Error(`Landing page returned status ${response.status}`);
+    error(response.status, `Landing page returned status ${response.status}`);
   }
 }
 
 async function checkExplore(f: typeof fetch) {
   const response = await f('/app', { signal: AbortSignal.timeout(10000) });
   if (!response.ok) {
-    throw new Error(`Explore page returned status ${response.status}`);
+    error(response.status, `Explore page returned status ${response.status}`);
   }
 }
 


### PR DESCRIPTION
<img width="1124" height="430" alt="Screenshot 2025-10-30 at 17 04 43" src="https://github.com/user-attachments/assets/fe14e531-f4c3-4961-abae-2f570f2103ad" />
