### PR TITLE
surface restricted account state on the two apply pages

### DIFF
--- a/src/lib/utils/wave/auth.ts
+++ b/src/lib/utils/wave/auth.ts
@@ -21,6 +21,10 @@ const accessClaimJwtSchema = z.object({
     })
     .optional(),
   permissions: z.array(z.string()).optional(),
+  // Backend embeds this claim only when the account is actively restricted
+  // (a lighter moderation level than a full ban — login still works, but
+  // certain actions like applying to issues / repos are blocked).
+  restricted: z.literal(true).optional(),
 });
 
 export type WaveLoggedInUser = WaveUser & {
@@ -32,6 +36,7 @@ export type WaveLoggedInUser = WaveUser & {
   };
   signUpDate: Date;
   permissions?: string[];
+  restricted?: boolean;
 };
 
 export function getAccessTokenCookieClientSide(): string | null {
@@ -78,6 +83,7 @@ export function getUserData(jwt: string | null): WaveLoggedInUser | null {
     signUpDate: content.signUpDate,
     payoutAddresses: content.payoutAddresses,
     permissions: content.permissions,
+    restricted: content.restricted,
   };
 }
 

--- a/src/lib/utils/wave/call.ts
+++ b/src/lib/utils/wave/call.ts
@@ -10,8 +10,24 @@ export class AccountSuspendedError extends Error {
   }
 }
 
+/**
+ * Thrown for 403 responses where the backend signals that the account is in a
+ * "restricted" state (lighter than a full ban — login still works, but
+ * specific actions like applying to issues / repos are blocked).
+ */
+export class AccountRestrictedError extends Error {
+  constructor() {
+    super('Your account is currently restricted from this action.');
+    this.name = 'AccountRestrictedError';
+  }
+}
+
 function isAccountSuspendedResponse(status: number, body: string): boolean {
   return status === 403 && body.includes('suspended');
+}
+
+function isAccountRestrictedResponse(status: number, body: string): boolean {
+  return status === 403 && body.includes('restricted');
 }
 
 const MAX_RETRIES = 3;
