### PR TITLE
1651 injected theme on project page does not revert to default when navigating from claimed to unclaimed project

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,13 +16,13 @@ const config = defineConfig(({ mode }) => ({
     sveltekit(),
     process.env.FARO_UPLOAD_SOURCE_MAPS_KEY
       ? faroUploader({
-        appName: 'app',
-        endpoint: 'https://faro-api-prod-eu-west-2.grafana.net/faro/api/v1',
-        appId: '2936',
-        stackId: '1238676',
-        apiKey: process.env.FARO_UPLOAD_SOURCE_MAPS_KEY,
-        gzipContents: true,
-      })
+          appName: 'app',
+          endpoint: 'https://faro-api-prod-eu-west-2.grafana.net/faro/api/v1',
+          appId: '2936',
+          stackId: '1238676',
+          apiKey: process.env.FARO_UPLOAD_SOURCE_MAPS_KEY,
+          gzipContents: true,
+        })
       : undefined,
   ],
   test: {


### PR DESCRIPTION
And prevents a tooltip error when the tooltip and/or content element are unavailable