### PR TITLE
wave: require explicit T&C and 18+ confirmation on login

### DIFF
--- a/src/lib/components/annotation-box/annotation-box.svelte
+++ b/src/lib/components/annotation-box/annotation-box.svelte
@@ -7,6 +7,7 @@
     size?: 'normal' | 'small';
     overlay?: boolean;
     icon?: Component | undefined;
+    hideIcon?: boolean;
     children?: import('svelte').Snippet;
     actions?: import('svelte').Snippet;
     centered?: boolean;
@@ -17,6 +18,7 @@
     size = 'normal',
     overlay = false,
     icon = undefined,
+    hideIcon = false,
     children,
     actions,
     centered = false,
@@ -25,18 +27,24 @@
 
 <div class="annotation-box typo-text-small {type} {size}" class:centered class:overlay>
   <div class="content-wrapper">
-    <div class="icon-container">
-      {#if icon}
-        {@const SvelteComponent = icon}
-        <SvelteComponent style="height: 1.25rem; width: 1.25rem; fill: currentColor" />
-      {:else if type === 'warning'}
-        <WarningIcon style="height: 1.25rem; width: 1.25rem; fill: var(--color-caution-level-6)" />
-      {:else if type === 'info'}
-        <InfoCircle style="height: 1.25rem; width: 1.25rem; fill: var(--color-primary-level-6)" />
-      {:else}
-        <WarningIcon style="height: 1.25rem; width: 1.25rem; fill: var(--color-negative-level-6)" />
-      {/if}
-    </div>
+    {#if !hideIcon}
+      <div class="icon-container">
+        {#if icon}
+          {@const SvelteComponent = icon}
+          <SvelteComponent style="height: 1.25rem; width: 1.25rem; fill: currentColor" />
+        {:else if type === 'warning'}
+          <WarningIcon
+            style="height: 1.25rem; width: 1.25rem; fill: var(--color-caution-level-6)"
+          />
+        {:else if type === 'info'}
+          <InfoCircle style="height: 1.25rem; width: 1.25rem; fill: var(--color-primary-level-6)" />
+        {:else}
+          <WarningIcon
+            style="height: 1.25rem; width: 1.25rem; fill: var(--color-negative-level-6)"
+          />
+        {/if}
+      </div>
+    {/if}
 
     <div class="text-wrapper">
       {@render children?.()}

--- a/src/lib/components/wave/log-in-button/log-in-button.svelte
+++ b/src/lib/components/wave/log-in-button/log-in-button.svelte
@@ -9,7 +9,14 @@
     wordy = false,
     primary = false,
     skipWelcome = false,
-  }: { backTo?: string; wordy?: boolean; primary?: boolean; skipWelcome?: boolean } = $props();
+    disabled = false,
+  }: {
+    backTo?: string;
+    wordy?: boolean;
+    primary?: boolean;
+    skipWelcome?: boolean;
+    disabled?: boolean;
+  } = $props();
 
   const WAVE_API_URL = getOptionalEnvVar(
     'PUBLIC_WAVE_API_URL',
@@ -27,6 +34,7 @@
 
 <Button
   icon={Github}
+  {disabled}
   variant={primary ? 'primary' : undefined}
   href="{WAVE_API_URL}/api/auth/oauth/github/login{backTo
     ? `?backTo=${encodeURIComponent(backTo)}&skipWelcome=${skipWelcome}${attributionRefParam ? `&ref=${encodeURIComponent(attributionRefParam)}` : ''}`

--- a/src/routes/(pages)/wave/(flows)/login/+page.svelte
+++ b/src/routes/(pages)/wave/(flows)/login/+page.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
+  import AnnotationBox from '$lib/components/annotation-box/annotation-box.svelte';
+  import Checkbox from '$lib/components/checkbox/checkbox.svelte';
   import HeadMeta from '$lib/components/head-meta/head-meta.svelte';
   import LogInButton from '$lib/components/wave/log-in-button/log-in-button.svelte';
 
   let { data } = $props();
+
+  let confirmed = $state(false);
 </script>
 
 <HeadMeta title="Sign In | Wave" />
@@ -10,19 +14,46 @@
 <h1>Sign in to Drips Wave</h1>
 <p>To start using Drips Wave, please sign in with your GitHub account.</p>
 
-<LogInButton primary wordy backTo={data.backTo || '/wave'} skipWelcome={data.skipWelcome} />
+<div class="confirm-box">
+  <AnnotationBox type="warning" hideIcon>
+    <label class="confirm">
+      <Checkbox bind:checked={confirmed} />
+      <span class="typo-text-small">
+        I confirm that <span class="typo-text-small-bold">I am at least 18 years of age</span> and
+        agree to the
+        <a class="typo-link" target="_blank" href="https://docs.drips.network/wave/terms-and-rules"
+          >Drips Wave Terms &amp; Rules</a
+        >.
+      </span>
+    </label>
+  </AnnotationBox>
+</div>
 
-<p
-  class="typo-text-small"
-  style:margin-top="1.5rem"
-  style:max-width="32rem"
-  style:color="var(--color-foreground-level-6)"
->
-  By logging into Drips Wave, <span class="typo-text-small-bold"
-    >you confirm to be over 18 years of age</span
-  >, and agree to the
-  <a class="typo-link" target="_blank" href="https://docs.drips.network/wave/terms-and-rules"
-    >Terms of Service</a
-  >
-  and <a class="typo-link" target="_blank" href="/legal/privacy">Privacy Policy</a>.
+<LogInButton
+  primary
+  wordy
+  disabled={!confirmed}
+  backTo={data.backTo || '/wave'}
+  skipWelcome={data.skipWelcome}
+/>
+
+<p class="typo-text-small" style:max-width="32rem" style:color="var(--color-foreground-level-6)">
+  By logging in, you acknowledge our
+  <a class="typo-link" target="_blank" href="/legal/privacy">Privacy Policy</a>.
 </p>
+
+<style>
+  .confirm-box {
+    max-width: 28rem;
+    width: 100%;
+    margin-bottom: 1rem;
+  }
+
+  .confirm {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+    text-align: left;
+    cursor: pointer;
+  }
+</style>


### PR DESCRIPTION
Adds a checkbox in a yellow annotation box above the GitHub login button on the Wave login page. Login is disabled until the user confirms they are at least 18 years old and agree to the Drips Wave Terms & Rules. A separate line below the button acknowledges the Privacy Policy.

Also adds a `hideIcon` prop to `AnnotationBox` so it can be used as a plain emphasis container without the type-based icon.

Note: this is the frontend half. We'll also want to log T&C consent server-side at login time so we have a record of who agreed and when. Tracking that in a backend issue.