@@ -60,6 +76,10 @@ export async function call(path: string, options: RequestInit = {}) {
 
     if (isAccountSuspendedResponse(response.status, errorText)) {
       throw new AccountSuspendedError();
+    }
+
+    if (isAccountRestrictedResponse(response.status, errorText)) {
+      throw new AccountRestrictedError();
     }
 
     throw new Error(`API call failed: ${response.status} ${response.statusText} - ${errorText}`);
@@ -127,6 +147,10 @@ export async function authenticatedCall(
 
       if (isAccountSuspendedResponse(res.status, errorText)) {
         throw new AccountSuspendedError();
+      }
+
+      if (isAccountRestrictedResponse(res.status, errorText)) {
+        throw new AccountRestrictedError();
       }
 
       if (res.status === 401) {

--- a/src/routes/(pages)/wave/(flows)/[waveProgramSlug]/issues/[issueId]/apply/+page.svelte
+++ b/src/routes/(pages)/wave/(flows)/[waveProgramSlug]/issues/[issueId]/apply/+page.svelte
@@ -82,7 +82,12 @@
 
   {#if data.user?.restricted}
     <AnnotationBox type="error">
-      Sorry, but your Drips Wave account has been restricted from applying to issues.
+      Sorry, but your Drips Wave account has been restricted from applying to issues. You can reach
+      out to support@drips.network for more details.
+
+      {#snippet actions()}
+        <Button href="mailto:support@drips.network">Contact support</Button>
+      {/snippet}
     </AnnotationBox>
   {:else if data.alreadyApplied}
     <AnnotationBox>You already previously applied to this issue.</AnnotationBox>

--- a/src/routes/(pages)/wave/(flows)/[waveProgramSlug]/issues/[issueId]/apply/+page.svelte
+++ b/src/routes/(pages)/wave/(flows)/[waveProgramSlug]/issues/[issueId]/apply/+page.svelte
@@ -80,7 +80,11 @@
     <IssuePreviewCard issue={data.issue} />
   </FormField>
 
-  {#if data.alreadyApplied}
+  {#if data.user?.restricted}
+    <AnnotationBox type="error">
+      Sorry, but your Drips Wave account has been restricted from applying to issues.
+    </AnnotationBox>
+  {:else if data.alreadyApplied}
     <AnnotationBox>You already previously applied to this issue.</AnnotationBox>
   {:else if data.isOwnIssue}
     <AnnotationBox>
@@ -206,7 +210,7 @@
   {/snippet}
 
   {#snippet actions()}
-    {#if waveProgramHasActiveWave && !data.alreadyApplied && !data.isOwnIssue && !data.issue.completedAt && !data.issue.assignedApplicant && (data.applicationQuota?.remaining ?? 0) > 0 && (data.orgAssignmentQuota?.remaining ?? 0) > 0}
+    {#if !data.user?.restricted && waveProgramHasActiveWave && !data.alreadyApplied && !data.isOwnIssue && !data.issue.completedAt && !data.issue.assignedApplicant && (data.applicationQuota?.remaining ?? 0) > 0 && (data.orgAssignmentQuota?.remaining ?? 0) > 0}
       <Button
         loading={submitting}
         variant="primary"

--- a/src/routes/(pages)/wave/(flows)/maintainer-onboarding/apply-to-wave-program/[waveProgramId]/form/+page.svelte
+++ b/src/routes/(pages)/wave/(flows)/maintainer-onboarding/apply-to-wave-program/[waveProgramId]/form/+page.svelte
@@ -206,8 +206,8 @@
 >
   {#if data.user?.restricted}
     <AnnotationBox type="error">
-      Sorry, but your Drips Wave account has been restricted from applying repos. You can reach out
-      to support@drips.network for more details.
+      Sorry, but your Drips Wave account has been restricted from applying repos to wave programs.
+      You can reach out to support@drips.network for more details.
 
       {#snippet actions()}
         <Button href="mailto:support@drips.network">Contact support</Button>

--- a/src/routes/(pages)/wave/(flows)/maintainer-onboarding/apply-to-wave-program/[waveProgramId]/form/+page.svelte
+++ b/src/routes/(pages)/wave/(flows)/maintainer-onboarding/apply-to-wave-program/[waveProgramId]/form/+page.svelte
@@ -204,181 +204,187 @@
     ? 'repo'
     : `${repoIds.length} repos`} you're applying to the {data.waveProgram.name} Wave Program."
 >
-  <FormField
-    title="Previous participation"
-    description="Have you previously participated in any of the following programs? Select all that apply."
-    type="div"
-  >
-    <Card style="padding: 0; text-align: left; width: 100%;">
-      <ListSelect
-        multiselect
-        searchable={false}
-        items={previousParticipationItems}
-        bind:selected={previousParticipation}
-      />
-    </Card>
-  </FormField>
+  {#if data.user?.restricted}
+    <AnnotationBox type="error">
+      Sorry, but your Drips Wave account has been restricted from applying repos.
+    </AnnotationBox>
+  {:else}
+    <FormField
+      title="Previous participation"
+      description="Have you previously participated in any of the following programs? Select all that apply."
+      type="div"
+    >
+      <Card style="padding: 0; text-align: left; width: 100%;">
+        <ListSelect
+          multiselect
+          searchable={false}
+          items={previousParticipationItems}
+          bind:selected={previousParticipation}
+        />
+      </Card>
+    </FormField>
 
-  <FormField
-    title="Planned issues*"
-    descriptionMd={`The Wave Program works by having maintainers create scoped issues that contributors pick up during sprint cycles. 
+    <FormField
+      title="Planned issues*"
+      descriptionMd={`The Wave Program works by having maintainers create scoped issues that contributors pick up during sprint cycles. 
 
 Describe the types of work you'd post — bug fixes, new features, documentation, testing, etc.`}
-    type="div"
-    validationState={touched['plannedIssues'] && !plannedIssuesValid
-      ? {
-          type: 'invalid',
-          message:
-            plannedIssuesDescription.length > 5000
-              ? 'Must not exceed 5,000 characters.'
-              : 'This field is required.',
-        }
-      : { type: 'valid' }}
-  >
-    <TextArea
-      bind:value={plannedIssuesDescription}
-      placeholder="We plan to add issues related to..."
-      onblur={() => touch('plannedIssues')}
-    />
-    <div class="char-count">
-      <span class:too-long={plannedIssuesDescription.length > 5000} class="tnum"
-        >{plannedIssuesDescription.length} / 5,000</span
+      type="div"
+      validationState={touched['plannedIssues'] && !plannedIssuesValid
+        ? {
+            type: 'invalid',
+            message:
+              plannedIssuesDescription.length > 5000
+                ? 'Must not exceed 5,000 characters.'
+                : 'This field is required.',
+          }
+        : { type: 'valid' }}
+    >
+      <TextArea
+        bind:value={plannedIssuesDescription}
+        placeholder="We plan to add issues related to..."
+        onblur={() => touch('plannedIssues')}
+      />
+      <div class="char-count">
+        <span class:too-long={plannedIssuesDescription.length > 5000} class="tnum"
+          >{plannedIssuesDescription.length} / 5,000</span
+        >
+      </div>
+    </FormField>
+
+    {#if multipleReposSelected}
+      <FormField
+        title="Repo relationship*"
+        description="You selected multiple repos. Please describe how they are related to each other."
+        type="div"
+        validationState={touched['repoRelationship'] && !repoRelationshipValid
+          ? {
+              type: 'invalid',
+              message:
+                repoRelationshipDescription.length > 5000
+                  ? 'Must not exceed 5,000 characters.'
+                  : 'This field is required when applying multiple repos.',
+            }
+          : { type: 'valid' }}
       >
-    </div>
-  </FormField>
+        <TextArea
+          bind:value={repoRelationshipDescription}
+          placeholder="These repos are related because..."
+          onblur={() => touch('repoRelationship')}
+        />
+        <div class="char-count">
+          <span class:too-long={repoRelationshipDescription.length > 5000} class="tnum"
+            >{repoRelationshipDescription.length} / 5,000</span
+          >
+        </div>
+      </FormField>
+    {/if}
 
-  {#if multipleReposSelected}
-    <FormField
-      title="Repo relationship*"
-      description="You selected multiple repos. Please describe how they are related to each other."
-      type="div"
-      validationState={touched['repoRelationship'] && !repoRelationshipValid
-        ? {
-            type: 'invalid',
-            message:
-              repoRelationshipDescription.length > 5000
-                ? 'Must not exceed 5,000 characters.'
-                : 'This field is required when applying multiple repos.',
-          }
-        : { type: 'valid' }}
-    >
-      <TextArea
-        bind:value={repoRelationshipDescription}
-        placeholder="These repos are related because..."
-        onblur={() => touch('repoRelationship')}
-      />
-      <div class="char-count">
-        <span class:too-long={repoRelationshipDescription.length > 5000} class="tnum"
-          >{repoRelationshipDescription.length} / 5,000</span
-        >
-      </div>
-    </FormField>
-  {/if}
+    {#if anySelectedRepoIsFork}
+      <AnnotationBox type="info">
+        One or more of your selected repos is a fork. Please answer the following additional
+        questions.
+      </AnnotationBox>
 
-  {#if anySelectedRepoIsFork}
-    <AnnotationBox type="info">
-      One or more of your selected repos is a fork. Please answer the following additional
-      questions.
-    </AnnotationBox>
+      <FormField
+        title="Upstream relationship*"
+        description="Describe the relationship between your fork(s) and the upstream repo(s)."
+        type="div"
+        validationState={touched['upstreamRelationship'] && !upstreamRelationshipValid
+          ? {
+              type: 'invalid',
+              message:
+                upstreamRelationshipDescription.length > 5000
+                  ? 'Must not exceed 5,000 characters.'
+                  : 'This field is required for forked repos.',
+            }
+          : { type: 'valid' }}
+      >
+        <TextArea
+          bind:value={upstreamRelationshipDescription}
+          placeholder="The relationship to the upstream repo is..."
+          onblur={() => touch('upstreamRelationship')}
+        />
+        <div class="char-count">
+          <span class:too-long={upstreamRelationshipDescription.length > 5000} class="tnum"
+            >{upstreamRelationshipDescription.length} / 5,000</span
+          >
+        </div>
+      </FormField>
 
-    <FormField
-      title="Upstream relationship*"
-      description="Describe the relationship between your fork(s) and the upstream repo(s)."
-      type="div"
-      validationState={touched['upstreamRelationship'] && !upstreamRelationshipValid
-        ? {
-            type: 'invalid',
-            message:
-              upstreamRelationshipDescription.length > 5000
-                ? 'Must not exceed 5,000 characters.'
-                : 'This field is required for forked repos.',
-          }
-        : { type: 'valid' }}
-    >
-      <TextArea
-        bind:value={upstreamRelationshipDescription}
-        placeholder="The relationship to the upstream repo is..."
-        onblur={() => touch('upstreamRelationship')}
-      />
-      <div class="char-count">
-        <span class:too-long={upstreamRelationshipDescription.length > 5000} class="tnum"
-          >{upstreamRelationshipDescription.length} / 5,000</span
-        >
-      </div>
-    </FormField>
-
-    <FormField
-      title="Fork justification*"
-      descriptionMd={`Help us understand the context of why you're submitting a fork.
+      <FormField
+        title="Fork justification*"
+        descriptionMd={`Help us understand the context of why you're submitting a fork.
       
 **Example:** "The original project went inactive 6 months ago; I'm continuing development independently".
 
 There's no wrong answer. We need this context to review forks accurately.`}
+        type="div"
+        validationState={touched['forkJustification'] && !forkJustificationValid
+          ? {
+              type: 'invalid',
+              message:
+                forkJustification.length > 5000
+                  ? 'Must not exceed 5,000 characters.'
+                  : 'This field is required for forked repos.',
+            }
+          : { type: 'valid' }}
+      >
+        <TextArea
+          bind:value={forkJustification}
+          placeholder="We are applying with this fork because..."
+          onblur={() => touch('forkJustification')}
+        />
+        <div class="char-count">
+          <span class:too-long={forkJustification.length > 5000} class="tnum"
+            >{forkJustification.length} / 5,000</span
+          >
+        </div>
+      </FormField>
+    {/if}
+
+    <FormField
+      title="Supporting links"
+      description="Provide links to resources relevant to your project (e.g. website, documentation, social media, deployed contracts). Up to 10 links."
       type="div"
-      validationState={touched['forkJustification'] && !forkJustificationValid
-        ? {
-            type: 'invalid',
-            message:
-              forkJustification.length > 5000
-                ? 'Must not exceed 5,000 characters.'
-                : 'This field is required for forked repos.',
-          }
-        : { type: 'valid' }}
     >
-      <TextArea
-        bind:value={forkJustification}
-        placeholder="We are applying with this fork because..."
-        onblur={() => touch('forkJustification')}
-      />
-      <div class="char-count">
-        <span class:too-long={forkJustification.length > 5000} class="tnum"
-          >{forkJustification.length} / 5,000</span
+      {#if supportingLinks.length > 0}
+        <ul class="links-list">
+          {#each supportingLinks as link, i (link)}
+            <li>
+              <span class="typo-text link-url">{link}</span>
+              <Button size="small" icon={Trash} onclick={() => removeLink(i)}>Remove</Button>
+            </li>
+          {/each}
+        </ul>
+      {/if}
+      <div class="add-link-row">
+        <TextInput
+          bind:value={newLink}
+          placeholder={supportingLinks.length >= 10 ? 'Link limit reached' : 'https://...'}
+          disabled={supportingLinks.length >= 10}
+          onkeydown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              addLink();
+            }
+          }}
+        />
+        <Button
+          size="large"
+          icon={Plus}
+          disabled={!newLinkIsValid || supportingLinks.length >= 10}
+          onclick={addLink}>Add link</Button
         >
       </div>
     </FormField>
+
+    <AnnotationBox>
+      By submitting this application, you confirm that all provided information is accurate.
+      Inaccurate information may result in your application being rejected and could lead to
+      disqualification from the Drips Wave Program.
+    </AnnotationBox>
   {/if}
-
-  <FormField
-    title="Supporting links"
-    description="Provide links to resources relevant to your project (e.g. website, documentation, social media, deployed contracts). Up to 10 links."
-    type="div"
-  >
-    {#if supportingLinks.length > 0}
-      <ul class="links-list">
-        {#each supportingLinks as link, i (link)}
-          <li>
-            <span class="typo-text link-url">{link}</span>
-            <Button size="small" icon={Trash} onclick={() => removeLink(i)}>Remove</Button>
-          </li>
-        {/each}
-      </ul>
-    {/if}
-    <div class="add-link-row">
-      <TextInput
-        bind:value={newLink}
-        placeholder={supportingLinks.length >= 10 ? 'Link limit reached' : 'https://...'}
-        disabled={supportingLinks.length >= 10}
-        onkeydown={(e) => {
-          if (e.key === 'Enter') {
-            e.preventDefault();
-            addLink();
-          }
-        }}
-      />
-      <Button
-        size="large"
-        icon={Plus}
-        disabled={!newLinkIsValid || supportingLinks.length >= 10}
-        onclick={addLink}>Add link</Button
-      >
-    </div>
-  </FormField>
-
-  <AnnotationBox>
-    By submitting this application, you confirm that all provided information is accurate.
-    Inaccurate information may result in your application being rejected and could lead to
-    disqualification from the Drips Wave Program.
-  </AnnotationBox>
 
   {#snippet leftActions()}
     <Button
@@ -389,13 +395,15 @@ There's no wrong answer. We need this context to review forks accurately.`}
   {/snippet}
 
   {#snippet actions()}
-    <Button
-      variant="primary"
-      disabled={!formValid}
-      icon={CheckCircle}
-      loading={applying}
-      onclick={handleApply}>Apply selected repos</Button
-    >
+    {#if !data.user?.restricted}
+      <Button
+        variant="primary"
+        disabled={!formValid}
+        icon={CheckCircle}
+        loading={applying}
+        onclick={handleApply}>Apply selected repos</Button
+      >
+    {/if}
   {/snippet}
 </FlowStepWrapper>
 

--- a/src/routes/(pages)/wave/(flows)/maintainer-onboarding/apply-to-wave-program/[waveProgramId]/form/+page.svelte
+++ b/src/routes/(pages)/wave/(flows)/maintainer-onboarding/apply-to-wave-program/[waveProgramId]/form/+page.svelte
@@ -206,7 +206,12 @@
 >
   {#if data.user?.restricted}
     <AnnotationBox type="error">
-      Sorry, but your Drips Wave account has been restricted from applying repos.
+      Sorry, but your Drips Wave account has been restricted from applying repos. You can reach out
+      to support@drips.network for more details.
+
+      {#snippet actions()}
+        <Button href="mailto:support@drips.network">Contact support</Button>
+      {/snippet}
     </AnnotationBox>
   {:else}
     <FormField


### PR DESCRIPTION
Companion to drips-network/wave#535. The Wave token now carries a `restricted: true` claim when the account is restricted (lighter than a full ban — login still works, the user just can't submit new applications). Plumbed through `getUserData` so it lands on `data.user.restricted`, then gated on the two apply pages so users see a direct inline message instead of bouncing off a 403 from the backend.

Also adds an `AccountRestrictedError` that mirrors `AccountSuspendedError` for the case where a stale token slips past the inline gate — keeps the error modal from displaying the raw status text.

Everything else stays open: viewing issues and repos, withdrawing existing applications, withdrawing grants, etc.

Note: the previous commit on main reverted an earlier accidental direct push of this same change. This PR re-applies it cleanly via review.