### PR TITLE
fix: handle hard-deleted issues in points history schemas and UI

### DIFF
--- a/src/lib/components/wave/points/source.svelte
+++ b/src/lib/components/wave/points/source.svelte
@@ -15,11 +15,19 @@
 {#if source.type === 'issue'}
   {@const issueInfo = source.data}
 
-  <span>Resolved "{issueInfo.title}"</span>
+  {#if issueInfo}
+    <span>Resolved "{issueInfo.title}"</span>
+  {:else}
+    <span>Resolved a deleted issue</span>
+  {/if}
 {:else if source.type === 'compliment'}
   {@const complimentInfo = source.data}
 
-  <span>Complimented for "{COMPLIMENT_FRIENDLY_NAMES[complimentInfo.type]}"</span>
+  {#if complimentInfo}
+    <span>Complimented for "{COMPLIMENT_FRIENDLY_NAMES[complimentInfo.type]}"</span>
+  {:else}
+    <span>Received a compliment</span>
+  {/if}
 {:else if source.type === 'adjustment'}
   <span>Manual points adjustment</span>
 {/if}

--- a/src/lib/utils/wave/types/points.ts
+++ b/src/lib/utils/wave/types/points.ts
@@ -20,17 +20,17 @@ export const pointsIssueDtoSchema = z.object({
 
 export const pointsComplimentDtoSchema = z.object({
   type: complimentTypeSchema,
-  issue: pointsIssueDtoSchema,
+  issue: pointsIssueDtoSchema.nullable(),
 });
 
 export const pointsSourceSchema = z.union([
   z.object({
     type: z.literal('issue'),
-    data: pointsIssueDtoSchema,
+    data: pointsIssueDtoSchema.nullable(),
   }),
   z.object({
     type: z.literal('compliment'),
-    data: pointsComplimentDtoSchema,
+    data: pointsComplimentDtoSchema.nullable(),
   }),
   z.object({
     type: z.literal('adjustment'),


### PR DESCRIPTION
## Summary

- Mirrors the Wave backend's nullability on `PointsSource` / `PointsCompliment` — `data` can be `null` on both `issue` and `compliment` branches, and the `issue` field inside a compliment can now be `null`.
- Previously `parseRes` would throw at schema parse time when the backend returned these nulls (e.g. points ledger entry whose referenced issue was hard-deleted), breaking the entire points page.
- `source.svelte` now renders a fallback string ("Resolved a deleted issue" / "Received a compliment") when `source.data` is null, instead of dereferencing it.

Paired with wave PR https://github.com/drips-network/wave/pull/506.

## Test plan

- [x] `npm run check` — 0 errors.
- [ ] Manually verify the points page renders correctly for an account with a hard-deleted-issue ledger entry.