### PR TITLE
add admin tool to unlink a user's phone verification

### DIFF
--- a/src/lib/utils/wave/adminPhone.ts
+++ b/src/lib/utils/wave/adminPhone.ts
@@ -1,0 +1,7 @@
+import { authenticatedCall } from './call';
+
+export async function unlinkPhoneVerification(f = fetch, userId: string) {
+  await authenticatedCall(f, `/api/admin/phone-verifications/${userId}`, {
+    method: 'DELETE',
+  });
+}

--- a/src/routes/(pages)/wave/(base-layout)/admin/+page.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/admin/+page.svelte
@@ -35,6 +35,15 @@
           },
         ]
       : []),
+    ...(data.user.permissions?.includes('managePhoneVerifications')
+      ? [
+          {
+            name: 'Unlink Phone',
+            description: "Remove a user's phone verification so they can re-verify.",
+            href: '/wave/admin/unlink-phone',
+          },
+        ]
+      : []),
   ]);
 </script>
 

--- a/src/routes/(pages)/wave/(base-layout)/admin/unlink-phone/+page.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/admin/unlink-phone/+page.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+  import HeadMeta from '$lib/components/head-meta/head-meta.svelte';
+  import Breadcrumbs from '$lib/components/breadcrumbs/breadcrumbs.svelte';
+  import Section from '$lib/components/section/section.svelte';
+  import FormField from '$lib/components/form-field/form-field.svelte';
+  import TextInput from '$lib/components/text-input/text-input.svelte';
+  import Button from '$lib/components/button/button.svelte';
+  import doWithConfirmationModal from '$lib/utils/do-with-confirmation-modal';
+  import doWithErrorModal from '$lib/utils/do-with-error-modal';
+  import { getUser } from '$lib/utils/wave/users';
+  import { unlinkPhoneVerification } from '$lib/utils/wave/adminPhone';
+
+  let gitHubUsername = $state('');
+  let submitting = $state(false);
+
+  let valid = $derived(gitHubUsername.trim().length > 0);
+
+  async function handleSubmit() {
+    if (!valid) return;
+
+    const trimmedUsername = gitHubUsername.trim();
+
+    submitting = true;
+
+    try {
+      const user = await doWithErrorModal(() => getUser(fetch, trimmedUsername));
+
+      if (!user) {
+        throw new Error(`User "${trimmedUsername}" not found.`);
+      }
+
+      const message = `You are about to unlink the phone number from ${trimmedUsername}'s account. They will be able to re-verify afterwards, possibly with a different number. Continue?`;
+
+      await doWithConfirmationModal(message, async () => {
+        await doWithErrorModal(() => unlinkPhoneVerification(fetch, user.id), undefined, {
+          message: 'Phone number unlinked successfully.',
+          confetti: false,
+        });
+        gitHubUsername = '';
+      });
+    } catch {
+      // Error already handled by doWithErrorModal
+    } finally {
+      submitting = false;
+    }
+  }
+</script>
+
+<HeadMeta title="Unlink Phone | Admin | Wave" />
+
+<div class="page">
+  <Breadcrumbs crumbs={[{ label: 'Admin', href: '/wave/admin' }, { label: 'Unlink Phone' }]} />
+  <Section
+    header={{
+      label: 'Unlink Phone',
+    }}
+    skeleton={{ loaded: true }}
+  >
+    <div class="form">
+      <FormField
+        title="GitHub Username"
+        description="The user's phone verification record will be deleted. They can re-verify a (possibly different) number afterwards via the normal flow."
+      >
+        <TextInput bind:value={gitHubUsername} placeholder="e.g. octocat" />
+      </FormField>
+
+      <Button disabled={!valid || submitting} onclick={handleSubmit}>
+        {submitting ? 'Unlinking...' : 'Unlink Phone'}
+      </Button>
+    </div>
+  </Section>
+</div>
+
+<style>
+  .page {
+    display: flex;
+    max-width: 90rem;
+    margin: 0 auto;
+    width: 100%;
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+
+  .form {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    max-width: 32rem;
+    margin: 0 auto;
+  }
+</style>

--- a/src/routes/(pages)/wave/(base-layout)/admin/unlink-phone/+page.ts
+++ b/src/routes/(pages)/wave/(base-layout)/admin/unlink-phone/+page.ts
@@ -1,0 +1,11 @@
+import { redirect } from '@sveltejs/kit';
+
+export const load = async ({ parent }) => {
+  const { user } = await parent();
+
+  if (!user.permissions?.includes('managePhoneVerifications')) {
+    throw redirect(302, '/wave/admin');
+  }
+
+  return {};
+};


### PR DESCRIPTION
Adds a new admin tool under `/wave/admin/unlink-phone` that removes a user's phone verification record, so they can re-verify afterwards (possibly with a different number) via the normal phone flow.

Visibility is gated on the new `managePhoneVerifications` permission. Follows the existing `adjust-points` pattern — GitHub username input, user lookup, confirmation modal, success toast.

Depends on drips-network/wave#521.