### PR TITLE
Pin Postgres images to version 16 in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -155,7 +155,7 @@ services:
         condition: service_healthy
 
   postgres:
-    image: postgres:latest
+    image: postgres:16
     restart: unless-stopped
     environment:
       POSTGRES_USER: user
@@ -172,7 +172,7 @@ services:
       start_period: 80s
 
   postgres-multiplayer:
-    image: postgres:latest
+    image: postgres:16
     restart: unless-stopped
     environment:
       POSTGRES_USER: user
@@ -189,7 +189,7 @@ services:
       start_period: 80s
 
   postgres-ecosystems:
-    image: postgres:latest
+    image: postgres:16
     restart: unless-stopped
     environment:
       POSTGRES_USER: user
@@ -266,7 +266,7 @@ services:
         condition: service_healthy
 
   postgres-rpgf:
-    image: postgres:latest
+    image: postgres:16
     restart: unless-stopped
     environment:
       POSTGRES_USER: postgres


### PR DESCRIPTION
This PR replaces all `postgres:latest` image references with `postgres:16` across the docker-compose setup.

Updated the following services to use `postgres:16`:
	•	postgres
	•	postgres-multiplayer
	•	postgres-ecosystems
	•	postgres-rpgf