### PR TITLE
fix(wave): dedupe concurrent refresh token calls

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -16,6 +16,56 @@ const WAVE_API_URL = getOptionalEnvVar(
   'Wave functionality will not work.',
 );
 
+// Dedupes concurrent token refreshes keyed by the incoming refresh token.
+// Backend rotates refresh tokens, so two SSR requests arriving at once with
+// the same token would otherwise race — the loser would get 401, clear
+// cookies, and log the user out. Entries are kept briefly after settling
+// so a trailing request that was dispatched with the pre-rotation token
+// still gets the cached result instead of re-racing.
+type RefreshResult = { accessToken: string; setCookie: string };
+const refreshInFlight = new Map<string, Promise<RefreshResult>>();
+const REFRESH_CACHE_GRACE_MS = 5000;
+
+function refreshWaveTokens(refreshToken: string): Promise<RefreshResult> {
+  const existing = refreshInFlight.get(refreshToken);
+  if (existing) return existing;
+
+  const promise = (async () => {
+    const res = await fetch(`${WAVE_API_URL}/api/auth/token/refresh`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { Cookie: `wave_refresh_token=${refreshToken}` },
+    });
+
+    if (!res.ok) {
+      const err = new Error('Failed to refresh token') as Error & {
+        status?: number;
+        body?: string;
+      };
+      err.status = res.status;
+      err.body = await res.text();
+      throw err;
+    }
+
+    const { accessToken } = z.object({ accessToken: z.string() }).parse(await res.json());
+
+    return { accessToken, setCookie: res.headers.get('set-cookie') ?? '' };
+  })();
+
+  refreshInFlight.set(refreshToken, promise);
+
+  const clear = () => {
+    setTimeout(() => {
+      if (refreshInFlight.get(refreshToken) === promise) {
+        refreshInFlight.delete(refreshToken);
+      }
+    }, REFRESH_CACHE_GRACE_MS);
+  };
+  promise.then(clear, clear);
+
+  return promise;
+}
+
 export const handle = async ({ event, resolve }) => {
   // If we're under /wave path, handle Wave authentication.
   // This allows the initial page render to be SSR even for logged-in-only views.
@@ -35,37 +85,13 @@ export const handle = async ({ event, resolve }) => {
       } else {
         // Access token missing or invalid/expired, attempt refresh
         try {
-          const res = await fetch(`${WAVE_API_URL}/api/auth/token/refresh`, {
-            method: 'POST',
-            credentials: 'include',
-            headers: { Cookie: `wave_refresh_token=${refreshToken}` },
-          });
-
-          if (!res.ok) {
-            if (res.status === 403) {
-              const body = await res.text();
-              if (body.includes('suspended')) {
-                event.cookies.delete('wave_refresh_token', { path: '/' });
-                event.cookies.delete('wave_access_token', { path: '/' });
-                throw redirect(302, '/wave/suspended');
-              }
-            }
-            throw new Error('Failed to refresh token');
-          }
-
-          const data = z
-            .object({
-              accessToken: z.string(),
-            })
-            .parse(await res.json());
+          const { accessToken: newAccessToken, setCookie } = await refreshWaveTokens(refreshToken);
 
           event.locals.waveRefreshToken = refreshToken;
-          event.locals.waveAccessToken = data.accessToken;
+          event.locals.waveAccessToken = newAccessToken;
 
           // Forward new cookies to browser
-          for (const str of setCookieParser.splitCookiesString(
-            res.headers.get('set-cookie') ?? '',
-          )) {
+          for (const str of setCookieParser.splitCookiesString(setCookie)) {
             const { name, value, ...options } = setCookieParser.parseString(str);
 
             if (name === 'wave_refresh_token' || name === 'wave_access_token') {
@@ -75,10 +101,21 @@ export const handle = async ({ event, resolve }) => {
                 path: options.path || '/',
                 httpOnly: name === 'wave_refresh_token', // Only refresh token is httpOnly
               });
+              if (name === 'wave_refresh_token') {
+                event.locals.waveRefreshToken = value;
+              }
             }
           }
         } catch (e) {
           if (isRedirect(e)) throw e;
+
+          const status = (e as { status?: number }).status;
+          const body = (e as { body?: string }).body ?? '';
+          if (status === 403 && body.includes('suspended')) {
+            event.cookies.delete('wave_refresh_token', { path: '/' });
+            event.cookies.delete('wave_access_token', { path: '/' });
+            throw redirect(302, '/wave/suspended');
+          }
 
           // Refresh failed, clear auth state
           event.cookies.delete('wave_refresh_token', { path: '/' });

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -16,56 +16,6 @@ const WAVE_API_URL = getOptionalEnvVar(
   'Wave functionality will not work.',
 );
 
-// Dedupes concurrent token refreshes keyed by the incoming refresh token.
-// Backend rotates refresh tokens, so two SSR requests arriving at once with
-// the same token would otherwise race — the loser would get 401, clear
-// cookies, and log the user out. Entries are kept briefly after settling
-// so a trailing request that was dispatched with the pre-rotation token
-// still gets the cached result instead of re-racing.
-type RefreshResult = { accessToken: string; setCookie: string };
-const refreshInFlight = new Map<string, Promise<RefreshResult>>();
-const REFRESH_CACHE_GRACE_MS = 5000;
-
-function refreshWaveTokens(refreshToken: string): Promise<RefreshResult> {
-  const existing = refreshInFlight.get(refreshToken);
-  if (existing) return existing;
-
-  const promise = (async () => {
-    const res = await fetch(`${WAVE_API_URL}/api/auth/token/refresh`, {
-      method: 'POST',
-      credentials: 'include',
-      headers: { Cookie: `wave_refresh_token=${refreshToken}` },
-    });
-
-    if (!res.ok) {
-      const err = new Error('Failed to refresh token') as Error & {
-        status?: number;
-        body?: string;
-      };
-      err.status = res.status;
-      err.body = await res.text();
-      throw err;
-    }
-
-    const { accessToken } = z.object({ accessToken: z.string() }).parse(await res.json());
-
-    return { accessToken, setCookie: res.headers.get('set-cookie') ?? '' };
-  })();
-
-  refreshInFlight.set(refreshToken, promise);
-
-  const clear = () => {
-    setTimeout(() => {
-      if (refreshInFlight.get(refreshToken) === promise) {
-        refreshInFlight.delete(refreshToken);
-      }
-    }, REFRESH_CACHE_GRACE_MS);
-  };
-  promise.then(clear, clear);
-
-  return promise;
-}
-
 export const handle = async ({ event, resolve }) => {
   // If we're under /wave path, handle Wave authentication.
   // This allows the initial page render to be SSR even for logged-in-only views.
@@ -85,13 +35,37 @@ export const handle = async ({ event, resolve }) => {
       } else {
         // Access token missing or invalid/expired, attempt refresh
         try {
-          const { accessToken: newAccessToken, setCookie } = await refreshWaveTokens(refreshToken);
+          const res = await fetch(`${WAVE_API_URL}/api/auth/token/refresh`, {
+            method: 'POST',
+            credentials: 'include',
+            headers: { Cookie: `wave_refresh_token=${refreshToken}` },
+          });
+
+          if (!res.ok) {
+            if (res.status === 403) {
+              const body = await res.text();
+              if (body.includes('suspended')) {
+                event.cookies.delete('wave_refresh_token', { path: '/' });
+                event.cookies.delete('wave_access_token', { path: '/' });
+                throw redirect(302, '/wave/suspended');
+              }
+            }
+            throw new Error('Failed to refresh token');
+          }
+
+          const data = z
+            .object({
+              accessToken: z.string(),
+            })
+            .parse(await res.json());
 
           event.locals.waveRefreshToken = refreshToken;
-          event.locals.waveAccessToken = newAccessToken;
+          event.locals.waveAccessToken = data.accessToken;
 
           // Forward new cookies to browser
-          for (const str of setCookieParser.splitCookiesString(setCookie)) {
+          for (const str of setCookieParser.splitCookiesString(
+            res.headers.get('set-cookie') ?? '',
+          )) {
             const { name, value, ...options } = setCookieParser.parseString(str);
 
             if (name === 'wave_refresh_token' || name === 'wave_access_token') {
@@ -101,21 +75,10 @@ export const handle = async ({ event, resolve }) => {
                 path: options.path || '/',
                 httpOnly: name === 'wave_refresh_token', // Only refresh token is httpOnly
               });
-              if (name === 'wave_refresh_token') {
-                event.locals.waveRefreshToken = value;
-              }
             }
           }
         } catch (e) {
           if (isRedirect(e)) throw e;
-
-          const status = (e as { status?: number }).status;
-          const body = (e as { body?: string }).body ?? '';
-          if (status === 403 && body.includes('suspended')) {
-            event.cookies.delete('wave_refresh_token', { path: '/' });
-            event.cookies.delete('wave_access_token', { path: '/' });
-            throw redirect(302, '/wave/suspended');
-          }
 
           // Refresh failed, clear auth state
           event.cookies.delete('wave_refresh_token', { path: '/' });

--- a/src/lib/utils/wave/auth.ts
+++ b/src/lib/utils/wave/auth.ts
@@ -44,6 +44,10 @@ const EXPIRY_BUFFER_SECONDS = 30; // Refresh if expiring within 30 seconds
 
 let loggingOut = false;
 
+// Dedupes concurrent refresh attempts. Backend rotates refresh tokens, so
+// parallel calls would otherwise race and the losers would trigger logout.
+let refreshInFlight: Promise<string | null> | null = null;
+
 export function getUserData(jwt: string | null): WaveLoggedInUser | null {
   if (!jwt) {
     return null;
@@ -80,39 +84,52 @@ export function getUserData(jwt: string | null): WaveLoggedInUser | null {
 export async function getRefreshedAuthToken(manualCookie?: string) {
   if (browser && loggingOut) return null;
 
-  try {
-    const res = await call('/api/auth/token/refresh', {
-      method: 'POST',
-      credentials: 'include',
-      headers: manualCookie ? { Cookie: manualCookie } : {},
-    });
+  if (browser && refreshInFlight) return refreshInFlight;
 
-    const data = z
-      .object({
-        accessToken: z.string(),
-      })
-      .parse(res);
+  const promise = (async () => {
+    try {
+      const res = await call('/api/auth/token/refresh', {
+        method: 'POST',
+        credentials: 'include',
+        headers: manualCookie ? { Cookie: manualCookie } : {},
+      });
 
-    // Defensive: if loggingOut were true we'd have returned early above,
-    // but reset it here as a safeguard against future refactors.
-    if (browser) loggingOut = false;
+      const data = z
+        .object({
+          accessToken: z.string(),
+        })
+        .parse(res);
 
-    return data.accessToken;
-  } catch (e) {
-    // eslint-disable-next-line no-console
-    console.error('Failed to refresh auth token:', e);
+      // Defensive: if loggingOut were true we'd have returned early above,
+      // but reset it here as a safeguard against future refactors.
+      if (browser) loggingOut = false;
 
-    await logOut();
+      return data.accessToken;
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error('Failed to refresh auth token:', e);
 
-    if (e instanceof AccountSuspendedError) {
-      await goto('/wave/suspended');
+      await logOut();
+
+      if (e instanceof AccountSuspendedError) {
+        await goto('/wave/suspended');
+        return null;
+      }
+
+      await invalidateAll();
+
       return null;
     }
+  })();
 
-    await invalidateAll();
-
-    return null;
+  if (browser) {
+    refreshInFlight = promise;
+    promise.finally(() => {
+      if (refreshInFlight === promise) refreshInFlight = null;
+    });
   }
+
+  return promise;
 }
 
 export async function redeemGitHubOAuthCode(code: string, state: string) {

--- a/src/lib/utils/wave/auth.ts
+++ b/src/lib/utils/wave/auth.ts
@@ -100,10 +100,6 @@ export async function getRefreshedAuthToken(manualCookie?: string) {
         })
         .parse(res);
 
-      // Defensive: if loggingOut were true we'd have returned early above,
-      // but reset it here as a safeguard against future refactors.
-      if (browser) loggingOut = false;
-
       return data.accessToken;
     } catch (e) {
       // eslint-disable-next-line no-console


### PR DESCRIPTION
## Summary

Fixes intermittent mid-session logouts where users are kicked out after a break, despite their refresh token still being valid. Backend logs show a new refresh token being issued successfully, yet the frontend still logs out.

**Root cause:** The wave backend rotates refresh tokens on every `/api/auth/token/refresh` call — the old token is revoked and a new one issued. The client-side refresh path fires without any deduplication: after a break, the access token is expired. When the user interacts, multiple `authenticatedCall`s fire in parallel, each gets 401, each independently calls `getRefreshedAuthToken()`. The first wins and rotates the token; subsequent ones POST with the now-revoked token, hit the `catch` in `auth.ts`, and call `logOut()`.

## Changes

- `src/lib/utils/wave/auth.ts`: `getRefreshedAuthToken` now holds a module-level in-flight promise (browser-only). Parallel callers await the same refresh instead of each making their own call.

## Test plan

- [x] Log in, wait >15min for access token to expire, then navigate — confirm single refresh request in network tab, no logout
- [x] Open two tabs, let access token expire, interact simultaneously — confirm both tabs stay logged in
- [x] Trigger a page with multiple parallel `authenticatedCall`s after access token expiry — confirm only one refresh fires
- [x] Verify suspended-account 403 still redirects to `/wave/suspended`
- [x] Verify invalid/expired refresh token still cleanly logs out