### PR TITLE
feat(wave): add per-repo budget override in admin panel

### DIFF
--- a/src/lib/utils/wave/types/waveProgram.ts
+++ b/src/lib/utils/wave/types/waveProgram.ts
@@ -137,6 +137,7 @@ export const waveProgramRepoWithDetailsDtoSchema = z.object({
   pointsUsed: z.number().int(),
   pointsBudget: z.number().int().nullable(),
   pointsRemaining: z.number().int().nullable(),
+  pointsBudgetOverride: z.number().int().nullable().optional(),
   pointsMultiplier: z.number().int().optional(),
   repo: z.object({
     stargazersCount: z.number().int().nullable().optional(),

--- a/src/lib/utils/wave/wavePrograms.ts
+++ b/src/lib/utils/wave/wavePrograms.ts
@@ -184,6 +184,36 @@ export async function unfeatureWaveProgramRepo(
   });
 }
 
+export async function setRepoBudgetOverride(
+  f = fetch,
+  waveProgramId: string,
+  orgRepoId: string,
+  pointsBudget: number,
+) {
+  await authenticatedCall(
+    f,
+    `/api/wave-programs/${waveProgramId}/repos/${orgRepoId}/budget-override`,
+    {
+      method: 'PUT',
+      body: JSON.stringify({ pointsBudget }),
+    },
+  );
+}
+
+export async function removeRepoBudgetOverride(
+  f = fetch,
+  waveProgramId: string,
+  orgRepoId: string,
+) {
+  await authenticatedCall(
+    f,
+    `/api/wave-programs/${waveProgramId}/repos/${orgRepoId}/budget-override`,
+    {
+      method: 'DELETE',
+    },
+  );
+}
+
 export async function addIssueToWaveProgram(
   f = fetch,
   waveProgramId: string,

--- a/src/routes/(pages)/wave/(base-layout)/admin/repos/+layout.ts
+++ b/src/routes/(pages)/wave/(base-layout)/admin/repos/+layout.ts
@@ -9,8 +9,9 @@ export const load = async ({ parent, fetch, depends }) => {
 
   const canManageTags = user.permissions?.includes('manageTags');
   const canFeatureRepos = user.permissions?.includes('featureWaveRepos');
+  const canManagePoints = user.permissions?.includes('managePoints');
 
-  if (!canManageTags && !canFeatureRepos) {
+  if (!canManageTags && !canFeatureRepos && !canManagePoints) {
     throw redirect(302, '/wave/admin');
   }
 
@@ -24,5 +25,6 @@ export const load = async ({ parent, fetch, depends }) => {
     tags,
     canManageTags: !!canManageTags,
     canFeatureRepos: !!canFeatureRepos,
+    canManagePoints: !!canManagePoints,
   };
 };

--- a/src/routes/(pages)/wave/(base-layout)/admin/repos/components/budget-override-modal.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/admin/repos/components/budget-override-modal.svelte
@@ -17,16 +17,16 @@
 
   let { repo, waveProgramId, onChanged }: Props = $props();
 
-  let hasExistingOverride = $derived(
-    repo.pointsBudgetOverride != null && repo.pointsBudgetOverride > 0,
-  );
+  let hasExistingOverride = $derived(repo.pointsBudgetOverride != null);
 
-  let budget = $state(hasExistingOverride ? String(repo.pointsBudgetOverride) : '');
+  let budget = $state(repo.pointsBudgetOverride != null ? String(repo.pointsBudgetOverride) : '');
   let submitting = $state(false);
   let error = $state<string | null>(null);
 
-  let budgetNum = $derived(parseInt(budget, 10));
-  let canSubmit = $derived(!isNaN(budgetNum) && budgetNum >= 1 && !submitting);
+  let budgetNum = $derived(Number(budget));
+  let canSubmit = $derived(
+    Number.isFinite(budgetNum) && Number.isInteger(budgetNum) && budgetNum >= 1 && !submitting,
+  );
 
   async function handleSubmit() {
     if (!canSubmit) return;

--- a/src/routes/(pages)/wave/(base-layout)/admin/repos/components/budget-override-modal.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/admin/repos/components/budget-override-modal.svelte
@@ -1,0 +1,113 @@
+<script lang="ts">
+  import Button from '$lib/components/button/button.svelte';
+  import TextInput from '$lib/components/text-input/text-input.svelte';
+  import FormField from '$lib/components/form-field/form-field.svelte';
+  import StandaloneFlowStepLayout from '$lib/components/standalone-flow-step-layout/standalone-flow-step-layout.svelte';
+  import AnnotationBox from '$lib/components/annotation-box/annotation-box.svelte';
+  import Coin from '$lib/components/icons/Coin.svelte';
+  import modal from '$lib/stores/modal';
+  import { setRepoBudgetOverride, removeRepoBudgetOverride } from '$lib/utils/wave/wavePrograms';
+  import type { WaveProgramRepoWithDetailsDto } from '$lib/utils/wave/types/waveProgram';
+
+  interface Props {
+    repo: WaveProgramRepoWithDetailsDto;
+    waveProgramId: string;
+    onChanged: () => void;
+  }
+
+  let { repo, waveProgramId, onChanged }: Props = $props();
+
+  let hasExistingOverride = $derived(
+    repo.pointsBudgetOverride != null && repo.pointsBudgetOverride > 0,
+  );
+
+  let budget = $state(hasExistingOverride ? String(repo.pointsBudgetOverride) : '');
+  let submitting = $state(false);
+  let error = $state<string | null>(null);
+
+  let budgetNum = $derived(parseInt(budget, 10));
+  let canSubmit = $derived(!isNaN(budgetNum) && budgetNum >= 1 && !submitting);
+
+  async function handleSubmit() {
+    if (!canSubmit) return;
+
+    submitting = true;
+    error = null;
+
+    try {
+      await setRepoBudgetOverride(fetch, waveProgramId, repo.repo.id, budgetNum);
+      onChanged();
+      modal.hide();
+    } catch (e) {
+      error = e instanceof Error ? e.message : 'An unexpected error occurred.';
+    } finally {
+      submitting = false;
+    }
+  }
+
+  async function handleRemove() {
+    submitting = true;
+    error = null;
+
+    try {
+      await removeRepoBudgetOverride(fetch, waveProgramId, repo.repo.id);
+      onChanged();
+      modal.hide();
+    } catch (e) {
+      error = e instanceof Error ? e.message : 'An unexpected error occurred.';
+    } finally {
+      submitting = false;
+    }
+  }
+</script>
+
+<div class="modal">
+  <StandaloneFlowStepLayout headline="Budget override" description={repo.repo.gitHubRepoFullName}>
+    <div class="fields">
+      <FormField
+        title="Points budget"
+        description="Override the wave program's default per-repo budget for this repo. Leave empty and remove to use the program default."
+      >
+        <TextInput
+          bind:value={budget}
+          placeholder={repo.pointsBudget != null ? String(repo.pointsBudget) : 'Unlimited'}
+          variant={{ type: 'number', min: 1 }}
+        />
+      </FormField>
+    </div>
+
+    {#if error}
+      <AnnotationBox type="error">{error}</AnnotationBox>
+    {/if}
+
+    {#snippet actions()}
+      {#if hasExistingOverride}
+        <Button variant="destructive-outline" disabled={submitting} onclick={handleRemove}
+          >Remove override</Button
+        >
+      {/if}
+      <Button variant="normal" disabled={submitting} onclick={modal.hide}>Cancel</Button>
+      <Button
+        variant="primary"
+        icon={Coin}
+        loading={submitting}
+        disabled={!canSubmit}
+        onclick={handleSubmit}
+      >
+        Set budget to {budgetNum || '?'}
+      </Button>
+    {/snippet}
+  </StandaloneFlowStepLayout>
+</div>
+
+<style>
+  .modal {
+    padding: 1rem;
+  }
+
+  .fields {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+</style>

--- a/src/routes/(pages)/wave/(base-layout)/admin/repos/repos/+page.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/admin/repos/repos/+page.svelte
@@ -19,6 +19,8 @@
   import type { Pagination } from '$lib/utils/wave/types/pagination';
   import ManageRepoTagsModal from '../components/manage-repo-tags-modal.svelte';
   import FeatureRepoModal from '../components/feature-repo-modal.svelte';
+  import BudgetOverrideModal from '../components/budget-override-modal.svelte';
+  import Coin from '$lib/components/icons/Coin.svelte';
 
   let { data } = $props();
 
@@ -26,6 +28,7 @@
   let wavePrograms = $derived(data.wavePrograms);
   let canManageTags = $derived(data.canManageTags);
   let canFeatureRepos = $derived(data.canFeatureRepos);
+  let canManagePoints = $derived(data.canManagePoints);
 
   let waveProgramId = $derived(data.waveProgramId);
   let repos = $derived(data.repos);
@@ -123,6 +126,14 @@
     });
   }
 
+  function openBudgetOverrideModal(repo: WaveProgramRepoWithDetailsDto) {
+    modal.show(BudgetOverrideModal, undefined, {
+      repo,
+      waveProgramId: waveProgramId!,
+      onChanged: reloadPage,
+    });
+  }
+
   async function handleUnfeature(repo: WaveProgramRepoWithDetailsDto) {
     await doWithConfirmationModal(
       `Remove featured status from ${repo.repo.gitHubRepoFullName}?`,
@@ -195,6 +206,18 @@
                     onclick={() => openFeatureModal(repoWithDetails)}>Feature</Button
                   >
                 {/if}
+              {/if}
+
+              {#if canManagePoints}
+                <Button
+                  size="small"
+                  variant={repoWithDetails.pointsBudgetOverride != null ? 'caution' : 'normal'}
+                  icon={Coin}
+                  onclick={() => openBudgetOverrideModal(repoWithDetails)}
+                  >{repoWithDetails.pointsBudgetOverride != null
+                    ? `Budget: ${repoWithDetails.pointsBudgetOverride}`
+                    : 'Budget'}</Button
+                >
               {/if}
             </div>
           {/snippet}


### PR DESCRIPTION
## Summary

Add the ability for admins with `managePoints` permission to set or remove a per-repo budget override from the wave admin repos panel.

## Changes

- **Schema**: Added `pointsBudgetOverride` field to `waveProgramRepoWithDetailsDtoSchema`
- **API functions**: Added `setRepoBudgetOverride` (PUT) and `removeRepoBudgetOverride` (DELETE) in `wavePrograms.ts`
- **Permissions**: Added `managePoints` permission check to repos layout guard
- **UI**: Added budget override button on repo cards (shows current override value when set)
- **Modal**: New `budget-override-modal.svelte` for setting/removing overrides with validation and error handling

## Files Changed

| File | Change |
|---|---|
| `src/lib/utils/wave/types/waveProgram.ts` | Modified — added `pointsBudgetOverride` to schema |
| `src/lib/utils/wave/wavePrograms.ts` | Modified — added two API functions |
| `src/routes/.../admin/repos/+layout.ts` | Modified — added `managePoints` permission |
| `src/routes/.../admin/repos/repos/+page.svelte` | Modified — added budget button to repo cards |
| `src/routes/.../admin/repos/components/budget-override-modal.svelte` | Added — new modal component |

## Testing

Manual testing in the admin panel — verify the budget button appears for users with `managePoints` permission, modal opens, and set/remove operations work.