### PR TITLE
Remove malformed html in split receivers view for project receiver

### DIFF
--- a/src/lib/components/splits/components/split/split.svelte
+++ b/src/lib/components/splits/components/split/split.svelte
@@ -222,8 +222,6 @@
             {linkToNewTab}
             project={split.project}
           />
-          project={split.project}
-          />
         </PrimaryColorThemer>
       {:else if split.__typename === 'LinkedIdentityReceiver'}
         <OrcidBadge {chainOverride} orcid={split.linkedIdentity} />


### PR DESCRIPTION
Fixes this: 
<img width="1003" height="858" alt="Screenshot 2025-11-19 at 14 53 17" src="https://github.com/user-attachments/assets/6353bab5-7cae-4ac6-b999-dfca256243cf" />
