### PR TITLE
feat: contributor stats dashboard page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "@web3-onboard/injected-wallets": "^2.10.17",
         "@web3-onboard/walletconnect": "^2.5.5",
         "bezier-easing": "^2.1.0",
+        "chart.js": "^4.5.1",
         "csv-simple-parser": "^1.0.3",
         "cupertino-pane": "^1.5.4",
         "ethereum-blockies-base64": "^1.0.2",
@@ -4804,6 +4805,12 @@
       "peerDependencies": {
         "solid-js": "^1.8.8"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
     },
     "node_modules/@lit-labs/ssr-dom-shim": {
       "version": "1.4.0",
@@ -15489,6 +15496,18 @@
       "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
     },
     "node_modules/chokidar": {
       "version": "3.6.0",

--- a/package.json
+++ b/package.json
@@ -82,12 +82,12 @@
     "vitest": "^4.0.6"
   },
   "dependencies": {
-    "@gelatocloud/gasless": "^0.0.12",
     "@apollo/client": "^3.11.8",
     "@drips-network/sdk": "0.1.0-alpha.15",
     "@efstajas/svelte-stored-writable": "^1.0.0",
     "@efstajas/versioned-parser": "^0.1.4",
     "@ethereum-attestation-service/eas-sdk": "^2.7.0",
+    "@gelatocloud/gasless": "^0.0.12",
     "@grafana/faro-web-sdk": "^1.18.1",
     "@grafana/faro-web-tracing": "^1.18.1",
     "@intercom/messenger-js-sdk": "^0.0.18",
@@ -114,6 +114,7 @@
     "@web3-onboard/injected-wallets": "^2.10.17",
     "@web3-onboard/walletconnect": "^2.5.5",
     "bezier-easing": "^2.1.0",
+    "chart.js": "^4.5.1",
     "csv-simple-parser": "^1.0.3",
     "cupertino-pane": "^1.5.4",
     "ethereum-blockies-base64": "^1.0.2",

--- a/src/lib/components/icons/ChartBar.svelte
+++ b/src/lib/components/icons/ChartBar.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import IconWrapper from './IconWrapper.svelte';
+
+  interface Props {
+    style?: string | undefined;
+  }
+
+  let { style = undefined }: Props = $props();
+</script>
+
+<IconWrapper {style}>
+  <rect x="4" y="14" width="4" height="6" rx="1" />
+  <rect x="10" y="10" width="4" height="10" rx="1" />
+  <rect x="16" y="5" width="4" height="15" rx="1" />
+</IconWrapper>

--- a/src/lib/utils/wave/stats.ts
+++ b/src/lib/utils/wave/stats.ts
@@ -1,0 +1,17 @@
+import { authenticatedCall } from './call';
+import { contributorStatsResponseSchema, contributorAiSummaryResponseSchema } from './types/stats';
+import parseRes from './utils/parse-res';
+
+export async function getContributorStats(f = fetch) {
+  return parseRes(
+    contributorStatsResponseSchema,
+    await authenticatedCall(f, '/api/stats/contributor'),
+  );
+}
+
+export async function getContributorAiSummary(f = fetch) {
+  return parseRes(
+    contributorAiSummaryResponseSchema,
+    await authenticatedCall(f, '/api/stats/contributor/ai-summary'),
+  );
+}

--- a/src/lib/utils/wave/types/stats.ts
+++ b/src/lib/utils/wave/types/stats.ts
@@ -1,0 +1,86 @@
+import z from 'zod';
+
+// ====== Points Stats ======
+
+export const contributorWavePointsSchema = z.object({
+  waveId: z.string(),
+  waveNumber: z.number().int(),
+  waveProgramId: z.string(),
+  waveProgramName: z.string(),
+  waveProgramSlug: z.string(),
+  points: z.number().int(),
+});
+
+export const contributorPointsStatsSchema = z.object({
+  totalAllTime: z.number().int(),
+  byWave: z.array(contributorWavePointsSchema),
+});
+
+// ====== Issue Stats ======
+
+export const contributorIssueStatsSchema = z.object({
+  totalResolved: z.number().int(),
+  byComplexity: z.object({
+    small: z.number().int(),
+    medium: z.number().int(),
+    large: z.number().int(),
+    unset: z.number().int(),
+  }),
+});
+
+// ====== Leaderboard Stats ======
+
+export const contributorLeaderboardWaveEntrySchema = z.object({
+  waveId: z.string(),
+  waveNumber: z.number().int(),
+  rank: z.number().int(),
+  totalParticipants: z.number().int(),
+  points: z.number().int(),
+});
+
+export const contributorLeaderboardProgramSchema = z.object({
+  waveProgramId: z.string(),
+  waveProgramName: z.string(),
+  waveProgramSlug: z.string(),
+  waves: z.array(contributorLeaderboardWaveEntrySchema),
+});
+
+export const contributorLeaderboardStatsSchema = z.object({
+  byProgram: z.array(contributorLeaderboardProgramSchema),
+});
+
+// ====== Review Stats ======
+
+export const contributorReviewStatsSchema = z.object({
+  totalReceived: z.number().int(),
+  experienceDistribution: z.object({
+    exceededExpectations: z.number().int(),
+    alright: z.number().int(),
+    belowExpectations: z.number().int(),
+  }),
+  averageRatings: z.object({
+    communicationQuality: z.number().nullable(),
+    codeQuality: z.number().nullable(),
+    timeliness: z.number().nullable(),
+    problemSolving: z.number().nullable(),
+  }),
+});
+
+// ====== Combined Response ======
+
+export const contributorStatsResponseSchema = z.object({
+  points: contributorPointsStatsSchema,
+  issues: contributorIssueStatsSchema,
+  leaderboard: contributorLeaderboardStatsSchema,
+  reviews: contributorReviewStatsSchema.nullable(),
+});
+export type ContributorStatsResponse = z.infer<typeof contributorStatsResponseSchema>;
+
+// ====== AI Summary Response ======
+
+export const contributorAiSummaryResponseSchema = z.object({
+  summary: z.string().nullable(),
+  generatedAt: z.string().nullable(),
+  reviewCount: z.number().int().nullable(),
+});
+export type ContributorAiSummaryResponse = z.infer<typeof contributorAiSummaryResponseSchema>;

--- a/src/routes/(pages)/wave/(base-layout)/+layout.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/+layout.svelte
@@ -16,6 +16,7 @@
   import Wave from '$lib/components/icons/Wave.svelte';
   import Wallet from '$lib/components/icons/Wallet.svelte';
   import Shield from '$lib/components/icons/Shield.svelte';
+  import ChartBar from '$lib/components/icons/ChartBar.svelte';
 
   let {
     data,
@@ -110,6 +111,12 @@
             name: 'Reward Grants',
             href: '/wave/rewards',
             icon: Wallet,
+          },
+          {
+            type: 'target' as const,
+            name: 'My Stats',
+            href: '/wave/stats/me',
+            icon: ChartBar,
           },
           {
             type: 'target' as const,

--- a/src/routes/(pages)/wave/(base-layout)/stats/me/+page.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/stats/me/+page.svelte
@@ -1,0 +1,538 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import {
+    Chart,
+    BarController,
+    BarElement,
+    LineController,
+    LineElement,
+    PointElement,
+    DoughnutController,
+    ArcElement,
+    RadarController,
+    RadialLinearScale,
+    CategoryScale,
+    LinearScale,
+    Tooltip as ChartTooltip,
+    Legend,
+    Filler,
+  } from 'chart.js';
+  import HeadMeta from '$lib/components/head-meta/head-meta.svelte';
+  import SectionHeader from '$lib/components/section-header/section-header.svelte';
+  import Card from '$lib/components/wave/card/card.svelte';
+  import Coin from '$lib/components/icons/Coin.svelte';
+  import Issue from '$lib/components/icons/Issue.svelte';
+  import Trophy from '$lib/components/icons/Trophy.svelte';
+  import Review from '$lib/components/icons/Review.svelte';
+  import Star from '$lib/components/icons/Star.svelte';
+  import type { ContributorStatsResponse } from '$lib/utils/wave/types/stats.js';
+
+  Chart.register(
+    BarController,
+    BarElement,
+    LineController,
+    LineElement,
+    PointElement,
+    DoughnutController,
+    ArcElement,
+    RadarController,
+    RadialLinearScale,
+    CategoryScale,
+    LinearScale,
+    ChartTooltip,
+    Legend,
+    Filler,
+  );
+
+  let { data } = $props();
+  let { stats, aiSummary } = $derived(data);
+
+  // Canvas refs
+  let pointsCanvas: HTMLCanvasElement | undefined = $state();
+  let issuesCanvas: HTMLCanvasElement | undefined = $state();
+  let reviewExpCanvas: HTMLCanvasElement | undefined = $state();
+  let reviewRatingsCanvas: HTMLCanvasElement | undefined = $state();
+  let leaderboardCanvases: Record<string, HTMLCanvasElement> = $state({});
+
+  // Chart instances for cleanup
+  let charts: Chart[] = [];
+
+  // Theme colors
+  let colors = $state({
+    primary: '#5555ff',
+    positive: '#00a83e',
+    caution: '#e0a800',
+    negative: '#d32f2f',
+    foreground5: '#999999',
+    foreground: '#000000',
+    background: '#ffffff',
+    primaryLevel2: '#e8e8ff',
+  });
+
+  function readCssColors() {
+    const s = getComputedStyle(document.documentElement);
+    colors = {
+      primary: s.getPropertyValue('--color-primary').trim() || colors.primary,
+      positive: s.getPropertyValue('--color-positive').trim() || colors.positive,
+      caution: s.getPropertyValue('--color-caution').trim() || colors.caution,
+      negative: s.getPropertyValue('--color-negative').trim() || colors.negative,
+      foreground5: s.getPropertyValue('--color-foreground-level-5').trim() || colors.foreground5,
+      foreground: s.getPropertyValue('--color-foreground').trim() || colors.foreground,
+      background: s.getPropertyValue('--color-background').trim() || colors.background,
+      primaryLevel2: s.getPropertyValue('--color-primary-level-2').trim() || colors.primaryLevel2,
+    };
+  }
+
+  function destroyCharts() {
+    for (const c of charts) c.destroy();
+    charts = [];
+  }
+
+  function buildCharts() {
+    destroyCharts();
+    readCssColors();
+
+    const fontFamily = getComputedStyle(document.documentElement)
+      .getPropertyValue('--typeface-regular')
+      .trim();
+
+    Chart.defaults.font.family = fontFamily || undefined;
+    Chart.defaults.color = colors.foreground5;
+
+    // Points bar chart
+    if (pointsCanvas && stats.points.byWave.length > 0) {
+      const byWave = stats.points.byWave;
+      const programColors = assignProgramColors(byWave);
+
+      charts.push(
+        new Chart(pointsCanvas, {
+          type: 'bar',
+          data: {
+            labels: byWave.map((w) => `${w.waveProgramName} W${w.waveNumber}`),
+            datasets: [
+              {
+                data: byWave.map((w) => w.points),
+                backgroundColor: byWave.map((w) => programColors[w.waveProgramId]),
+                borderRadius: 6,
+                borderSkipped: false,
+              },
+            ],
+          },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: { legend: { display: false } },
+            scales: {
+              y: {
+                beginAtZero: true,
+                grid: { color: colors.primaryLevel2 },
+              },
+              x: {
+                grid: { display: false },
+              },
+            },
+          },
+        }),
+      );
+    }
+
+    // Issues doughnut chart
+    if (issuesCanvas && stats.issues.totalResolved > 0) {
+      const c = stats.issues.byComplexity;
+      const segments = [
+        { label: 'Small', value: c.small, color: colors.positive },
+        { label: 'Medium', value: c.medium, color: colors.caution },
+        { label: 'Large', value: c.large, color: colors.negative },
+        { label: 'Unset', value: c.unset, color: colors.foreground5 },
+      ].filter((s) => s.value > 0);
+
+      charts.push(
+        new Chart(issuesCanvas, {
+          type: 'doughnut',
+          data: {
+            labels: segments.map((s) => s.label),
+            datasets: [
+              {
+                data: segments.map((s) => s.value),
+                backgroundColor: segments.map((s) => s.color),
+                borderWidth: 2,
+                borderColor: colors.background,
+              },
+            ],
+          },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+              legend: { position: 'bottom' },
+            },
+          },
+        }),
+      );
+    }
+
+    // Leaderboard charts
+    for (const program of stats.leaderboard.byProgram) {
+      const canvas = leaderboardCanvases[program.waveProgramId];
+      if (!canvas || program.waves.length <= 1) continue;
+
+      charts.push(
+        new Chart(canvas, {
+          type: 'line',
+          data: {
+            labels: program.waves.map((w) => `Wave ${w.waveNumber}`),
+            datasets: [
+              {
+                label: 'Rank',
+                data: program.waves.map((w) => w.rank),
+                borderColor: colors.primary,
+                backgroundColor: colors.primaryLevel2,
+                fill: true,
+                tension: 0.3,
+                pointRadius: 5,
+                pointHoverRadius: 7,
+              },
+            ],
+          },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            scales: {
+              y: {
+                reverse: true,
+                beginAtZero: false,
+                min: 1,
+                ticks: { stepSize: 1 },
+                title: { display: true, text: 'Rank' },
+                grid: { color: colors.primaryLevel2 },
+              },
+              x: {
+                grid: { display: false },
+              },
+            },
+            plugins: {
+              legend: { display: false },
+              tooltip: {
+                callbacks: {
+                  label: (ctx) => {
+                    const wave = program.waves[ctx.dataIndex];
+                    return `Rank ${wave.rank} of ${wave.totalParticipants} participants (${wave.points} pts)`;
+                  },
+                },
+              },
+            },
+          },
+        }),
+      );
+    }
+
+    // Reviews experience doughnut
+    if (reviewExpCanvas && stats.reviews) {
+      const d = stats.reviews.experienceDistribution;
+      const segments = [
+        { label: 'Exceeded expectations', value: d.exceededExpectations, color: colors.positive },
+        { label: 'Alright', value: d.alright, color: colors.caution },
+        { label: 'Below expectations', value: d.belowExpectations, color: colors.negative },
+      ].filter((s) => s.value > 0);
+
+      charts.push(
+        new Chart(reviewExpCanvas, {
+          type: 'doughnut',
+          data: {
+            labels: segments.map((s) => s.label),
+            datasets: [
+              {
+                data: segments.map((s) => s.value),
+                backgroundColor: segments.map((s) => s.color),
+                borderWidth: 2,
+                borderColor: colors.background,
+              },
+            ],
+          },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+              legend: { position: 'bottom' },
+            },
+          },
+        }),
+      );
+    }
+
+    // Reviews ratings radar
+    if (reviewRatingsCanvas && stats.reviews) {
+      const r = stats.reviews.averageRatings;
+      const ratingLabels = ['Communication', 'Code Quality', 'Timeliness', 'Problem Solving'];
+      const ratingValues = [r.communicationQuality, r.codeQuality, r.timeliness, r.problemSolving];
+
+      if (ratingValues.some((v) => v !== null)) {
+        charts.push(
+          new Chart(reviewRatingsCanvas, {
+            type: 'radar',
+            data: {
+              labels: ratingLabels,
+              datasets: [
+                {
+                  label: 'Average Rating',
+                  data: ratingValues.map((v) => v ?? 0),
+                  borderColor: colors.primary,
+                  backgroundColor: colors.primaryLevel2,
+                  fill: true,
+                  pointRadius: 4,
+                  pointHoverRadius: 6,
+                },
+              ],
+            },
+            options: {
+              responsive: true,
+              maintainAspectRatio: false,
+              scales: {
+                r: {
+                  min: 0,
+                  max: 5,
+                  ticks: { stepSize: 1 },
+                  grid: { color: colors.primaryLevel2 },
+                  pointLabels: {
+                    font: { size: 12 },
+                  },
+                },
+              },
+              plugins: {
+                legend: { display: false },
+              },
+            },
+          }),
+        );
+      }
+    }
+  }
+
+  function assignProgramColors(
+    byWave: ContributorStatsResponse['points']['byWave'],
+  ): Record<string, string> {
+    const palette = [colors.primary, colors.positive, colors.caution, colors.negative];
+    const programIds = [...new Set(byWave.map((w) => w.waveProgramId))];
+    const map: Record<string, string> = {};
+    for (let i = 0; i < programIds.length; i++) {
+      map[programIds[i]] = palette[i % palette.length];
+    }
+    return map;
+  }
+
+  function formatDate(iso: string): string {
+    return new Date(iso).toLocaleDateString(undefined, {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+  }
+
+  onMount(() => {
+    buildCharts();
+    return () => destroyCharts();
+  });
+</script>
+
+<HeadMeta title="My Stats | Wave" />
+
+<div class="stats-grid">
+  <!-- Points -->
+  <Card>
+    <div class="card-content">
+      <SectionHeader label="Points" icon={Coin} />
+      {#if stats.points.byWave.length === 0 && stats.points.totalAllTime === 0}
+        <p class="typo-text-small empty-text">
+          Earn points by completing issues within active Waves.
+        </p>
+      {:else}
+        <div class="stat-highlight">
+          <span class="stat-number typo-header-1">{stats.points.totalAllTime.toLocaleString()}</span
+          >
+          <span class="stat-label typo-text-small">Total points earned</span>
+        </div>
+        {#if stats.points.byWave.length > 0}
+          <div class="chart-container">
+            <canvas bind:this={pointsCanvas}></canvas>
+          </div>
+        {/if}
+      {/if}
+    </div>
+  </Card>
+
+  <!-- Issues -->
+  <Card>
+    <div class="card-content">
+      <SectionHeader label="Issues" icon={Issue} />
+      {#if stats.issues.totalResolved === 0}
+        <p class="typo-text-small empty-text">Start contributing to see your issue stats here.</p>
+      {:else}
+        <div class="stat-highlight">
+          <span class="stat-number typo-header-1">{stats.issues.totalResolved}</span>
+          <span class="stat-label typo-text-small">Issues resolved</span>
+        </div>
+        <div class="chart-container chart-container-small">
+          <canvas bind:this={issuesCanvas}></canvas>
+        </div>
+      {/if}
+    </div>
+  </Card>
+
+  <!-- Leaderboard Ranks -->
+  <Card>
+    <div class="card-content">
+      <SectionHeader label="Leaderboard Ranks" icon={Trophy} />
+      {#if stats.leaderboard.byProgram.length === 0}
+        <p class="typo-text-small empty-text">Participate in a Wave to see your rankings.</p>
+      {:else}
+        {#each stats.leaderboard.byProgram as program (program.waveProgramId)}
+          <div class="leaderboard-program">
+            <h4 class="typo-text-small-bold">{program.waveProgramName}</h4>
+            {#if program.waves.length === 1}
+              {@const wave = program.waves[0]}
+              <div class="rank-card">
+                <span class="stat-number typo-header-2">#{wave.rank}</span>
+                <span class="stat-label typo-text-small">
+                  of {wave.totalParticipants} participants &middot; Wave {wave.waveNumber} &middot; {wave.points}
+                  pts
+                </span>
+              </div>
+            {:else}
+              <div class="chart-container">
+                <canvas bind:this={leaderboardCanvases[program.waveProgramId]}></canvas>
+              </div>
+            {/if}
+          </div>
+        {/each}
+      {/if}
+    </div>
+  </Card>
+
+  <!-- Reviews -->
+  <Card>
+    <div class="card-content">
+      <SectionHeader label="Reviews" icon={Review} />
+      {#if stats.reviews === null}
+        <p class="typo-text-small empty-text">Not enough reviews to display stats yet.</p>
+      {:else}
+        <div class="stat-highlight">
+          <span class="stat-number typo-header-1">{stats.reviews.totalReceived}</span>
+          <span class="stat-label typo-text-small">Reviews received</span>
+        </div>
+        <div class="review-charts">
+          <div class="chart-container chart-container-small">
+            <p class="typo-text-small-bold chart-label">Experience distribution</p>
+            <canvas bind:this={reviewExpCanvas}></canvas>
+          </div>
+          <div class="chart-container chart-container-small">
+            <p class="typo-text-small-bold chart-label">Average ratings</p>
+            <canvas bind:this={reviewRatingsCanvas}></canvas>
+          </div>
+        </div>
+      {/if}
+    </div>
+  </Card>
+
+  <!-- AI Summary -->
+  <div class="full-width">
+    <Card>
+      <div class="card-content">
+        <SectionHeader label="AI Feedback Summary" icon={Star} />
+        {#if aiSummary.summary === null}
+          <p class="typo-text-small empty-text">
+            Your AI feedback summary hasn't been generated yet.
+          </p>
+        {:else}
+          <p class="typo-text">{aiSummary.summary}</p>
+          {#if aiSummary.generatedAt}
+            <p class="typo-text-small summary-footer">
+              Generated on {formatDate(aiSummary.generatedAt)}
+            </p>
+          {/if}
+        {/if}
+      </div>
+    </Card>
+  </div>
+</div>
+
+<style>
+  .stats-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+  }
+
+  .full-width {
+    grid-column: 1 / -1;
+  }
+
+  @media (max-width: 768px) {
+    .stats-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  .card-content {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .empty-text {
+    color: var(--color-foreground-level-5);
+  }
+
+  .stat-highlight {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .stat-number {
+    color: var(--color-foreground);
+  }
+
+  .stat-label {
+    color: var(--color-foreground-level-5);
+  }
+
+  .chart-container {
+    position: relative;
+    height: 16rem;
+    width: 100%;
+  }
+
+  .chart-container-small {
+    height: 14rem;
+  }
+
+  .chart-label {
+    color: var(--color-foreground-level-5);
+    margin-bottom: 0.5rem;
+  }
+
+  .review-charts {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+
+  .leaderboard-program {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .rank-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    align-items: center;
+    text-align: center;
+    padding: 0.5rem 0;
+  }
+
+  .summary-footer {
+    color: var(--color-foreground-level-5);
+  }
+</style>

--- a/src/routes/(pages)/wave/(base-layout)/stats/me/+page.ts
+++ b/src/routes/(pages)/wave/(base-layout)/stats/me/+page.ts
@@ -1,0 +1,23 @@
+import { getContributorStats, getContributorAiSummary } from '$lib/utils/wave/stats.js';
+import { redirect } from '@sveltejs/kit';
+
+export const load = async ({ parent, url, fetch, depends }) => {
+  const { user } = await parent();
+
+  if (!user) {
+    throw redirect(302, `/wave/login?backTo=${encodeURIComponent(url.pathname + url.search)}`);
+  }
+
+  depends('wave:stats');
+
+  const [stats, aiSummary] = await Promise.all([
+    getContributorStats(fetch),
+    getContributorAiSummary(fetch),
+  ]);
+
+  return {
+    user,
+    stats,
+    aiSummary,
+  };
+};


### PR DESCRIPTION
## Summary
- Add `/wave/stats/me` page displaying contributor stats with Chart.js visualizations
- Points (bar chart), Issues (doughnut), Leaderboard Ranks (line chart / rank card), Reviews (doughnut + radar), AI Feedback Summary
- Card-based grid layout on wide screens, single column on mobile
- Add "My Stats" nav item to sidenav
- Add Zod schemas and API fetch functions for stats endpoints

**Depends on:** drips-network/wave#feat/contributor-stats-dashboard (backend stats endpoints)

## Test plan
- [ ] `npm run dev` starts without errors
- [ ] Navigate to `/wave/stats/me` while logged in — page renders
- [ ] Redirects to login if not authenticated
- [ ] Charts render with correct data and theme colors
- [ ] "My Stats" appears in sidenav and highlights when active
- [ ] Responsive: grid collapses to single column on mobile