### PR TITLE
Add repo tags with admin management tool

### DIFF
--- a/src/lib/components/wave/paginated-card-grid/paginated-card-grid.svelte
+++ b/src/lib/components/wave/paginated-card-grid/paginated-card-grid.svelte
@@ -106,6 +106,7 @@
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(20rem, 1fr));
     gap: 1rem;
+    isolation: isolate;
   }
 
   .fetch-trigger {

--- a/src/lib/components/wave/repo-preview-card/repo-preview-card.svelte
+++ b/src/lib/components/wave/repo-preview-card/repo-preview-card.svelte
@@ -17,19 +17,30 @@
   interface Props {
     repoWithDetails: WaveProgramRepoWithDetailsDto;
     actions?: Snippet;
+    tagHref?: (tagId: string) => string;
   }
 
-  let { repoWithDetails, actions }: Props = $props();
+  let { repoWithDetails, actions, tagHref }: Props = $props();
 
   const { repo, org, pointsMultiplier } = $derived(repoWithDetails);
   const isFeatured = $derived(pointsMultiplier && pointsMultiplier > 1);
+  const tagWithImage = $derived(repo.tags?.find((t) => t.imageUrl));
+  const tagImageUrl = $derived(tagWithImage?.imageUrl);
+  const tagColor = $derived(tagWithImage?.color);
+
+  const cardStyle = $derived.by(() => {
+    if (tagColor)
+      return `position: relative; background: linear-gradient(135deg, ${tagColor}15 0%, transparent 60%); border-color: ${tagColor}30;`;
+    if (isFeatured)
+      return 'background: linear-gradient(135deg, var(--color-caution-level-1) 0%, transparent 50%);';
+    return undefined;
+  });
 </script>
 
-<Card
-  style={isFeatured
-    ? 'background: linear-gradient(135deg, var(--color-caution-level-1) 0%, transparent 50%);'
-    : undefined}
->
+<Card style={cardStyle}>
+  {#if tagImageUrl}
+    <img src={tagImageUrl} alt="" class="card-bg-image" />
+  {/if}
   <div class="repo-item">
     <div class="top">
       <div class="owner-and-repo">
@@ -59,6 +70,33 @@
           <span style:color="var(--color-foreground-level-4)">No description</span>
         {/if}
       </span>
+
+      {#if repo.tags && repo.tags.length > 0}
+        <div class="tags">
+          {#each repo.tags as tag (tag.id)}
+            {#if tagHref}
+              <a
+                class="tag-badge clickable"
+                style:background-color="{tag.color}20"
+                style:color={tag.color}
+                style:border-color="{tag.color}40"
+                href={tagHref(tag.id)}
+              >
+                {tag.name}
+              </a>
+            {:else}
+              <span
+                class="tag-badge"
+                style:background-color="{tag.color}20"
+                style:color={tag.color}
+                style:border-color="{tag.color}40"
+              >
+                {tag.name}
+              </span>
+            {/if}
+          {/each}
+        </div>
+      {/if}
 
       <div class="languages">
         <ProgrammingLanguageBreakdown
@@ -109,6 +147,23 @@
     flex-direction: column;
     justify-content: space-between;
     gap: 1.5rem;
+    position: relative;
+    z-index: 1;
+  }
+
+  .card-bg-image {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    object-position: right;
+    opacity: 0.15;
+    filter: blur(2px);
+    scale: 1.05;
+    pointer-events: none;
+    mask-image: linear-gradient(to right, transparent 20%, black);
+    -webkit-mask-image: linear-gradient(to right, transparent 20%, black);
   }
 
   .top {
@@ -131,6 +186,33 @@
   .description {
     min-height: 2lh;
     color: var(--color-foreground-level-6);
+  }
+
+  .tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.375rem;
+  }
+
+  .tag-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.0625rem 0.5rem;
+    border-radius: 1rem 0 1rem 1rem;
+    font-size: 0.75rem;
+    font-weight: 500;
+    white-space: nowrap;
+    border: 1px solid;
+    background: none;
+  }
+
+  .tag-badge.clickable {
+    cursor: pointer;
+    transition: opacity 0.15s;
+  }
+
+  .tag-badge.clickable:hover {
+    opacity: 0.7;
   }
 
   .languages {

--- a/src/lib/components/wave/repos-filter-bar/repos-filter-bar.svelte
+++ b/src/lib/components/wave/repos-filter-bar/repos-filter-bar.svelte
@@ -214,13 +214,15 @@
             <div class="filter-item">
               <span class="filter-label">Org</span>
               <div class="filter-dropdown">
-                <MultiSelectFilter
-                  optionsPromise={orgOptionsPromise}
-                  selectedValues={selectedOrgs}
-                  onchange={handleOrgsChange}
-                  placeholder="Any"
-                  singleSelect
-                />
+                {#if orgOptionsPromise}
+                  <MultiSelectFilter
+                    optionsPromise={orgOptionsPromise}
+                    selectedValues={selectedOrgs}
+                    onchange={handleOrgsChange}
+                    placeholder="Any"
+                    singleSelect
+                  />
+                {/if}
               </div>
               <button
                 class="remove-filter"
@@ -234,12 +236,14 @@
             <div class="filter-item">
               <span class="filter-label">Tag</span>
               <div class="filter-dropdown">
-                <MultiSelectFilter
-                  optionsPromise={tagOptionsPromise}
-                  selectedValues={selectedTags}
-                  onchange={handleTagsChange}
-                  placeholder="Any"
-                />
+                {#if tagOptionsPromise}
+                  <MultiSelectFilter
+                    optionsPromise={tagOptionsPromise}
+                    selectedValues={selectedTags}
+                    onchange={handleTagsChange}
+                    placeholder="Any"
+                  />
+                {/if}
               </div>
               <button
                 class="remove-filter"

--- a/src/lib/components/wave/repos-filter-bar/repos-filter-bar.svelte
+++ b/src/lib/components/wave/repos-filter-bar/repos-filter-bar.svelte
@@ -2,6 +2,7 @@
   import Plus from '$lib/components/icons/Plus.svelte';
   import Cross from '$lib/components/icons/Cross.svelte';
   import type {
+    Tag,
     WaveProgramOrgDto,
     WaveProgramReposFilters,
     WaveProgramReposSortBy,
@@ -19,15 +20,17 @@
   const AVAILABLE_FILTERS: FilterType[] = [
     { key: 'primaryLanguages', label: 'Primary language' },
     { key: 'orgId', label: 'Org' },
+    { key: 'tagId', label: 'Tag' },
   ];
 
   interface Props {
     filters: WaveProgramReposFilters;
     onFiltersChange: (filters: WaveProgramReposFilters) => void;
-    orgsPromise?: Promise<WaveProgramOrgDto[]>;
+    loadOrgs?: () => Promise<WaveProgramOrgDto[]>;
+    loadTags?: () => Promise<Tag[]>;
   }
 
-  let { filters, onFiltersChange, orgsPromise }: Props = $props();
+  let { filters, onFiltersChange, loadOrgs, loadTags }: Props = $props();
 
   // Track which filters are currently visible (shown in UI)
   // Initialize with filters that already have values
@@ -63,18 +66,17 @@
     });
   });
 
-  // Org options promise
-  let orgOptionsPromise = $derived(
-    orgsPromise?.then((orgs) =>
-      orgs.map((o) => ({
-        label: o.gitHubOrgLogin,
-        value: o.id,
-      })),
-    ),
+  // Org options — loaded lazily when the filter is first shown
+  let orgOptionsPromise = $state<Promise<{ label: string; value: string }[]> | undefined>(
+    undefined,
   );
-
-  // Get selected org as array (MultiSelectFilter expects array)
   let selectedOrgs = $derived(filters.orgId ? [filters.orgId] : []);
+
+  // Tag options — loaded lazily when the filter is first shown
+  let tagOptionsPromise = $state<Promise<{ label: string; value: string }[]> | undefined>(
+    undefined,
+  );
+  let selectedTags = $derived(filters.tagId ? filters.tagId.split(',') : []);
 
   // Sort options
   const SORT_OPTIONS: { value: WaveProgramReposSortBy; label: string }[] = [
@@ -113,10 +115,36 @@
     });
   }
 
+  function handleTagsChange(tags: string[]) {
+    onFiltersChange({
+      ...filters,
+      tagId: tags.length > 0 ? tags.join(',') : undefined,
+    });
+  }
+
+  function ensureFilterDataLoaded(filterKey: keyof WaveProgramReposFilters) {
+    if (filterKey === 'orgId' && !orgOptionsPromise && loadOrgs) {
+      orgOptionsPromise = loadOrgs().then((orgs) =>
+        orgs.map((o) => ({ label: o.gitHubOrgLogin, value: o.id })),
+      );
+    }
+    if (filterKey === 'tagId' && !tagOptionsPromise && loadTags) {
+      tagOptionsPromise = loadTags().then((tags) =>
+        tags.map((t) => ({ label: t.name, value: t.id })),
+      );
+    }
+  }
+
+  // Load data for filters that are already visible on init
+  for (const key of visibleFilterKeys) {
+    ensureFilterDataLoaded(key);
+  }
+
   function addFilter(filterKey: keyof WaveProgramReposFilters) {
     if (!visibleFilterKeys.includes(filterKey)) {
       visibleFilterKeys = [...visibleFilterKeys, filterKey];
     }
+    ensureFilterDataLoaded(filterKey);
     showAddFilterDropdown = false;
   }
 
@@ -182,7 +210,7 @@
                 <Cross style="fill: var(--color-foreground-level-5)" />
               </button>
             </div>
-          {:else if key === 'orgId' && orgOptionsPromise}
+          {:else if key === 'orgId' && (orgOptionsPromise || loadOrgs)}
             <div class="filter-item">
               <span class="filter-label">Org</span>
               <div class="filter-dropdown">
@@ -198,6 +226,25 @@
                 class="remove-filter"
                 aria-label="Remove org filter"
                 onclick={() => removeFilter('orgId')}
+              >
+                <Cross style="fill: var(--color-foreground-level-5)" />
+              </button>
+            </div>
+          {:else if key === 'tagId' && (tagOptionsPromise || loadTags)}
+            <div class="filter-item">
+              <span class="filter-label">Tag</span>
+              <div class="filter-dropdown">
+                <MultiSelectFilter
+                  optionsPromise={tagOptionsPromise}
+                  selectedValues={selectedTags}
+                  onchange={handleTagsChange}
+                  placeholder="Any"
+                />
+              </div>
+              <button
+                class="remove-filter"
+                aria-label="Remove tag filter"
+                onclick={() => removeFilter('tagId')}
               >
                 <Cross style="fill: var(--color-foreground-level-5)" />
               </button>
@@ -287,6 +334,7 @@
 
   .add-filter-wrapper {
     position: relative;
+    z-index: 10;
   }
 
   .add-filter-button {

--- a/src/lib/utils/wave/tags.ts
+++ b/src/lib/utils/wave/tags.ts
@@ -1,0 +1,73 @@
+import { authenticatedCall } from './call';
+import { paginatedResponseSchema } from './types/pagination';
+import { tagSchema } from './types/waveProgram';
+import parseRes from './utils/parse-res';
+
+export async function getTags(
+  f = fetch,
+  options: { page?: number; pageSize?: number; search?: string } = {},
+) {
+  const params = new URLSearchParams();
+
+  if (options.page !== undefined) {
+    params.append('page', options.page.toString());
+  }
+
+  if (options.pageSize !== undefined) {
+    params.append('pageSize', options.pageSize.toString());
+  }
+
+  if (options.search) {
+    params.append('search', options.search);
+  }
+
+  return parseRes(
+    paginatedResponseSchema(tagSchema),
+    await authenticatedCall(f, `/api/tags?${params.toString()}`),
+  );
+}
+
+export async function createTag(
+  f = fetch,
+  data: { name: string; color: string; imageUrl?: string | null },
+) {
+  return parseRes(
+    tagSchema,
+    await authenticatedCall(f, '/api/tags', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+  );
+}
+
+export async function updateTag(
+  f = fetch,
+  tagId: string,
+  data: { name?: string; color?: string; imageUrl?: string | null },
+) {
+  return parseRes(
+    tagSchema,
+    await authenticatedCall(f, `/api/tags/${tagId}`, {
+      method: 'PATCH',
+      body: JSON.stringify(data),
+    }),
+  );
+}
+
+export async function deleteTag(f = fetch, tagId: string) {
+  await authenticatedCall(f, `/api/tags/${tagId}`, {
+    method: 'DELETE',
+  });
+}
+
+export async function assignTagToRepo(f = fetch, orgRepoId: string, tagId: string) {
+  await authenticatedCall(f, `/api/repos/${orgRepoId}/tags/${tagId}`, {
+    method: 'PUT',
+  });
+}
+
+export async function unassignTagFromRepo(f = fetch, orgRepoId: string, tagId: string) {
+  await authenticatedCall(f, `/api/repos/${orgRepoId}/tags/${tagId}`, {
+    method: 'DELETE',
+  });
+}

--- a/src/lib/utils/wave/types/waveProgram.ts
+++ b/src/lib/utils/wave/types/waveProgram.ts
@@ -77,6 +77,28 @@ export const waveProgramFiltersSchema = filterSchema(
 export type WaveProgramFilters = z.infer<typeof waveProgramFiltersSchema>;
 
 // ===========================
+// Repo Tag Types
+// ===========================
+
+export const repoTagSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  color: z.string(),
+  imageUrl: z.string().nullable().optional(),
+});
+export type RepoTag = z.infer<typeof repoTagSchema>;
+
+export const tagSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  color: z.string(),
+  imageUrl: z.string().nullable().optional(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+export type Tag = z.infer<typeof tagSchema>;
+
+// ===========================
 // Wave Program Repo Types
 // ===========================
 
@@ -121,6 +143,7 @@ export const waveProgramRepoWithDetailsDtoSchema = z.object({
     gitHubRepoUrl: z.string(),
     description: z.string().nullable(),
     languages: z.record(z.string(), z.number()).nullable(),
+    tags: z.array(repoTagSchema).optional(),
   }),
   org: z.object({
     id: z.uuid(),
@@ -184,6 +207,7 @@ export const waveProgramReposFiltersSchema = filterSchema(
     search: z.string().optional(),
     sortBy: waveProgramReposSortBySchema.optional(),
     orgId: z.uuid().optional(),
+    tagId: z.string().optional(), // comma-separated list of tag UUIDs
   }),
 );
 export type WaveProgramReposFilters = z.infer<typeof waveProgramReposFiltersSchema>;

--- a/src/lib/utils/wave/wavePrograms.ts
+++ b/src/lib/utils/wave/wavePrograms.ts
@@ -155,6 +155,28 @@ export async function rejectWaveProgramRepo(
   );
 }
 
+export async function featureWaveProgramRepo(
+  f = fetch,
+  waveProgramId: string,
+  orgRepoId: string,
+  pointsMultiplier: number,
+) {
+  await authenticatedCall(f, `/api/wave-programs/${waveProgramId}/repos/${orgRepoId}/feature`, {
+    method: 'POST',
+    body: JSON.stringify({ pointsMultiplier }),
+  });
+}
+
+export async function unfeatureWaveProgramRepo(
+  f = fetch,
+  waveProgramId: string,
+  orgRepoId: string,
+) {
+  await authenticatedCall(f, `/api/wave-programs/${waveProgramId}/repos/${orgRepoId}/feature`, {
+    method: 'DELETE',
+  });
+}
+
 export async function addIssueToWaveProgram(
   f = fetch,
   waveProgramId: string,

--- a/src/routes/(pages)/wave/(base-layout)/[waveProgramSlug]/repos/+page.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/[waveProgramSlug]/repos/+page.svelte
@@ -14,13 +14,29 @@
     WaveProgramRepoWithDetailsDto,
   } from '$lib/utils/wave/types/waveProgram';
   import type { Pagination } from '$lib/utils/wave/types/pagination';
-  import { getWaveProgramRepos } from '$lib/utils/wave/wavePrograms.js';
+  import { getWaveProgramRepos, getWaveProgramOrgs } from '$lib/utils/wave/wavePrograms.js';
+  import { getTags } from '$lib/utils/wave/tags.js';
+  import { getAllPaginated } from '$lib/utils/wave/getAllPaginated.js';
   import type { Snapshot } from './$types.js';
   import HeadMeta from '$lib/components/head-meta/head-meta.svelte';
   import Folder from '$lib/components/icons/Folder.svelte';
 
   let { data } = $props();
-  const { repos: initialRepos, waveProgram, filters, orgsPromise } = $derived(data);
+  const { repos: initialRepos, waveProgram, filters } = $derived(data);
+
+  const loadOrgs = () =>
+    getAllPaginated((page, limit) => getWaveProgramOrgs(fetch, waveProgram.id, { page, limit }));
+
+  const loadTags = () =>
+    getAllPaginated((page, limit) => getTags(fetch, { page, pageSize: limit }));
+
+  function getTagFilterHref(tagId: string): string {
+    const newFilters = { ...filters, tagId };
+    const encoded = btoa(JSON.stringify(newFilters));
+    const currentUrl = new URL(page.url);
+    currentUrl.searchParams.set('filters', encoded);
+    return currentUrl.toString();
+  }
 
   function getIssueFilterString(repoId: string) {
     const filters: IssueFilters = {
@@ -101,11 +117,9 @@
 
 <div class="page">
   <div
+    class="header-section"
     style:view-transition-name="repos-page-content"
     style:view-transition-class="element-handover"
-    style:display="flex"
-    style:flex-direction="column"
-    style:gap="1.5rem"
   >
     <Breadcrumbs
       crumbs={[
@@ -130,7 +144,9 @@
       ]}
     />
 
-    <ReposFilterBar {filters} onFiltersChange={handleApplyFilters} {orgsPromise} />
+    {#key filters}
+      <ReposFilterBar {filters} onFiltersChange={handleApplyFilters} {loadOrgs} {loadTags} />
+    {/key}
   </div>
 
   <span class="typo-text intro" style:color="var(--color-foreground-level-5)">
@@ -152,7 +168,7 @@
     bind:pagination
   >
     {#snippet card(repoWithDetails: WaveProgramRepoWithDetailsDto)}
-      <RepoPreviewCard {repoWithDetails}>
+      <RepoPreviewCard {repoWithDetails} tagHref={getTagFilterHref}>
         {#snippet actions()}
           <Button
             size="small"
@@ -179,6 +195,14 @@
     width: 100%;
     flex-direction: column;
     gap: 1.5rem;
+  }
+
+  .header-section {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    position: relative;
+    z-index: 1;
   }
 
   .intro {

--- a/src/routes/(pages)/wave/(base-layout)/[waveProgramSlug]/repos/+page.ts
+++ b/src/routes/(pages)/wave/(base-layout)/[waveProgramSlug]/repos/+page.ts
@@ -1,7 +1,6 @@
 import type { WaveProgramReposFilters } from '$lib/utils/wave/types/waveProgram.js';
 import { waveProgramReposFiltersSchema } from '$lib/utils/wave/types/waveProgram.js';
-import { getAllPaginated } from '$lib/utils/wave/getAllPaginated.js';
-import { getWaveProgramOrgs, getWaveProgramRepos } from '$lib/utils/wave/wavePrograms.js';
+import { getWaveProgramRepos } from '$lib/utils/wave/wavePrograms.js';
 import { redirect } from '@sveltejs/kit';
 
 export const load = async ({ parent, fetch, url }) => {
@@ -34,14 +33,8 @@ export const load = async ({ parent, fetch, url }) => {
     filters,
   );
 
-  // Streamed — not awaited so it doesn't block page load
-  const orgsPromise = getAllPaginated((page, limit) =>
-    getWaveProgramOrgs(fetch, waveProgram.id, { page, limit }),
-  );
-
   return {
     repos,
     filters,
-    orgsPromise,
   };
 };

--- a/src/routes/(pages)/wave/(base-layout)/admin/+page.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/admin/+page.svelte
@@ -24,6 +24,17 @@
           },
         ]
       : []),
+    ...(data.user.permissions?.includes('manageTags') ||
+    data.user.permissions?.includes('featureWaveRepos')
+      ? [
+          {
+            name: 'Repos & Tags',
+            description:
+              'Manage tags, assign them to repos, and feature repos across Wave Programs.',
+            href: '/wave/admin/repos',
+          },
+        ]
+      : []),
   ]);
 </script>
 

--- a/src/routes/(pages)/wave/(base-layout)/admin/repos/+layout.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/admin/repos/+layout.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+  import HeadMeta from '$lib/components/head-meta/head-meta.svelte';
+  import Breadcrumbs from '$lib/components/breadcrumbs/breadcrumbs.svelte';
+  import Label from '$lib/components/icons/Label.svelte';
+  import Folder from '$lib/components/icons/Folder.svelte';
+  import ScrollableTabs from '$lib/components/scrollable-tabs/scrollable-tabs.svelte';
+  import type { Snippet } from 'svelte';
+
+  const { children, data }: { children: Snippet; data: { canManageTags: boolean } } = $props();
+
+  const baseUrl = '/wave/admin/repos';
+</script>
+
+<HeadMeta title="Repos & Tags | Admin | Wave" />
+
+<div class="page">
+  <Breadcrumbs crumbs={[{ label: 'Admin', href: '/wave/admin' }, { label: 'Repos & Tags' }]} />
+
+  <div class="tabs">
+    <ScrollableTabs
+      tabs={[
+        { label: 'Repos', href: `${baseUrl}/repos`, icon: Folder },
+        ...(data.canManageTags ? [{ label: 'Tags', href: `${baseUrl}/tags`, icon: Label }] : []),
+      ]}
+    />
+  </div>
+
+  <div class="content">
+    {@render children()}
+  </div>
+</div>
+
+<style>
+  .page {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    max-width: 90rem;
+    width: 100%;
+    margin: 0 auto;
+  }
+
+  .tabs {
+    position: sticky;
+    top: 2.5rem;
+    width: 100%;
+    background-color: var(--color-background);
+    z-index: 2;
+  }
+
+  .content {
+    margin-top: 0.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+</style>

--- a/src/routes/(pages)/wave/(base-layout)/admin/repos/+layout.ts
+++ b/src/routes/(pages)/wave/(base-layout)/admin/repos/+layout.ts
@@ -1,0 +1,28 @@
+import { getTags } from '$lib/utils/wave/tags.js';
+import { getWavePrograms } from '$lib/utils/wave/wavePrograms.js';
+import { redirect } from '@sveltejs/kit';
+
+export const load = async ({ parent, fetch, depends }) => {
+  depends('wave:admin:repos');
+
+  const { user } = await parent();
+
+  const canManageTags = user.permissions?.includes('manageTags');
+  const canFeatureRepos = user.permissions?.includes('featureWaveRepos');
+
+  if (!canManageTags && !canFeatureRepos) {
+    throw redirect(302, '/wave/admin');
+  }
+
+  const [wavePrograms, tags] = await Promise.all([
+    getWavePrograms(fetch, { limit: 100 }),
+    getTags(fetch, { pageSize: 100 }),
+  ]);
+
+  return {
+    wavePrograms,
+    tags,
+    canManageTags: !!canManageTags,
+    canFeatureRepos: !!canFeatureRepos,
+  };
+};

--- a/src/routes/(pages)/wave/(base-layout)/admin/repos/+page.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/admin/repos/+page.svelte
@@ -1,0 +1,1 @@
+<!-- Redirects to /tags or /repos via +page.ts -->

--- a/src/routes/(pages)/wave/(base-layout)/admin/repos/+page.ts
+++ b/src/routes/(pages)/wave/(base-layout)/admin/repos/+page.ts
@@ -1,0 +1,5 @@
+import { redirect } from '@sveltejs/kit';
+
+export const load = async () => {
+  throw redirect(302, '/wave/admin/repos/repos');
+};

--- a/src/routes/(pages)/wave/(base-layout)/admin/repos/components/feature-repo-modal.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/admin/repos/components/feature-repo-modal.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+  import Button from '$lib/components/button/button.svelte';
+  import TextInput from '$lib/components/text-input/text-input.svelte';
+  import FormField from '$lib/components/form-field/form-field.svelte';
+  import StandaloneFlowStepLayout from '$lib/components/standalone-flow-step-layout/standalone-flow-step-layout.svelte';
+  import AnnotationBox from '$lib/components/annotation-box/annotation-box.svelte';
+  import Star from '$lib/components/icons/Star.svelte';
+  import modal from '$lib/stores/modal';
+  import { featureWaveProgramRepo } from '$lib/utils/wave/wavePrograms';
+  import type { WaveProgramRepoWithDetailsDto } from '$lib/utils/wave/types/waveProgram';
+
+  interface Props {
+    repo: WaveProgramRepoWithDetailsDto;
+    waveProgramId: string;
+    onFeatured: () => void;
+  }
+
+  let { repo, waveProgramId, onFeatured }: Props = $props();
+
+  let multiplier = $state(
+    String(repo.pointsMultiplier && repo.pointsMultiplier > 1 ? repo.pointsMultiplier : 2),
+  );
+  let submitting = $state(false);
+  let error = $state<string | null>(null);
+
+  let multiplierNum = $derived(parseInt(multiplier, 10));
+  let canSubmit = $derived(!isNaN(multiplierNum) && multiplierNum >= 2 && !submitting);
+
+  async function handleSubmit() {
+    if (!canSubmit) return;
+
+    submitting = true;
+    error = null;
+
+    try {
+      await featureWaveProgramRepo(fetch, waveProgramId, repo.repo.id, multiplierNum);
+      onFeatured();
+      modal.hide();
+    } catch (e) {
+      error = e instanceof Error ? e.message : 'An unexpected error occurred.';
+    } finally {
+      submitting = false;
+    }
+  }
+</script>
+
+<div class="modal">
+  <StandaloneFlowStepLayout headline="Feature repo" description={repo.repo.gitHubRepoFullName}>
+    <div class="fields">
+      <FormField
+        title="Points multiplier"
+        description="Issues in this repo will earn this many times the normal points. Minimum 2."
+      >
+        <TextInput bind:value={multiplier} placeholder="2" variant={{ type: 'number', min: 2 }} />
+      </FormField>
+    </div>
+
+    {#if error}
+      <AnnotationBox type="error">{error}</AnnotationBox>
+    {/if}
+
+    {#snippet actions()}
+      <Button variant="normal" disabled={submitting} onclick={modal.hide}>Cancel</Button>
+      <Button
+        variant="primary"
+        icon={Star}
+        loading={submitting}
+        disabled={!canSubmit}
+        onclick={handleSubmit}
+      >
+        Feature at {multiplierNum || '?'}x
+      </Button>
+    {/snippet}
+  </StandaloneFlowStepLayout>
+</div>
+
+<style>
+  .modal {
+    padding: 1rem;
+  }
+
+  .fields {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+</style>

--- a/src/routes/(pages)/wave/(base-layout)/admin/repos/components/manage-repo-tags-modal.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/admin/repos/components/manage-repo-tags-modal.svelte
@@ -1,0 +1,171 @@
+<script lang="ts">
+  import Button from '$lib/components/button/button.svelte';
+  import Cross from '$lib/components/icons/Cross.svelte';
+  import Dropdown from '$lib/components/dropdown/dropdown.svelte';
+  import StandaloneFlowStepLayout from '$lib/components/standalone-flow-step-layout/standalone-flow-step-layout.svelte';
+  import AnnotationBox from '$lib/components/annotation-box/annotation-box.svelte';
+  import modal from '$lib/stores/modal';
+  import { assignTagToRepo, unassignTagFromRepo } from '$lib/utils/wave/tags';
+  import type { Tag, WaveProgramRepoWithDetailsDto } from '$lib/utils/wave/types/waveProgram';
+
+  interface Props {
+    repo: WaveProgramRepoWithDetailsDto;
+    allTags: Tag[];
+    onChanged: () => void;
+  }
+
+  let { repo, allTags, onChanged }: Props = $props();
+
+  let assignedTags = $state<{ id: string; name: string; color: string }[]>([
+    ...(repo.repo.tags ?? []),
+  ]);
+  let busy = $state(false);
+  let error = $state<string | null>(null);
+
+  let availableTags = $derived(allTags.filter((t) => !assignedTags.some((at) => at.id === t.id)));
+
+  async function handleAssign(tagId: string) {
+    const tag = allTags.find((t) => t.id === tagId);
+    if (!tag) return;
+
+    busy = true;
+    error = null;
+    try {
+      await assignTagToRepo(fetch, repo.repo.id, tagId);
+      assignedTags = [...assignedTags, { id: tag.id, name: tag.name, color: tag.color }];
+      onChanged();
+    } catch (e) {
+      error = e instanceof Error ? e.message : 'Failed to assign tag.';
+    } finally {
+      busy = false;
+    }
+  }
+
+  async function handleUnassign(tagId: string) {
+    busy = true;
+    error = null;
+    try {
+      await unassignTagFromRepo(fetch, repo.repo.id, tagId);
+      assignedTags = assignedTags.filter((t) => t.id !== tagId);
+      onChanged();
+    } catch (e) {
+      error = e instanceof Error ? e.message : 'Failed to remove tag.';
+    } finally {
+      busy = false;
+    }
+  }
+</script>
+
+<div class="modal">
+  <StandaloneFlowStepLayout headline="Manage tags" description={repo.repo.gitHubRepoFullName}>
+    <div class="content">
+      <div class="assigned-tags">
+        {#if assignedTags.length === 0}
+          <span class="typo-text-small dim">No tags assigned.</span>
+        {:else}
+          {#each assignedTags as tag (tag.id)}
+            <span
+              class="tag-badge"
+              style:background-color="{tag.color}20"
+              style:color={tag.color}
+              style:border-color="{tag.color}40"
+            >
+              {tag.name}
+              <button
+                class="tag-remove"
+                style:color={tag.color}
+                disabled={busy}
+                onclick={() => handleUnassign(tag.id)}
+                aria-label="Remove tag {tag.name}"
+              >
+                <Cross style="width: 0.75rem; height: 0.75rem; fill: currentColor" />
+              </button>
+            </span>
+          {/each}
+        {/if}
+      </div>
+
+      {#if availableTags.length > 0}
+        <div class="add-tag">
+          <span class="typo-text-small dim">Add tag:</span>
+          <Dropdown
+            small
+            value={undefined}
+            options={availableTags.map((t) => ({ value: t.id, title: t.name }))}
+            onchange={handleAssign}
+          />
+        </div>
+      {/if}
+
+      {#if error}
+        <AnnotationBox type="error">{error}</AnnotationBox>
+      {/if}
+    </div>
+
+    {#snippet actions()}
+      <Button variant="primary" onclick={modal.hide}>Done</Button>
+    {/snippet}
+  </StandaloneFlowStepLayout>
+</div>
+
+<style>
+  .modal {
+    padding: 1rem;
+  }
+
+  .content {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .assigned-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    align-items: center;
+    min-height: 2rem;
+  }
+
+  .tag-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.125rem 0.5rem;
+    border-radius: 1rem 0 1rem 1rem;
+    font-size: 0.75rem;
+    font-weight: 500;
+    white-space: nowrap;
+    border: 1px solid;
+  }
+
+  .tag-remove {
+    display: inline-flex;
+    align-items: center;
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    opacity: 0.7;
+    transition: opacity 0.15s;
+  }
+
+  .tag-remove:hover {
+    opacity: 1;
+  }
+
+  .tag-remove:disabled {
+    opacity: 0.3;
+    cursor: default;
+  }
+
+  .add-tag {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .dim {
+    color: var(--color-foreground-level-5);
+  }
+</style>

--- a/src/routes/(pages)/wave/(base-layout)/admin/repos/components/tag-modal.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/admin/repos/components/tag-modal.svelte
@@ -1,0 +1,175 @@
+<script lang="ts">
+  import Button from '$lib/components/button/button.svelte';
+  import TextInput from '$lib/components/text-input/text-input.svelte';
+  import FormField from '$lib/components/form-field/form-field.svelte';
+  import StandaloneFlowStepLayout from '$lib/components/standalone-flow-step-layout/standalone-flow-step-layout.svelte';
+  import AnnotationBox from '$lib/components/annotation-box/annotation-box.svelte';
+  import modal from '$lib/stores/modal';
+  import { createTag, updateTag } from '$lib/utils/wave/tags';
+  import type { Tag } from '$lib/utils/wave/types/waveProgram';
+
+  interface Props {
+    onSaved: () => void;
+    existingTag?: Tag;
+  }
+
+  let { onSaved, existingTag }: Props = $props();
+
+  const isEdit = $derived(!!existingTag);
+
+  let name = $state(existingTag?.name ?? '');
+  let color = $state(existingTag?.color ?? '#6366f1');
+  let imageUrl = $state(existingTag?.imageUrl ?? '');
+  let submitting = $state(false);
+  let error = $state<string | null>(null);
+
+  const COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/;
+
+  const nameValid = $derived(name.trim().length >= 1 && name.trim().length <= 50);
+  const colorValid = $derived(COLOR_PATTERN.test(color));
+  const canSubmit = $derived(nameValid && colorValid && !submitting);
+
+  async function handleSubmit() {
+    if (!canSubmit) return;
+
+    submitting = true;
+    error = null;
+
+    try {
+      const data = {
+        name: name.trim(),
+        color,
+        imageUrl: imageUrl.trim() || null,
+      };
+
+      if (isEdit && existingTag) {
+        await updateTag(fetch, existingTag.id, data);
+      } else {
+        await createTag(fetch, data);
+      }
+      onSaved();
+      modal.hide();
+    } catch (e) {
+      error = e instanceof Error ? e.message : 'An unexpected error occurred.';
+    } finally {
+      submitting = false;
+    }
+  }
+</script>
+
+<div class="modal">
+  <StandaloneFlowStepLayout
+    headline={isEdit ? 'Edit tag' : 'Create tag'}
+    description={isEdit
+      ? 'Update the tag name or color.'
+      : 'Create a new tag that can be assigned to repos.'}
+  >
+    <div class="fields">
+      <FormField title="Name" description="1–50 characters.">
+        <TextInput bind:value={name} placeholder="e.g. DeFi" />
+      </FormField>
+
+      <FormField title="Color" description="Hex color code.">
+        <div class="color-field">
+          <input type="color" bind:value={color} class="color-picker" />
+          <TextInput bind:value={color} placeholder="#6366f1" />
+        </div>
+      </FormField>
+
+      <FormField title="Image URL" description="Optional. Displayed as a background on repo cards.">
+        <TextInput bind:value={imageUrl} placeholder="https://example.com/image.png" />
+      </FormField>
+
+      {#if imageUrl.trim()}
+        <div class="image-preview">
+          <span class="typo-text-small" style:color="var(--color-foreground-level-5)"
+            >Image preview:</span
+          >
+          <img src={imageUrl.trim()} alt="Tag image preview" class="preview-img" />
+        </div>
+      {/if}
+
+      <div class="preview">
+        <span class="typo-text-small" style:color="var(--color-foreground-level-5)">Preview:</span>
+        <span
+          class="tag-preview"
+          style:background-color="{color}20"
+          style:color
+          style:border-color="{color}40"
+        >
+          {name || 'Tag name'}
+        </span>
+      </div>
+    </div>
+
+    {#if error}
+      <AnnotationBox type="error">{error}</AnnotationBox>
+    {/if}
+
+    {#snippet actions()}
+      <Button variant="normal" disabled={submitting} onclick={modal.hide}>Cancel</Button>
+      <Button variant="primary" loading={submitting} disabled={!canSubmit} onclick={handleSubmit}>
+        {isEdit ? 'Save' : 'Create'}
+      </Button>
+    {/snippet}
+  </StandaloneFlowStepLayout>
+</div>
+
+<style>
+  .modal {
+    padding: 1rem;
+  }
+
+  .fields {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .color-field {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+  }
+
+  .color-picker {
+    width: 2.5rem;
+    height: 2.5rem;
+    border: 1px solid var(--color-foreground-level-2);
+    border-radius: 0.5rem;
+    padding: 0.125rem;
+    cursor: pointer;
+    flex-shrink: 0;
+  }
+
+  .image-preview {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .preview-img {
+    width: 100%;
+    max-height: 6rem;
+    object-fit: contain;
+    border-radius: 0.5rem;
+    background: var(--color-foreground-level-1);
+  }
+
+  .preview {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .tag-preview {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.0625rem 0.5rem;
+    border-radius: 1rem 0 1rem 1rem;
+    font-size: 0.75rem;
+    font-weight: 500;
+    white-space: nowrap;
+    border: 1px solid;
+  }
+</style>

--- a/src/routes/(pages)/wave/(base-layout)/admin/repos/repos/+page.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/admin/repos/repos/+page.svelte
@@ -1,0 +1,245 @@
+<script lang="ts">
+  import { goto, invalidate } from '$app/navigation';
+  import { page } from '$app/state';
+  import Button from '$lib/components/button/button.svelte';
+  import Dropdown from '$lib/components/dropdown/dropdown.svelte';
+  import Label from '$lib/components/icons/Label.svelte';
+  import Star from '$lib/components/icons/Star.svelte';
+  import PaginatedCardGrid from '$lib/components/wave/paginated-card-grid/paginated-card-grid.svelte';
+  import RepoPreviewCard from '$lib/components/wave/repo-preview-card/repo-preview-card.svelte';
+  import ReposFilterBar from '$lib/components/wave/repos-filter-bar/repos-filter-bar.svelte';
+  import modal from '$lib/stores/modal';
+  import doWithConfirmationModal from '$lib/utils/do-with-confirmation-modal';
+  import doWithErrorModal from '$lib/utils/do-with-error-modal';
+  import { unfeatureWaveProgramRepo, getWaveProgramRepos } from '$lib/utils/wave/wavePrograms';
+  import type {
+    WaveProgramReposFilters,
+    WaveProgramRepoWithDetailsDto,
+  } from '$lib/utils/wave/types/waveProgram';
+  import type { Pagination } from '$lib/utils/wave/types/pagination';
+  import ManageRepoTagsModal from '../components/manage-repo-tags-modal.svelte';
+  import FeatureRepoModal from '../components/feature-repo-modal.svelte';
+
+  let { data } = $props();
+
+  let tags = $derived(data.tags);
+  let wavePrograms = $derived(data.wavePrograms);
+  let canManageTags = $derived(data.canManageTags);
+  let canFeatureRepos = $derived(data.canFeatureRepos);
+
+  let waveProgramId = $derived(data.waveProgramId);
+  let repos = $derived(data.repos);
+  let filters = $derived(data.filters);
+
+  const loadOrgs = () => data.orgsPromise;
+  const loadTags = () => Promise.resolve(tags.data);
+
+  let waveProgramOptions = $derived(
+    wavePrograms.data.map((wp) => ({
+      value: wp.id,
+      title: wp.name,
+    })),
+  );
+
+  // === URL-based navigation ===
+
+  function updateUrl(params: Record<string, string | undefined>) {
+    const currentUrl = new URL(page.url);
+    for (const [key, value] of Object.entries(params)) {
+      if (value === undefined || value === '') {
+        currentUrl.searchParams.delete(key);
+      } else {
+        currentUrl.searchParams.set(key, value);
+      }
+    }
+    return goto(currentUrl.toString(), { noScroll: true, keepFocus: true });
+  }
+
+  function handleWaveProgramChange(value: string) {
+    const currentUrl = new URL(page.url);
+    currentUrl.searchParams.set('waveProgramId', value);
+    currentUrl.searchParams.delete('filters');
+    goto(currentUrl.toString(), { noScroll: true, keepFocus: true });
+  }
+
+  async function handleApplyFilters(newFilters: WaveProgramReposFilters) {
+    if (JSON.stringify(newFilters) === JSON.stringify(filters)) return;
+
+    const encodedFilters =
+      Object.values(newFilters).filter((v) => !!v).length === 0
+        ? ''
+        : btoa(JSON.stringify(newFilters));
+
+    await updateUrl({ filters: encodedFilters });
+  }
+
+  function getTagFilterHref(tagId: string): string {
+    const newFilters = { ...filters, tagId };
+    const encoded = btoa(JSON.stringify(newFilters));
+    const currentUrl = new URL(page.url);
+    currentUrl.searchParams.set('filters', encoded);
+    return currentUrl.toString();
+  }
+
+  // === PaginatedCardGrid state ===
+
+  // svelte-ignore state_referenced_locally
+  let items = $state<WaveProgramRepoWithDetailsDto[]>(repos?.data ?? []);
+  // svelte-ignore state_referenced_locally
+  let pagination = $state<Pagination>(
+    repos?.pagination ?? {
+      total: 0,
+      page: 1,
+      limit: 20,
+      totalPages: 0,
+      hasNextPage: false,
+      hasPreviousPage: false,
+    },
+  );
+
+  async function fetchMore(nextPage: number) {
+    return getWaveProgramRepos(undefined, waveProgramId!, { page: nextPage, limit: 20 }, filters);
+  }
+
+  // === Admin actions ===
+
+  async function reloadPage() {
+    await invalidate('wave:admin:repos');
+  }
+
+  function openManageTagsModal(repo: WaveProgramRepoWithDetailsDto) {
+    modal.show(ManageRepoTagsModal, undefined, {
+      repo,
+      allTags: tags.data,
+      onChanged: reloadPage,
+    });
+  }
+
+  function openFeatureModal(repo: WaveProgramRepoWithDetailsDto) {
+    modal.show(FeatureRepoModal, undefined, {
+      repo,
+      waveProgramId: waveProgramId!,
+      onFeatured: reloadPage,
+    });
+  }
+
+  async function handleUnfeature(repo: WaveProgramRepoWithDetailsDto) {
+    await doWithConfirmationModal(
+      `Remove featured status from ${repo.repo.gitHubRepoFullName}?`,
+      () =>
+        doWithErrorModal(async () => {
+          await unfeatureWaveProgramRepo(fetch, waveProgramId!, repo.repo.id);
+          await reloadPage();
+        }),
+    );
+  }
+</script>
+
+<div class="repos-page">
+  <div class="header-row">
+    <h3 class="typo-header-4">Repos</h3>
+    <Dropdown
+      value={waveProgramId ?? undefined}
+      options={waveProgramOptions}
+      onchange={handleWaveProgramChange}
+    />
+  </div>
+
+  {#if waveProgramId && repos}
+    <div class="filter-section">
+      {#key filters}
+        <ReposFilterBar {filters} onFiltersChange={handleApplyFilters} {loadOrgs} {loadTags} />
+      {/key}
+    </div>
+
+    <span class="typo-text intro" style:color="var(--color-foreground-level-5)">
+      {#if pagination.total === 0}
+        No matching repos found.
+      {:else}
+        Showing {pagination.total} matching repo{pagination.total === 1 ? '' : 's'}.
+      {/if}
+    </span>
+
+    <PaginatedCardGrid
+      initialData={repos}
+      {fetchMore}
+      key={(item) => item.repo.id}
+      bind:items
+      bind:pagination
+    >
+      {#snippet card(repoWithDetails: WaveProgramRepoWithDetailsDto)}
+        <RepoPreviewCard {repoWithDetails} tagHref={getTagFilterHref}>
+          {#snippet actions()}
+            <div class="admin-actions">
+              {#if canManageTags}
+                <Button
+                  size="small"
+                  icon={Label}
+                  onclick={() => openManageTagsModal(repoWithDetails)}>Tags</Button
+                >
+              {/if}
+
+              {#if canFeatureRepos}
+                {#if repoWithDetails.pointsMultiplier && repoWithDetails.pointsMultiplier > 1}
+                  <Button
+                    size="small"
+                    variant="destructive-outline"
+                    icon={Star}
+                    onclick={() => handleUnfeature(repoWithDetails)}>Unfeature</Button
+                  >
+                {:else}
+                  <Button
+                    size="small"
+                    variant="primary"
+                    icon={Star}
+                    onclick={() => openFeatureModal(repoWithDetails)}>Feature</Button
+                  >
+                {/if}
+              {/if}
+            </div>
+          {/snippet}
+        </RepoPreviewCard>
+      {/snippet}
+    </PaginatedCardGrid>
+  {:else}
+    <p class="typo-text dim">No Wave Programs available.</p>
+  {/if}
+</div>
+
+<style>
+  .repos-page {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+
+  .header-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    flex-wrap: wrap;
+  }
+
+  .filter-section {
+    position: relative;
+    z-index: 1;
+  }
+
+  .intro {
+    max-width: 36rem;
+  }
+
+  .admin-actions {
+    display: flex;
+    gap: 0.375rem;
+    flex-wrap: wrap;
+    font-size: 0.75rem;
+    scale: 0.9;
+    transform-origin: left center;
+  }
+
+  .dim {
+    color: var(--color-foreground-level-5);
+  }
+</style>

--- a/src/routes/(pages)/wave/(base-layout)/admin/repos/repos/+page.ts
+++ b/src/routes/(pages)/wave/(base-layout)/admin/repos/repos/+page.ts
@@ -1,0 +1,53 @@
+import type { WaveProgramReposFilters } from '$lib/utils/wave/types/waveProgram.js';
+import { waveProgramReposFiltersSchema } from '$lib/utils/wave/types/waveProgram.js';
+import { getAllPaginated } from '$lib/utils/wave/getAllPaginated.js';
+import { getWaveProgramOrgs, getWaveProgramRepos } from '$lib/utils/wave/wavePrograms.js';
+import { redirect } from '@sveltejs/kit';
+
+export const load = async ({ parent, fetch, url }) => {
+  const { wavePrograms } = await parent();
+
+  // Get waveProgramId from URL, or default to the first one
+  let waveProgramId = url.searchParams.get('waveProgramId');
+
+  if (!waveProgramId && wavePrograms.data.length > 0) {
+    waveProgramId = wavePrograms.data[0].id;
+    const currentUrl = new URL(url);
+    currentUrl.searchParams.set('waveProgramId', waveProgramId);
+    throw redirect(302, `${currentUrl.pathname}?${currentUrl.searchParams.toString()}`);
+  }
+
+  if (!waveProgramId) {
+    return { repos: null, filters: {}, waveProgramId: null, orgsPromise: Promise.resolve([]) };
+  }
+
+  // Parse filters from URL
+  const filtersParam = url.searchParams.get('filters');
+  const filtersParamDecoded = filtersParam ? atob(filtersParam) : null;
+  const filtersParamParseResult = waveProgramReposFiltersSchema
+    .nullable()
+    .safeParse(filtersParamDecoded ? JSON.parse(filtersParamDecoded) : null);
+
+  if (!filtersParamParseResult.success) {
+    const currentParams = new URLSearchParams(url.search);
+    currentParams.delete('filters');
+    throw redirect(302, `${url.pathname}?${currentParams.toString()}`);
+  }
+
+  const filters: WaveProgramReposFilters = filtersParamParseResult.data || {
+    sortBy: 'stargazersCount',
+  };
+
+  const repos = await getWaveProgramRepos(fetch, waveProgramId, { limit: 20 }, filters);
+
+  const orgsPromise = getAllPaginated((page, limit) =>
+    getWaveProgramOrgs(fetch, waveProgramId!, { page, limit }),
+  );
+
+  return {
+    repos,
+    filters,
+    waveProgramId,
+    orgsPromise,
+  };
+};

--- a/src/routes/(pages)/wave/(base-layout)/admin/repos/tags/+page.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/admin/repos/tags/+page.svelte
@@ -1,0 +1,142 @@
+<script lang="ts">
+  import { invalidate } from '$app/navigation';
+  import Section from '$lib/components/section/section.svelte';
+  import Button from '$lib/components/button/button.svelte';
+  import Plus from '$lib/components/icons/Plus.svelte';
+  import Pen from '$lib/components/icons/Pen.svelte';
+  import Trash from '$lib/components/icons/Trash.svelte';
+  import modal from '$lib/stores/modal';
+  import doWithConfirmationModal from '$lib/utils/do-with-confirmation-modal';
+  import doWithErrorModal from '$lib/utils/do-with-error-modal';
+  import { deleteTag } from '$lib/utils/wave/tags';
+  import type { Tag } from '$lib/utils/wave/types/waveProgram';
+  import TagModal from '../components/tag-modal.svelte';
+
+  let { data } = $props();
+
+  let tags = $derived(data.tags);
+
+  async function refresh() {
+    await invalidate('wave:admin:repos');
+  }
+
+  function openCreateTagModal() {
+    modal.show(TagModal, undefined, {
+      onSaved: refresh,
+    });
+  }
+
+  function openEditTagModal(tag: Tag) {
+    modal.show(TagModal, undefined, {
+      existingTag: tag,
+      onSaved: refresh,
+    });
+  }
+
+  async function handleDeleteTag(tag: Tag) {
+    await doWithConfirmationModal(
+      `Delete tag "${tag.name}"? This will unassign it from all repos.`,
+      () =>
+        doWithErrorModal(async () => {
+          await deleteTag(fetch, tag.id);
+          await refresh();
+        }),
+    );
+  }
+</script>
+
+<Section
+  header={{
+    label: 'Tags',
+    actions: [
+      {
+        label: 'Create tag',
+        icon: Plus,
+        variant: 'primary',
+        handler: openCreateTagModal,
+      },
+    ],
+    infoTooltip: 'Manage tags that can be assigned to repos.',
+  }}
+  skeleton={{
+    loaded: true,
+    empty: tags.data.length === 0,
+    emptyStateEmoji: '🏷️',
+    emptyStateHeadline: 'No tags',
+    emptyStateText: 'Create a tag to get started.',
+  }}
+>
+  <div class="list">
+    {#each tags.data as tag (tag.id)}
+      <div class="row">
+        <div class="tag-info">
+          <span
+            class="tag-badge"
+            style:background-color="{tag.color}20"
+            style:color={tag.color}
+            style:border-color="{tag.color}40"
+          >
+            {tag.name}
+          </span>
+        </div>
+        <div class="actions">
+          <Button size="small" variant="ghost" icon={Pen} onclick={() => openEditTagModal(tag)}
+            >Edit</Button
+          >
+          <Button
+            size="small"
+            variant="destructive-outline"
+            icon={Trash}
+            onclick={() => handleDeleteTag(tag)}>Delete</Button
+          >
+        </div>
+      </div>
+    {/each}
+  </div>
+</Section>
+
+<style>
+  .list {
+    display: flex;
+    flex-direction: column;
+    border: 1px solid var(--color-foreground-level-2);
+    border-radius: 1rem 0 1rem 1rem;
+    overflow: hidden;
+  }
+
+  .row {
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid var(--color-foreground-level-2);
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    align-items: center;
+  }
+
+  .row:last-child {
+    border-bottom: none;
+  }
+
+  .tag-info {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .tag-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.0625rem 0.5rem;
+    border-radius: 1rem 0 1rem 1rem;
+    font-size: 0.75rem;
+    font-weight: 500;
+    white-space: nowrap;
+    border: 1px solid;
+  }
+
+  .actions {
+    display: flex;
+    gap: 0.5rem;
+    flex-shrink: 0;
+  }
+</style>


### PR DESCRIPTION
## Summary

- **Repo tags on cards**: Tags display as colored badges on repo preview cards, clickable to filter by tag
- **Tag filter**: New "Tag" filter option in the repos filter bar (lazy-loaded, only fetches when filter is added)
- **Admin tool** (`/wave/admin/repos`): Tabbed layout with Repos and Tags tabs
  - **Repos tab**: Reuses the user-facing repo grid with search/filter/infinite scroll. Adds admin actions per card: "Tags" button (modal for assigning/removing tags) and "Feature"/"Unfeature" buttons (for `featureWaveRepos` permission)
  - **Tags tab**: CRUD for tags (name, color, optional image URL). Gated by `manageTags` permission
- **Tag image backgrounds**: Tags with an `imageUrl` display as a low-opacity blurred background on repo cards, with subtle color theming from the tag color
- **Feature/unfeature repos**: New API utilities and admin UI for setting points multipliers on repos
- **Filter bar improvements**: Org and tag filter options load lazily (only when filter is added), `{#key}` block ensures filter bar updates on external filter changes (e.g. tag click navigation)

## Test plan

- [x] Verify tags appear on repo cards on the user-facing repos listing page
- [x] Click a tag badge to filter — should navigate and show the tag filter active
- [x] Add/remove tag and org filters via "Add filter" — verify options load on demand
- [x] Navigate to `/wave/admin/repos` with `manageTags` permission — verify both tabs appear
- [x] Navigate to `/wave/admin/repos` with only `featureWaveRepos` — verify only Repos tab appears
- [x] On Repos tab: select a wave program, verify repo grid loads with search/filter
- [x] On Repos tab: click "Tags" on a card, assign/remove tags in modal
- [x] On Repos tab: click "Feature" on a card, set multiplier, verify badge appears
- [x] On Repos tab: click "Unfeature", confirm, verify badge removed
- [x] On Tags tab: create, edit, delete tags (including image URL)
- [x] Verify tag with `imageUrl` shows blurred background image on repo cards
- [x] Verify filter dropdowns don't z-fight with cards or modals
- [x] Test in both light and dark mode