### PR TITLE
Add KYB support for org grant withdrawals

### DIFF
--- a/src/lib/flows/wave/test-transaction/confirm.svelte
+++ b/src/lib/flows/wave/test-transaction/confirm.svelte
@@ -11,7 +11,7 @@
   import { requestTestTransaction } from '$lib/utils/wave/grants';
   import type { GrantDto } from '$lib/utils/wave/types/grant';
   import type { Writable } from 'svelte/store';
-  import type { State } from './test-transaction-flow';
+  import type { State, KybData } from './test-transaction-flow';
   import CheckCircle from '$lib/components/icons/CheckCircle.svelte';
 
   const dispatch = createEventDispatcher<StepComponentEvents>();
@@ -19,9 +19,10 @@
   interface Props {
     grant: GrantDto;
     context: Writable<State>;
+    kyb?: KybData;
   }
 
-  let { grant, context }: Props = $props();
+  let { grant, context, kyb }: Props = $props();
 
   let confirmed = $state(false);
 
@@ -35,7 +36,7 @@
           undefined,
           grant.id,
           $context.stellarAddress,
-          $context.memo ? 'text' : undefined,
+          $context.memoType ?? ($context.memo ? 'text' : undefined),
           $context.memo,
         );
         await invalidate('wave:rewards');
@@ -52,6 +53,12 @@
   headline="Confirm test transaction"
   description="Please review the details below and confirm."
 >
+  {#if kyb}
+    <AnnotationBox type="info">
+      You are withdrawing on behalf of your organization to a designated wallet address.
+    </AnnotationBox>
+  {/if}
+
   <AnnotationBox type="info">
     We'll send $1 to verify your wallet can receive USDC on Stellar. Once requested, transfers will
     usually be processed within a few minutes, but may take up to 3 days in rare cases.

--- a/src/lib/flows/wave/test-transaction/enter-address.svelte
+++ b/src/lib/flows/wave/test-transaction/enter-address.svelte
@@ -9,7 +9,7 @@
   import modal from '$lib/stores/modal';
   import type { GrantDto } from '$lib/utils/wave/types/grant';
   import type { Writable } from 'svelte/store';
-  import type { State } from './test-transaction-flow';
+  import type { State, KybData } from './test-transaction-flow';
   import StellarAddressInput from '$lib/components/wave/rewards/stellar-address-input.svelte';
   import TextInput from '$lib/components/text-input/text-input.svelte';
 
@@ -18,19 +18,23 @@
   interface Props {
     grant: GrantDto;
     context: Writable<State>;
+    kyb?: KybData;
   }
 
-  let { grant, context }: Props = $props();
+  let { grant, context, kyb }: Props = $props();
 
-  let stellarAddress = $state('');
+  let stellarAddress = $state(kyb?.stellarAddress ?? '');
   let addressValid = $state(false);
-  let memo = $state('');
+  let memo = $state(kyb?.memoValue ?? '');
 
   let canSubmit = $derived(addressValid);
 
   function handleSubmit() {
     $context.stellarAddress = stellarAddress;
     $context.memo = memo || undefined;
+    if (kyb) {
+      $context.memoType = kyb.memoType ?? undefined;
+    }
     dispatch('goForward');
   }
 </script>
@@ -39,10 +43,18 @@
   headline="Request test transaction"
   description="We'll send $1 to verify your wallet can receive USDC on Stellar. Test transactions will usually be processed within a few minutes, but may take up to 3 days in rare cases."
 >
-  <AnnotationBox type="info">
-    Make sure your wallet supports USDC on the Stellar network and has the USDC trustline enabled
-    before requesting a test transaction.
-  </AnnotationBox>
+  {#if kyb}
+    <AnnotationBox type="info">
+      You are withdrawing on behalf of your organization to a designated wallet address. The
+      destination address and memo have been set by your organization's KYB record and cannot be
+      changed.
+    </AnnotationBox>
+  {:else}
+    <AnnotationBox type="info">
+      Make sure your wallet supports USDC on the Stellar network and has the USDC trustline enabled
+      before requesting a test transaction.
+    </AnnotationBox>
+  {/if}
 
   <div class="fields">
     <FormField title="Grant" type="div">
@@ -60,19 +72,29 @@
 
     <FormField
       title="Stellar address*"
-      description="Enter your Stellar wallet address (starts with G)."
+      description={kyb
+        ? "Set by your organization's KYB record."
+        : 'Enter your Stellar wallet address (starts with G).'}
       type="div"
     >
-      <StellarAddressInput bind:value={stellarAddress} bind:isValid={addressValid} />
+      <StellarAddressInput
+        bind:value={stellarAddress}
+        bind:isValid={addressValid}
+        disabled={!!kyb}
+      />
     </FormField>
 
-    <FormField
-      title="Memo"
-      description="If the recipient address requires a memo, enter it here. If you have a memo and don't enter it, the transaction may be lost."
-      type="div"
-    >
-      <TextInput bind:value={memo} placeholder="Enter memo" />
-    </FormField>
+    {#if !kyb || kyb.memoValue}
+      <FormField
+        title="Memo"
+        description={kyb
+          ? "Set by your organization's KYB record."
+          : "If the recipient address requires a memo, enter it here. If you have a memo and don't enter it, the transaction may be lost."}
+        type="div"
+      >
+        <TextInput bind:value={memo} placeholder="Enter memo" disabled={!!kyb} />
+      </FormField>
+    {/if}
   </div>
 
   {#snippet left_actions()}

--- a/src/lib/flows/wave/test-transaction/test-transaction-flow.ts
+++ b/src/lib/flows/wave/test-transaction/test-transaction-flow.ts
@@ -1,5 +1,5 @@
 import { makeStep } from '$lib/components/stepper/types';
-import type { GrantDto } from '$lib/utils/wave/types/grant';
+import type { GrantDto, StellarMemoType } from '$lib/utils/wave/types/grant';
 import { writable } from 'svelte/store';
 import EnterAddress from './enter-address.svelte';
 import Confirm from './confirm.svelte';
@@ -8,12 +8,20 @@ import Success from './success.svelte';
 export interface State {
   stellarAddress: string;
   memo?: string;
+  memoType?: StellarMemoType;
 }
 
-export default (grant: GrantDto) => {
+export interface KybData {
+  stellarAddress: string;
+  memoType: StellarMemoType | null;
+  memoValue: string | null;
+}
+
+export default (grant: GrantDto, kyb?: KybData) => {
   const state = writable<State>({
-    stellarAddress: '',
-    memo: undefined,
+    stellarAddress: kyb?.stellarAddress ?? '',
+    memo: kyb?.memoValue ?? undefined,
+    memoType: kyb?.memoType ?? undefined,
   });
 
   return {
@@ -21,11 +29,11 @@ export default (grant: GrantDto) => {
     steps: [
       makeStep({
         component: EnterAddress,
-        props: { grant },
+        props: { grant, kyb },
       }),
       makeStep({
         component: Confirm,
-        props: { grant },
+        props: { grant, kyb },
       }),
       makeStep({
         component: Success,

--- a/src/lib/flows/wave/withdrawal/confirm.svelte
+++ b/src/lib/flows/wave/withdrawal/confirm.svelte
@@ -11,7 +11,7 @@
   import { requestWithdrawal } from '$lib/utils/wave/grants';
   import type { GrantDto } from '$lib/utils/wave/types/grant';
   import type { Writable } from 'svelte/store';
-  import type { State } from './withdrawal-flow';
+  import type { State, KybData } from './withdrawal-flow';
   import CheckCircle from '$lib/components/icons/CheckCircle.svelte';
 
   const dispatch = createEventDispatcher<StepComponentEvents>();
@@ -19,9 +19,10 @@
   interface Props {
     grant: GrantDto;
     context: Writable<State>;
+    kyb?: KybData;
   }
 
-  let { grant, context }: Props = $props();
+  let { grant, context, kyb }: Props = $props();
 
   let confirmed = $state(false);
 
@@ -35,7 +36,7 @@
           undefined,
           grant.id,
           $context.stellarAddress,
-          $context.memo ? 'text' : undefined,
+          $context.memoType ?? ($context.memo ? 'text' : undefined),
           $context.memo,
         );
         await invalidate('wave:rewards');
@@ -52,8 +53,14 @@
   headline="Confirm withdrawal"
   description="Please review the details below and confirm."
 >
+  {#if kyb}
+    <AnnotationBox type="info">
+      You are withdrawing on behalf of your organization to a designated wallet address.
+    </AnnotationBox>
+  {/if}
+
   <AnnotationBox type="warning">
-    Once submitted, withdrawals cannot be cancelled or modified. Please double-check all details.
+    Once submitted, withdrawals cannot be modified. Please double-check all details.
   </AnnotationBox>
 
   <div class="fields">

--- a/src/lib/flows/wave/withdrawal/enter-address.svelte
+++ b/src/lib/flows/wave/withdrawal/enter-address.svelte
@@ -9,7 +9,7 @@
   import modal from '$lib/stores/modal';
   import type { GrantDto } from '$lib/utils/wave/types/grant';
   import type { Writable } from 'svelte/store';
-  import type { State, PrefillData } from './withdrawal-flow';
+  import type { State, PrefillData, KybData } from './withdrawal-flow';
   import StellarAddressInput from '$lib/components/wave/rewards/stellar-address-input.svelte';
   import TextInput from '$lib/components/text-input/text-input.svelte';
 
@@ -19,19 +19,23 @@
     grant: GrantDto;
     context: Writable<State>;
     prefill?: PrefillData;
+    kyb?: KybData;
   }
 
-  let { grant, context, prefill }: Props = $props();
+  let { grant, context, prefill, kyb }: Props = $props();
 
-  let stellarAddress = $state(prefill?.stellarAddress ?? '');
+  let stellarAddress = $state(kyb?.stellarAddress ?? prefill?.stellarAddress ?? '');
   let addressValid = $state(false);
-  let memo = $state(prefill?.memo ?? '');
+  let memo = $state(kyb?.memoValue ?? prefill?.memo ?? '');
 
   let canSubmit = $derived(addressValid);
 
   function handleSubmit() {
     $context.stellarAddress = stellarAddress;
     $context.memo = memo || undefined;
+    if (kyb) {
+      $context.memoType = kyb.memoType ?? undefined;
+    }
     dispatch('goForward');
   }
 </script>
@@ -40,9 +44,17 @@
   headline="Request full withdrawal"
   description="Withdraw your grant funds to your Stellar wallet as USDC. Once requested, transfers will be processed within 1–3 business days."
 >
-  <AnnotationBox type="info">
-    Make sure your wallet supports USDC on the Stellar network and has the USDC trustline enabled.
-  </AnnotationBox>
+  {#if kyb}
+    <AnnotationBox type="info">
+      You are withdrawing on behalf of your organization to a designated wallet address. The
+      destination address and memo have been set by your organization's KYB record and cannot be
+      changed.
+    </AnnotationBox>
+  {:else}
+    <AnnotationBox type="info">
+      Make sure your wallet supports USDC on the Stellar network and has the USDC trustline enabled.
+    </AnnotationBox>
+  {/if}
 
   <div class="fields">
     <FormField title="Withdrawal amount" type="div">
@@ -54,19 +66,29 @@
 
     <FormField
       title="Stellar address*"
-      description="Enter your Stellar wallet address (starts with G)."
+      description={kyb
+        ? "Set by your organization's KYB record."
+        : 'Enter your Stellar wallet address (starts with G).'}
       type="div"
     >
-      <StellarAddressInput bind:value={stellarAddress} bind:isValid={addressValid} />
+      <StellarAddressInput
+        bind:value={stellarAddress}
+        bind:isValid={addressValid}
+        disabled={!!kyb}
+      />
     </FormField>
 
-    <FormField
-      title="Memo"
-      description="If the recipient address requires a memo, enter it here. If you have a memo and don't enter it, the transaction may be lost."
-      type="div"
-    >
-      <TextInput bind:value={memo} placeholder="Enter memo" />
-    </FormField>
+    {#if !kyb || kyb.memoValue}
+      <FormField
+        title="Memo"
+        description={kyb
+          ? "Set by your organization's KYB record."
+          : "If the recipient address requires a memo, enter it here. If you have a memo and don't enter it, the transaction may be lost."}
+        type="div"
+      >
+        <TextInput bind:value={memo} placeholder="Enter memo" disabled={!!kyb} />
+      </FormField>
+    {/if}
   </div>
 
   {#snippet left_actions()}

--- a/src/lib/flows/wave/withdrawal/withdrawal-flow.ts
+++ b/src/lib/flows/wave/withdrawal/withdrawal-flow.ts
@@ -1,5 +1,5 @@
 import { makeStep } from '$lib/components/stepper/types';
-import type { GrantDto } from '$lib/utils/wave/types/grant';
+import type { GrantDto, StellarMemoType } from '$lib/utils/wave/types/grant';
 import { writable } from 'svelte/store';
 import EnterAddress from './enter-address.svelte';
 import Confirm from './confirm.svelte';
@@ -8,6 +8,7 @@ import Success from './success.svelte';
 export interface State {
   stellarAddress: string;
   memo?: string;
+  memoType?: StellarMemoType;
 }
 
 export interface PrefillData {
@@ -15,10 +16,17 @@ export interface PrefillData {
   memo?: string;
 }
 
-export default (grant: GrantDto, prefill?: PrefillData) => {
+export interface KybData {
+  stellarAddress: string;
+  memoType: StellarMemoType | null;
+  memoValue: string | null;
+}
+
+export default (grant: GrantDto, prefill?: PrefillData, kyb?: KybData) => {
   const state = writable<State>({
-    stellarAddress: prefill?.stellarAddress ?? '',
-    memo: prefill?.memo,
+    stellarAddress: kyb?.stellarAddress ?? prefill?.stellarAddress ?? '',
+    memo: kyb?.memoValue ?? prefill?.memo,
+    memoType: kyb?.memoType ?? undefined,
   });
 
   return {
@@ -26,11 +34,11 @@ export default (grant: GrantDto, prefill?: PrefillData) => {
     steps: [
       makeStep({
         component: EnterAddress,
-        props: { grant, prefill },
+        props: { grant, prefill, kyb },
       }),
       makeStep({
         component: Confirm,
-        props: { grant },
+        props: { grant, kyb },
       }),
       makeStep({
         component: Success,

--- a/src/lib/utils/wave/kyb.ts
+++ b/src/lib/utils/wave/kyb.ts
@@ -1,0 +1,18 @@
+import z from 'zod';
+import { authenticatedCall } from './call';
+import { stellarMemoTypeSchema } from './types/grant';
+import parseRes from './utils/parse-res';
+
+const kybStatusSchema = z.object({
+  hasKyb: z.boolean(),
+  authorized: z.boolean(),
+  stellarAddress: z.string().nullable(),
+  memoType: stellarMemoTypeSchema.nullable(),
+  memoValue: z.string().nullable(),
+});
+
+export type KybStatus = z.infer<typeof kybStatusSchema>;
+
+export async function getKybStatus(f = fetch, orgId: string) {
+  return parseRes(kybStatusSchema, await authenticatedCall(f, `/api/orgs/${orgId}/kyb`));
+}

--- a/src/routes/(pages)/wave/(base-layout)/rewards/+page.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/rewards/+page.svelte
@@ -20,14 +20,37 @@
   let {
     grants: { data: grants },
     kycStatus,
+    kybByOrg,
   } = $derived(data);
 
   let kycApproved = $derived(kycStatus.reviewAnswer === 'GREEN');
 
+  function getKybForGrant(grant: GrantDto) {
+    return grant.isOrgGrant && grant.orgId ? kybByOrg[grant.orgId] : undefined;
+  }
+
+  function canActOnGrant(grant: GrantDto): boolean {
+    const kyb = getKybForGrant(grant);
+    if (kyb?.hasKyb) return kyb.authorized;
+    return kycApproved;
+  }
+
   let loadingWithdrawalGrantId = $state<string | null>(null);
 
+  function getKybDataForGrant(grant: GrantDto) {
+    const kyb = getKybForGrant(grant);
+    if (kyb?.hasKyb && kyb.authorized && kyb.stellarAddress) {
+      return {
+        stellarAddress: kyb.stellarAddress,
+        memoType: kyb.memoType,
+        memoValue: kyb.memoValue,
+      };
+    }
+    return undefined;
+  }
+
   function openTestTransactionFlow(grant: GrantDto) {
-    modal.show(Stepper, undefined, testTransactionFlow(grant));
+    modal.show(Stepper, undefined, testTransactionFlow(grant, getKybDataForGrant(grant)));
   }
 
   function getLastSuccessfulTestTransaction(g: GrantDetailDto) {
@@ -39,12 +62,14 @@
   async function openWithdrawalFlow(grant: GrantDto) {
     loadingWithdrawalGrantId = grant.id;
     try {
+      const kybData = getKybDataForGrant(grant);
       const grantDetail = await getGrant(fetch, grant.id);
       const lastTest = grantDetail ? getLastSuccessfulTestTransaction(grantDetail) : undefined;
-      const prefill = lastTest
-        ? { stellarAddress: lastTest.stellarAddress, memo: lastTest.memoValue ?? undefined }
-        : undefined;
-      modal.show(Stepper, undefined, withdrawalFlow(grant, prefill));
+      const prefill =
+        !kybData && lastTest
+          ? { stellarAddress: lastTest.stellarAddress, memo: lastTest.memoValue ?? undefined }
+          : undefined;
+      modal.show(Stepper, undefined, withdrawalFlow(grant, prefill, kybData));
     } finally {
       loadingWithdrawalGrantId = null;
     }
@@ -76,103 +101,113 @@
 
 <HeadMeta title="Reward Grants | Wave" />
 
-<Section
-  header={{
-    label: 'Your Reward Grants',
-    icon: Orgs,
-    infoTooltip: 'View and withdraw your earned grants from completed Wave contributions.',
-  }}
-  skeleton={{
-    loaded: true,
-    empty: grants.length === 0,
-    emptyStateEmoji: '💰',
-    emptyStateHeadline: 'No current Reward Grants available',
-    emptyStateText:
-      "Rewards are made available when Points for rewards have been frozen after each Wave. You'll receive an email notification when a grant is available.",
-  }}
->
-  {#if !kycApproved}
-    <div class="kyc-warning">
-      <AnnotationBox type="warning">
-        <span>
-          You need to complete identity verification before you can withdraw funds.
-          <a href="/wave/settings/identity-and-payments">Verify your identity</a>
-        </span>
-      </AnnotationBox>
-    </div>
-  {/if}
+<div class="page">
+  <Section
+    header={{
+      label: 'Your Reward Grants',
+      icon: Orgs,
+      infoTooltip: 'View and withdraw your earned grants from completed Wave contributions.',
+    }}
+    skeleton={{
+      loaded: true,
+      empty: grants.length === 0,
+      emptyStateEmoji: '💰',
+      emptyStateHeadline: 'No current Reward Grants available',
+      emptyStateText:
+        "Rewards are made available when Points for rewards have been frozen after each Wave. You'll receive an email notification when a grant is available.",
+    }}
+  >
+    {#if !kycApproved}
+      <div class="kyc-warning">
+        <AnnotationBox type="warning">
+          <span>
+            You need to complete identity verification before you can withdraw grants.
+            <a href="/wave/settings/identity-and-payments">Verify your identity</a>
+          </span>
+        </AnnotationBox>
+      </div>
+    {/if}
 
-  <div class="grants-list">
-    {#each grants as grant (grant.id)}
-      <a href="/wave/rewards/{grant.id}" class="grant-card">
-        <div class="grant-info">
-          <div class="grant-header">
-            <span class="program-name typo-text-bold"
-              >{grant.waveProgramName} Wave {grant.waveNumber}</span
-            >
-            <GrantStatusBadge status={grant.status} expired={isExpired(grant)} size="small" />
-            {#if grant.isOrgGrant}
-              <StatusBadge size="small" color="primary" icon={Orgs}>
-                <span
-                  style="display: inline-flex; align-items: center; gap: 0.25rem;"
-                  title="This grant is issued to your organization and can be withdrawn by anyone within the org."
-                >
-                  Org grant
-                  <InfoCircle
-                    style="width: 1rem; height: 1rem; fill: currentColor; cursor: help;"
-                  />
-                </span>
-              </StatusBadge>
-            {/if}
-          </div>
-          {#if grant.description}
-            <p class="grant-description typo-text-small">{grant.description}</p>
-          {/if}
-          <div class="grant-amount">
-            <span class="amount tnum">${grant.initialAmountUSD.toLocaleString()}</span>
-            <span class="currency">USD</span>
-          </div>
-        </div>
-
-        <div class="grant-right">
-          {#if !isExpired(grant) && !isProcessing(grant.status) && grant.status !== 'withdrawal_complete'}
-            <!-- svelte-ignore a11y_click_events_have_key_events -->
-            <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-            <div class="grant-actions" onclick={(e) => e.preventDefault()} role="group">
-              {#if canRequestTest(grant)}
-                <Button
-                  variant="primary"
-                  onclick={() => openTestTransactionFlow(grant)}
-                  disabled={!kycApproved}
-                >
-                  Request test
-                </Button>
-              {/if}
-              {#if canWithdraw(grant)}
-                <Button
-                  variant={grant.status === 'test_transaction_sent' ? 'primary' : 'normal'}
-                  onclick={() => openWithdrawalFlow(grant)}
-                  disabled={!kycApproved}
-                  loading={loadingWithdrawalGrantId === grant.id}
-                >
-                  Request full withdrawal
-                </Button>
+    <div class="grants-list">
+      {#each grants as grant (grant.id)}
+        <a href="/wave/rewards/{grant.id}" class="grant-card">
+          <div class="grant-info">
+            <div class="grant-header">
+              <span class="program-name typo-text-bold"
+                >{grant.waveProgramName} Wave {grant.waveNumber}</span
+              >
+              <GrantStatusBadge status={grant.status} expired={isExpired(grant)} size="small" />
+              {#if grant.isOrgGrant}
+                <StatusBadge size="small" color="primary" icon={Orgs}>
+                  <span
+                    style="display: inline-flex; align-items: center; gap: 0.25rem;"
+                    title={getKybForGrant(grant)?.hasKyb
+                      ? 'This grant is issued to your organization. Withdrawals are managed through entity verification (KYB) and restricted to authorized accounts.'
+                      : 'This grant is issued to your organization and can be withdrawn by anyone within the org.'}
+                  >
+                    Org grant
+                    <InfoCircle
+                      style="width: 1rem; height: 1rem; fill: currentColor; cursor: help;"
+                    />
+                  </span>
+                </StatusBadge>
               {/if}
             </div>
-          {/if}
-
-          <div class="chevron">
-            <ChevronRight
-              style="width: 1.25rem; height: 1.25rem; fill: var(--color-foreground-level-4);"
-            />
+            {#if grant.description}
+              <p class="grant-description typo-text-small">{grant.description}</p>
+            {/if}
+            <div class="grant-amount">
+              <span class="amount tnum">${grant.initialAmountUSD.toLocaleString()}</span>
+              <span class="currency">USD</span>
+            </div>
           </div>
-        </div>
-      </a>
-    {/each}
-  </div>
-</Section>
+
+          <div class="grant-right">
+            {#if !isExpired(grant) && !isProcessing(grant.status) && grant.status !== 'withdrawal_complete'}
+              <!-- svelte-ignore a11y_click_events_have_key_events -->
+              <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+              <div class="grant-actions" onclick={(e) => e.preventDefault()} role="group">
+                {#if canRequestTest(grant)}
+                  <Button
+                    variant="primary"
+                    onclick={() => openTestTransactionFlow(grant)}
+                    disabled={!canActOnGrant(grant)}
+                  >
+                    Request test
+                  </Button>
+                {/if}
+                {#if canWithdraw(grant)}
+                  <Button
+                    variant={grant.status === 'test_transaction_sent' ? 'primary' : 'normal'}
+                    onclick={() => openWithdrawalFlow(grant)}
+                    disabled={!canActOnGrant(grant)}
+                    loading={loadingWithdrawalGrantId === grant.id}
+                  >
+                    Request full withdrawal
+                  </Button>
+                {/if}
+              </div>
+            {/if}
+
+            <div class="chevron">
+              <ChevronRight
+                style="width: 1.25rem; height: 1.25rem; fill: var(--color-foreground-level-4);"
+              />
+            </div>
+          </div>
+        </a>
+      {/each}
+    </div>
+  </Section>
+</div>
 
 <style>
+  .page {
+    max-width: 90rem;
+    margin: 0 auto;
+    width: 100%;
+  }
+
   .kyc-warning {
     margin-bottom: 1rem;
   }

--- a/src/routes/(pages)/wave/(base-layout)/rewards/+page.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/rewards/+page.svelte
@@ -35,6 +35,10 @@
     return kycApproved;
   }
 
+  let hasAnyGrantRequiringKyc = $derived(
+    grants.length === 0 || grants.some((g) => !getKybForGrant(g)?.hasKyb),
+  );
+
   let loadingWithdrawalGrantId = $state<string | null>(null);
 
   function getKybDataForGrant(grant: GrantDto) {
@@ -117,7 +121,7 @@
         "Rewards are made available when Points for rewards have been frozen after each Wave. You'll receive an email notification when a grant is available.",
     }}
   >
-    {#if !kycApproved}
+    {#if !kycApproved && hasAnyGrantRequiringKyc}
       <div class="kyc-warning">
         <AnnotationBox type="warning">
           <span>

--- a/src/routes/(pages)/wave/(base-layout)/rewards/+page.ts
+++ b/src/routes/(pages)/wave/(base-layout)/rewards/+page.ts
@@ -1,5 +1,6 @@
 import { getGrants } from '$lib/utils/wave/grants.js';
 import { getKycStatus } from '$lib/utils/wave/kyc.js';
+import { getKybStatus, type KybStatus } from '$lib/utils/wave/kyb.js';
 import { redirect } from '@sveltejs/kit';
 
 export const load = async ({ parent, url, fetch, depends }) => {
@@ -16,9 +17,19 @@ export const load = async ({ parent, url, fetch, depends }) => {
     getKycStatus(fetch),
   ]);
 
+  // Fetch KYB status for each unique org among org grants
+  const orgIds = [
+    ...new Set(grants.data.filter((g) => g.isOrgGrant && g.orgId).map((g) => g.orgId!)),
+  ];
+  const kybEntries = await Promise.all(
+    orgIds.map(async (orgId) => [orgId, await getKybStatus(fetch, orgId)] as const),
+  );
+  const kybByOrg: Record<string, KybStatus> = Object.fromEntries(kybEntries);
+
   return {
     user,
     grants,
     kycStatus,
+    kybByOrg,
   };
 };

--- a/src/routes/(pages)/wave/(base-layout)/rewards/+page.ts
+++ b/src/routes/(pages)/wave/(base-layout)/rewards/+page.ts
@@ -22,9 +22,17 @@ export const load = async ({ parent, url, fetch, depends }) => {
     ...new Set(grants.data.filter((g) => g.isOrgGrant && g.orgId).map((g) => g.orgId!)),
   ];
   const kybEntries = await Promise.all(
-    orgIds.map(async (orgId) => [orgId, await getKybStatus(fetch, orgId)] as const),
+    orgIds.map(async (orgId) => {
+      try {
+        return [orgId, await getKybStatus(fetch, orgId)] as const;
+      } catch {
+        return null;
+      }
+    }),
   );
-  const kybByOrg: Record<string, KybStatus> = Object.fromEntries(kybEntries);
+  const kybByOrg: Record<string, KybStatus> = Object.fromEntries(
+    kybEntries.filter((e) => e !== null),
+  );
 
   return {
     user,

--- a/src/routes/(pages)/wave/(base-layout)/rewards/[grantId]/+page.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/rewards/[grantId]/+page.svelte
@@ -25,12 +25,31 @@
 
   let { data } = $props();
 
-  let { grant, kycStatus } = $derived(data);
+  let { grant, kycStatus, kybStatus } = $derived(data);
 
   let kycApproved = $derived(kycStatus.reviewAnswer === 'GREEN');
 
+  // KYB state: if the org has KYB, it overrides KYC requirements
+  let hasKyb = $derived(kybStatus?.hasKyb ?? false);
+  let kybAuthorized = $derived(kybStatus?.authorized ?? false);
+
+  // Can the user take withdrawal actions?
+  // KYB authorized users bypass KYC. Non-KYB users need KYC approval.
+  let canAct = $derived(hasKyb ? kybAuthorized : kycApproved);
+
+  // KYB data to pass to flows when authorized
+  let kybData = $derived(
+    hasKyb && kybAuthorized && kybStatus?.stellarAddress
+      ? {
+          stellarAddress: kybStatus.stellarAddress,
+          memoType: kybStatus.memoType,
+          memoValue: kybStatus.memoValue,
+        }
+      : undefined,
+  );
+
   function openTestTransactionFlow(g: GrantDetailDto) {
-    modal.show(Stepper, undefined, testTransactionFlow(g));
+    modal.show(Stepper, undefined, testTransactionFlow(g, kybData));
   }
 
   function getLastSuccessfulTestTransaction(g: GrantDetailDto) {
@@ -41,10 +60,11 @@
 
   function openWithdrawalFlow(g: GrantDetailDto) {
     const lastTest = getLastSuccessfulTestTransaction(g);
-    const prefill = lastTest
-      ? { stellarAddress: lastTest.stellarAddress, memo: lastTest.memoValue ?? undefined }
-      : undefined;
-    modal.show(Stepper, undefined, withdrawalFlow(g, prefill));
+    const prefill =
+      !kybData && lastTest
+        ? { stellarAddress: lastTest.stellarAddress, memo: lastTest.memoValue ?? undefined }
+        : undefined;
+    modal.show(Stepper, undefined, withdrawalFlow(g, prefill, kybData));
   }
 
   let cancellingWithdrawal = $state(false);
@@ -114,12 +134,34 @@
           </div>
         {/if}
 
-        {#if !kycApproved}
+        {#if hasKyb && !kybAuthorized}
+          <!-- Hard block: user is not on the KYB allowlist -->
           <div class="kyc-warning">
             <AnnotationBox type="warning">
               <span>
-                You need to complete identity verification before you can withdraw funds.
+                This organization uses entity-level verification (KYB) for withdrawals. Your account
+                is not on the authorized withdrawal list. Please contact your organization
+                administrator for access.
+              </span>
+            </AnnotationBox>
+          </div>
+        {:else if !hasKyb && !kycApproved}
+          <!-- No KYB, personal KYC required -->
+          <div class="kyc-warning">
+            <AnnotationBox type="warning">
+              <span>
+                You need to complete identity verification before you can withdraw grants.
                 <a href="/wave/settings/identity-and-payments">Verify your identity</a>
+              </span>
+            </AnnotationBox>
+          </div>
+        {:else if hasKyb && kybAuthorized && !kycApproved}
+          <!-- KYB authorized but no personal KYC — show informational notice -->
+          <div class="kyc-warning">
+            <AnnotationBox type="info">
+              <span>
+                You are authorized to withdraw on behalf of your organization via entity
+                verification (KYB). Personal identity verification is not required.
               </span>
             </AnnotationBox>
           </div>
@@ -148,7 +190,9 @@
               <StatusBadge size="small" color="primary" icon={Orgs}>
                 <span
                   style="display: inline-flex; align-items: center; gap: 0.25rem;"
-                  title="This grant is issued to your organization and can be withdrawn by anyone within the org."
+                  title={hasKyb
+                    ? 'This grant is issued to your organization. Withdrawals are managed through entity verification (KYB) and restricted to authorized accounts.'
+                    : 'This grant is issued to your organization and can be withdrawn by anyone within the org.'}
                 >
                   Org grant
                   <InfoCircle
@@ -179,7 +223,7 @@
             <Button
               variant="primary"
               onclick={() => openTestTransactionFlow(grant)}
-              disabled={!kycApproved}
+              disabled={!canAct}
             >
               Request test transaction
             </Button>
@@ -188,7 +232,7 @@
             <Button
               variant={grant.status === 'test_transaction_sent' ? 'primary' : 'normal'}
               onclick={() => openWithdrawalFlow(grant)}
-              disabled={!kycApproved}
+              disabled={!canAct}
             >
               Request full withdrawal
             </Button>

--- a/src/routes/(pages)/wave/(base-layout)/rewards/[grantId]/+page.ts
+++ b/src/routes/(pages)/wave/(base-layout)/rewards/[grantId]/+page.ts
@@ -1,5 +1,6 @@
 import { getGrant } from '$lib/utils/wave/grants.js';
 import { getKycStatus } from '$lib/utils/wave/kyc.js';
+import { getKybStatus } from '$lib/utils/wave/kyb.js';
 import { error, redirect } from '@sveltejs/kit';
 
 export const load = async ({ parent, url, fetch, params, depends }) => {
@@ -20,9 +21,12 @@ export const load = async ({ parent, url, fetch, params, depends }) => {
     throw error(404, 'Grant not found');
   }
 
+  const kybStatus = grant.isOrgGrant && grant.orgId ? await getKybStatus(fetch, grant.orgId) : null;
+
   return {
     user,
     grant,
     kycStatus,
+    kybStatus,
   };
 };

--- a/src/routes/(pages)/wave/(base-layout)/rewards/[grantId]/+page.ts
+++ b/src/routes/(pages)/wave/(base-layout)/rewards/[grantId]/+page.ts
@@ -21,7 +21,14 @@ export const load = async ({ parent, url, fetch, params, depends }) => {
     throw error(404, 'Grant not found');
   }
 
-  const kybStatus = grant.isOrgGrant && grant.orgId ? await getKybStatus(fetch, grant.orgId) : null;
+  let kybStatus = null;
+  if (grant.isOrgGrant && grant.orgId) {
+    try {
+      kybStatus = await getKybStatus(fetch, grant.orgId);
+    } catch {
+      // Fall back to no KYB — user will see the default KYC flow
+    }
+  }
 
   return {
     user,


### PR DESCRIPTION
## Summary
- Integrate `GET /api/orgs/:orgId/kyb` to fetch entity verification status for org grants
- When KYB is active and user is authorized: bypass personal KYC, prefill and lock the Stellar address and memo fields to the KYB-designated values
- When KYB is active and user is not authorized: show a hard block preventing withdrawal
- When no KYB: existing personal KYC flow remains unchanged
- Update org grant badge tooltips on both listing and detail pages to reflect KYB status
- Constrain rewards listing page max-width to match other pages

## Test plan
- [x] Verify org grant with no KYB record behaves exactly as before (personal KYC required)
- [x] Verify org grant with KYB + authorized user: buttons enabled without KYC, address/memo locked to KYB values, memo hidden if KYB has no memo
- [x] Verify org grant with KYB + unauthorized user: hard block message shown, buttons disabled
- [x] Verify trustline check still runs and blocks on KYB-locked addresses
- [x] Verify correct memoType is passed through to test-transaction and withdrawal API calls
- [x] Verify org grant badge tooltip text changes based on KYB status