### PR TITLE
add admin tool to ban or restrict github users

### DIFF
--- a/src/lib/utils/github/lookup-user.ts
+++ b/src/lib/utils/github/lookup-user.ts
@@ -1,0 +1,93 @@
+/**
+ * Lightweight, unauthenticated lookups against the public GitHub API.
+ * Used by the admin bans tool: usernames must be resolved to numeric
+ * IDs before they can be banned, and existing ban records only carry
+ * the numeric ID so we resolve back to a login for display.
+ *
+ * Unauthenticated GitHub API allows 60 req/hour per IP. We cache
+ * results in-memory for the lifetime of the page to avoid re-fetching.
+ */
+
+export type GitHubUser = {
+  id: number;
+  login: string;
+  name: string | null;
+  avatarUrl: string;
+  htmlUrl: string;
+};
+
+const byIdCache = new Map<number, GitHubUser>();
+const byLoginCache = new Map<string, GitHubUser | null>();
+
+function normalize(raw: unknown): GitHubUser {
+  const r = raw as {
+    id: number;
+    login: string;
+    name: string | null;
+    avatar_url: string;
+    html_url: string;
+  };
+  return {
+    id: r.id,
+    login: r.login,
+    name: r.name ?? null,
+    avatarUrl: r.avatar_url,
+    htmlUrl: r.html_url,
+  };
+}
+
+export async function lookupGitHubUserByLogin(login: string): Promise<GitHubUser | null> {
+  const key = login.toLowerCase();
+  if (byLoginCache.has(key)) {
+    return byLoginCache.get(key) ?? null;
+  }
+
+  const res = await fetch(`https://api.github.com/users/${encodeURIComponent(login)}`, {
+    headers: { Accept: 'application/vnd.github+json' },
+  });
+
+  if (res.status === 404) {
+    byLoginCache.set(key, null);
+    return null;
+  }
+
+  if (res.status === 403 || res.status === 429) {
+    throw new Error('GitHub API rate limit exceeded. Please wait a while and try again.');
+  }
+
+  if (!res.ok) {
+    throw new Error(`GitHub API request failed: ${res.status} ${res.statusText}`);
+  }
+
+  const user = normalize(await res.json());
+  byLoginCache.set(key, user);
+  byIdCache.set(user.id, user);
+  return user;
+}
+
+export async function lookupGitHubUserById(id: number): Promise<GitHubUser | null> {
+  if (byIdCache.has(id)) {
+    return byIdCache.get(id) ?? null;
+  }
+
+  const res = await fetch(`https://api.github.com/user/${id}`, {
+    headers: { Accept: 'application/vnd.github+json' },
+  });
+
+  if (res.status === 404) {
+    return null;
+  }
+
+  if (res.status === 403 || res.status === 429) {
+    throw new Error('GitHub API rate limit exceeded. Please wait a while and try again.');
+  }
+
+  if (!res.ok) {
+    throw new Error(`GitHub API request failed: ${res.status} ${res.statusText}`);
+  }
+
+  const user = normalize(await res.json());
+  byIdCache.set(user.id, user);
+  byLoginCache.set(user.login.toLowerCase(), user);
+  return user;
+}

--- a/src/lib/utils/wave/bans.ts
+++ b/src/lib/utils/wave/bans.ts
@@ -13,6 +13,7 @@ export type RestrictionType = z.infer<typeof restrictionTypeSchema>;
 export const bannedUserSchema = z.object({
   id: z.uuid(),
   gitHubUserId: z.number().int(),
+  gitHubUsername: z.string().nullable(),
   type: restrictionTypeSchema,
   reason: z.string().nullable(),
   bannedAt: z.coerce.date(),

--- a/src/lib/utils/wave/bans.ts
+++ b/src/lib/utils/wave/bans.ts
@@ -1,0 +1,69 @@
+import z from 'zod';
+import { authenticatedCall } from './call';
+import parseRes from './utils/parse-res';
+import {
+  paginatedResponseSchema,
+  type PaginationInput,
+  toPaginationParams,
+} from './types/pagination';
+
+export const restrictionTypeSchema = z.enum(['ban', 'restriction']);
+export type RestrictionType = z.infer<typeof restrictionTypeSchema>;
+
+export const bannedUserSchema = z.object({
+  id: z.uuid(),
+  gitHubUserId: z.number().int(),
+  type: restrictionTypeSchema,
+  reason: z.string().nullable(),
+  bannedAt: z.coerce.date(),
+  bannedBy: z
+    .object({
+      id: z.uuid(),
+      gitHubUsername: z.string(),
+    })
+    .nullable(),
+});
+export type BannedUser = z.infer<typeof bannedUserSchema>;
+
+export const banGitHubUserResponseSchema = z.object({
+  success: z.boolean(),
+  revokedTokenCount: z.number().int().nonnegative(),
+});
+export type BanGitHubUserResponse = z.infer<typeof banGitHubUserResponseSchema>;
+
+export async function listBans(
+  f = fetch,
+  options: { pagination?: PaginationInput; type?: RestrictionType } = {},
+) {
+  const params = new URLSearchParams(toPaginationParams(options.pagination));
+  if (options.type) {
+    params.append('type', options.type);
+  }
+
+  const queryString = params.toString();
+  const path = `/api/admin/bans${queryString ? `?${queryString}` : ''}`;
+
+  const res = await authenticatedCall(f, path);
+  return parseRes(paginatedResponseSchema(bannedUserSchema), res);
+}
+
+export async function banGitHubUser(
+  f = fetch,
+  data: { gitHubUserId: number; type: RestrictionType; reason?: string },
+) {
+  const res = await authenticatedCall(f, '/api/admin/bans', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+  return parseRes(banGitHubUserResponseSchema, res);
+}
+
+export async function unbanGitHubUser(f = fetch, gitHubUserId: number) {
+  const res = await authenticatedCall(f, `/api/admin/bans/${gitHubUserId}`, {
+    method: 'DELETE',
+  });
+
+  if (res.status === 404) {
+    throw new Error('That user is not currently banned or restricted.');
+  }
+}

--- a/src/routes/(pages)/wave/(base-layout)/admin/+page.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/admin/+page.svelte
@@ -44,6 +44,16 @@
           },
         ]
       : []),
+    ...(data.user.permissions?.includes('manageBans')
+      ? [
+          {
+            name: 'Bans & Restrictions',
+            description:
+              'Ban or restrict a GitHub user, and review existing bans and restrictions.',
+            href: '/wave/admin/bans',
+          },
+        ]
+      : []),
   ]);
 </script>
 

--- a/src/routes/(pages)/wave/(base-layout)/admin/bans/+page.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/admin/bans/+page.svelte
@@ -1,0 +1,253 @@
+<script lang="ts">
+  import { goto, invalidate } from '$app/navigation';
+  import { page } from '$app/state';
+  import HeadMeta from '$lib/components/head-meta/head-meta.svelte';
+  import Breadcrumbs from '$lib/components/breadcrumbs/breadcrumbs.svelte';
+  import Section from '$lib/components/section/section.svelte';
+  import Button from '$lib/components/button/button.svelte';
+  import Dropdown from '$lib/components/dropdown/dropdown.svelte';
+  import FormField from '$lib/components/form-field/form-field.svelte';
+  import Refresh from '$lib/components/icons/Refresh.svelte';
+  import Plus from '$lib/components/icons/Plus.svelte';
+  import modal from '$lib/stores/modal';
+  import doWithConfirmationModal from '$lib/utils/do-with-confirmation-modal';
+  import doWithErrorModal from '$lib/utils/do-with-error-modal';
+  import { unbanGitHubUser } from '$lib/utils/wave/bans';
+  import CreateBanModal from './components/create-ban-modal.svelte';
+  import GitHubUserById from './components/github-user-by-id.svelte';
+
+  let { data } = $props();
+
+  let bans = $derived(data.bans);
+  let typeFilter = $state<string>(data.type ?? 'all');
+  let refreshing = $state(false);
+
+  const typeOptions = [
+    { value: 'all', title: 'All' },
+    { value: 'ban', title: 'Bans' },
+    { value: 'restriction', title: 'Restrictions' },
+  ];
+
+  async function refresh() {
+    refreshing = true;
+    await invalidate('wave:admin:bans');
+    refreshing = false;
+  }
+
+  async function applyFilter() {
+    const url = new URL(page.url);
+    if (typeFilter === 'all') {
+      url.searchParams.delete('type');
+    } else {
+      url.searchParams.set('type', typeFilter);
+    }
+    await goto(url.pathname + url.search, { keepFocus: true, noScroll: true });
+  }
+
+  function openCreateModal() {
+    modal.show(CreateBanModal, undefined, {
+      onCreated: refresh,
+    });
+  }
+
+  async function lift(gitHubUserId: number, type: 'ban' | 'restriction') {
+    const noun = type === 'ban' ? 'ban' : 'restriction';
+    const message = `Lift the ${noun} on GitHub user #${gitHubUserId}? They will regain ${type === 'ban' ? 'the ability to log in' : 'access to restricted actions'} immediately.`;
+
+    await doWithConfirmationModal(message, async () => {
+      await doWithErrorModal(() => unbanGitHubUser(fetch, gitHubUserId), undefined, {
+        message: `${noun[0].toUpperCase() + noun.slice(1)} lifted.`,
+        confetti: false,
+      });
+      await refresh();
+    });
+  }
+
+  function formatDate(date: Date) {
+    return date.toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+  }
+</script>
+
+<HeadMeta title="Bans & Restrictions | Admin | Wave" />
+
+<div class="page">
+  <Breadcrumbs
+    crumbs={[{ label: 'Admin', href: '/wave/admin' }, { label: 'Bans & Restrictions' }]}
+  />
+  <Section
+    header={{
+      label: 'Bans & Restrictions',
+      actions: [
+        {
+          label: 'Refresh',
+          icon: Refresh,
+          disabled: refreshing,
+          handler: refresh,
+        },
+        {
+          label: 'Ban or restrict a user',
+          icon: Plus,
+          variant: 'primary',
+          handler: openCreateModal,
+        },
+      ],
+    }}
+    skeleton={{
+      loaded: true,
+      empty: bans.pagination.total === 0,
+      emptyStateEmoji: '🛡️',
+      emptyStateHeadline:
+        typeFilter === 'all'
+          ? 'No active bans or restrictions'
+          : typeFilter === 'ban'
+            ? 'No active bans'
+            : 'No active restrictions',
+      emptyStateText: 'Use the button above to ban or restrict a GitHub user.',
+    }}
+  >
+    <div class="filter">
+      <FormField title="Type">
+        <Dropdown options={typeOptions} bind:value={typeFilter} onchange={applyFilter} />
+      </FormField>
+    </div>
+
+    {#if bans.pagination.total > 0}
+      <div class="list">
+        {#each bans.data as ban (ban.id)}
+          <div class="row">
+            <div class="left">
+              <GitHubUserById gitHubUserId={ban.gitHubUserId} />
+              <div class="meta typo-text-small">
+                <span
+                  class="badge"
+                  class:ban={ban.type === 'ban'}
+                  class:restriction={ban.type === 'restriction'}
+                >
+                  {ban.type}
+                </span>
+                <span class="dim">·</span>
+                <span class="dim">{formatDate(ban.bannedAt)}</span>
+                {#if ban.bannedBy}
+                  <span class="dim">·</span>
+                  <span class="dim">by {ban.bannedBy.gitHubUsername}</span>
+                {/if}
+              </div>
+              {#if ban.reason}
+                <p class="reason typo-text-small">{ban.reason}</p>
+              {/if}
+            </div>
+
+            <div class="actions">
+              <Button size="small" variant="ghost" onclick={() => lift(ban.gitHubUserId, ban.type)}>
+                Lift
+              </Button>
+            </div>
+          </div>
+        {/each}
+      </div>
+
+      {#if bans.pagination.total > bans.data.length}
+        <p class="footer typo-text-small">
+          Showing {bans.data.length} of {bans.pagination.total}.
+        </p>
+      {/if}
+    {/if}
+  </Section>
+</div>
+
+<style>
+  .page {
+    display: flex;
+    max-width: 90rem;
+    margin: 0 auto;
+    width: 100%;
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+
+  .filter {
+    max-width: 16rem;
+    margin-bottom: 1.5rem;
+  }
+
+  .list {
+    display: flex;
+    flex-direction: column;
+    border: 1px solid var(--color-foreground-level-2);
+    border-radius: 1rem 0 1rem 1rem;
+    overflow: hidden;
+  }
+
+  .row {
+    padding: 1rem;
+    border-bottom: 1px solid var(--color-foreground-level-2);
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    align-items: center;
+  }
+
+  .row:last-child {
+    border-bottom: none;
+  }
+
+  .left {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    min-width: 0;
+    flex: 1;
+  }
+
+  .meta {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    flex-wrap: wrap;
+  }
+
+  .badge {
+    text-transform: uppercase;
+    font-size: 0.625rem;
+    letter-spacing: 0.05em;
+    padding: 0.125rem 0.5rem;
+    border-radius: 0.5rem;
+    font-family: var(--typeface-mono);
+  }
+
+  .badge.ban {
+    background: var(--color-negative-level-1);
+    color: var(--color-negative-level-6);
+  }
+
+  .badge.restriction {
+    background: var(--color-caution-level-1);
+    color: var(--color-caution-level-6);
+  }
+
+  .dim {
+    color: var(--color-foreground-level-5);
+  }
+
+  .reason {
+    color: var(--color-foreground-level-6);
+    margin: 0;
+    word-break: break-word;
+  }
+
+  .actions {
+    display: flex;
+    gap: 0.5rem;
+    flex-shrink: 0;
+  }
+
+  .footer {
+    color: var(--color-foreground-level-5);
+    margin-top: 0.75rem;
+    text-align: center;
+  }
+</style>

--- a/src/routes/(pages)/wave/(base-layout)/admin/bans/+page.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/admin/bans/+page.svelte
@@ -120,7 +120,7 @@
         {#each bans.data as ban (ban.id)}
           <div class="row">
             <div class="left">
-              <GitHubUserById gitHubUserId={ban.gitHubUserId} />
+              <GitHubUserById gitHubUserId={ban.gitHubUserId} gitHubUsername={ban.gitHubUsername} />
               <div class="meta typo-text-small">
                 <span
                   class="badge"

--- a/src/routes/(pages)/wave/(base-layout)/admin/bans/+page.ts
+++ b/src/routes/(pages)/wave/(base-layout)/admin/bans/+page.ts
@@ -1,0 +1,23 @@
+import { listBans, type RestrictionType } from '$lib/utils/wave/bans.js';
+import { redirect } from '@sveltejs/kit';
+
+export const load = async ({ parent, fetch, depends, url }) => {
+  depends('wave:admin:bans');
+
+  const { user } = await parent();
+
+  if (!user.permissions?.includes('manageBans')) {
+    throw redirect(302, '/wave/admin');
+  }
+
+  const typeParam = url.searchParams.get('type');
+  const type: RestrictionType | undefined =
+    typeParam === 'ban' || typeParam === 'restriction' ? typeParam : undefined;
+
+  const bans = await listBans(fetch, { pagination: { limit: 100 }, type });
+
+  return {
+    bans,
+    type,
+  };
+};

--- a/src/routes/(pages)/wave/(base-layout)/admin/bans/components/create-ban-modal.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/admin/bans/components/create-ban-modal.svelte
@@ -1,0 +1,212 @@
+<script lang="ts">
+  import Button from '$lib/components/button/button.svelte';
+  import TextInput from '$lib/components/text-input/text-input.svelte';
+  import TextArea from '$lib/components/text-area/text-area.svelte';
+  import Dropdown from '$lib/components/dropdown/dropdown.svelte';
+  import FormField from '$lib/components/form-field/form-field.svelte';
+  import StandaloneFlowStepLayout from '$lib/components/standalone-flow-step-layout/standalone-flow-step-layout.svelte';
+  import AnnotationBox from '$lib/components/annotation-box/annotation-box.svelte';
+  import modal from '$lib/stores/modal';
+  import { lookupGitHubUserByLogin, type GitHubUser } from '$lib/utils/github/lookup-user';
+  import { banGitHubUser, type RestrictionType } from '$lib/utils/wave/bans';
+
+  interface Props {
+    onCreated: () => void;
+  }
+
+  let { onCreated }: Props = $props();
+
+  const typeOptions = [
+    { value: 'ban', title: 'Ban — block login entirely, revoke existing sessions' },
+    { value: 'restriction', title: 'Restriction — login allowed, blocks specific actions' },
+  ];
+
+  let username = $state('');
+  let type = $state<string>('ban');
+  let reason = $state('');
+
+  let resolvedUser = $state<GitHubUser | null | undefined>(undefined);
+  let lookupError = $state<string | null>(null);
+  let lookingUp = $state(false);
+  let lookupToken = 0;
+
+  let submitting = $state(false);
+  let submitError = $state<string | null>(null);
+
+  const trimmedUsername = $derived(username.trim());
+  const canSubmit = $derived(!!resolvedUser && !submitting && !lookingUp && reason.length <= 500);
+
+  async function lookup() {
+    const value = trimmedUsername;
+    if (value.length === 0) {
+      resolvedUser = undefined;
+      lookupError = null;
+      return;
+    }
+
+    if (resolvedUser && resolvedUser.login.toLowerCase() === value.toLowerCase()) {
+      return;
+    }
+
+    const token = ++lookupToken;
+    lookingUp = true;
+    lookupError = null;
+    resolvedUser = undefined;
+
+    try {
+      const user = await lookupGitHubUserByLogin(value);
+      if (token !== lookupToken) return;
+      if (!user) {
+        lookupError = `No GitHub user found with username "${value}".`;
+        resolvedUser = null;
+      } else {
+        resolvedUser = user;
+      }
+    } catch (e) {
+      if (token !== lookupToken) return;
+      lookupError = e instanceof Error ? e.message : 'Lookup failed.';
+      resolvedUser = null;
+    } finally {
+      if (token === lookupToken) lookingUp = false;
+    }
+  }
+
+  function onUsernameInput() {
+    // Invalidate any previous resolution as the user edits.
+    resolvedUser = undefined;
+    lookupError = null;
+  }
+
+  async function handleSubmit() {
+    if (!canSubmit || !resolvedUser) return;
+
+    submitting = true;
+    submitError = null;
+
+    try {
+      await banGitHubUser(fetch, {
+        gitHubUserId: resolvedUser.id,
+        type: type as RestrictionType,
+        reason: reason.trim() ? reason.trim() : undefined,
+      });
+      onCreated();
+      modal.hide();
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'An unexpected error occurred.';
+      if (msg.includes('409')) {
+        submitError = `${resolvedUser.login} is already banned or restricted.`;
+      } else if (msg.includes('400')) {
+        submitError = 'Bad request. The backend rejected this ban.';
+      } else {
+        submitError = msg;
+      }
+    } finally {
+      submitting = false;
+    }
+  }
+</script>
+
+<div class="modal">
+  <StandaloneFlowStepLayout
+    headline="Ban or restrict a user"
+    description="Bans block login entirely and revoke sessions immediately. Restrictions allow login but block actions like applying to issues or repos."
+  >
+    <div class="fields">
+      <FormField
+        title="GitHub Username"
+        description="Looked up against the public GitHub API to resolve the numeric user ID."
+      >
+        <TextInput
+          bind:value={username}
+          placeholder="e.g. octocat"
+          oninput={onUsernameInput}
+          onblur={lookup}
+        />
+      </FormField>
+
+      {#if lookingUp}
+        <p class="hint typo-text-small">Looking up GitHub user…</p>
+      {:else if resolvedUser}
+        <div class="preview">
+          <img class="avatar" src={resolvedUser.avatarUrl} alt="" referrerpolicy="no-referrer" />
+          <div class="info">
+            <span class="login typo-text-bold">{resolvedUser.login}</span>
+            {#if resolvedUser.name}
+              <span class="name typo-text-small dim">{resolvedUser.name}</span>
+            {/if}
+            <span class="id typo-text-small dim">GitHub ID #{resolvedUser.id}</span>
+          </div>
+        </div>
+      {:else if lookupError}
+        <AnnotationBox type="warning">{lookupError}</AnnotationBox>
+      {/if}
+
+      <FormField title="Type">
+        <Dropdown options={typeOptions} bind:value={type} />
+      </FormField>
+
+      <FormField title="Reason" description="Optional. Up to 500 characters.">
+        <TextArea bind:value={reason} placeholder="Why is this user being banned or restricted?" />
+      </FormField>
+    </div>
+
+    {#if submitError}
+      <AnnotationBox type="error">{submitError}</AnnotationBox>
+    {/if}
+
+    {#snippet actions()}
+      <Button variant="normal" disabled={submitting} onclick={modal.hide}>Cancel</Button>
+      {#if !resolvedUser && trimmedUsername.length > 0 && !lookingUp}
+        <Button variant="primary" loading={lookingUp} onclick={lookup}>Look up</Button>
+      {:else}
+        <Button variant="primary" loading={submitting} disabled={!canSubmit} onclick={handleSubmit}>
+          {type === 'ban' ? 'Ban user' : 'Restrict user'}
+        </Button>
+      {/if}
+    {/snippet}
+  </StandaloneFlowStepLayout>
+</div>
+
+<style>
+  .modal {
+    padding: 1rem;
+  }
+
+  .fields {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .hint {
+    color: var(--color-foreground-level-5);
+  }
+
+  .preview {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem;
+    border: 1px solid var(--color-foreground-level-2);
+    border-radius: 0.5rem;
+    background: var(--color-foreground-level-1);
+  }
+
+  .avatar {
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .info {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+    min-width: 0;
+  }
+
+  .dim {
+    color: var(--color-foreground-level-5);
+  }
+</style>

--- a/src/routes/(pages)/wave/(base-layout)/admin/bans/components/create-ban-modal.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/admin/bans/components/create-ban-modal.svelte
@@ -18,7 +18,10 @@
 
   const typeOptions = [
     { value: 'ban', title: 'Ban — block login entirely, revoke existing sessions' },
-    { value: 'restriction', title: 'Restriction — login allowed, blocks specific actions' },
+    {
+      value: 'restriction',
+      title: 'Restriction — login allowed, blocks applying to issues / applying repos',
+    },
   ];
 
   let username = $state('');

--- a/src/routes/(pages)/wave/(base-layout)/admin/bans/components/github-user-by-id.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/admin/bans/components/github-user-by-id.svelte
@@ -3,14 +3,27 @@
 
   interface Props {
     gitHubUserId: number;
+    /**
+     * Pre-resolved GitHub username, when wave already knew it (i.e. the
+     * banned user has a Wave account). When provided, no GitHub API
+     * lookup happens. Null means wave looked but found no Wave user
+     * (pre-emptive ban) — fall back to the unauthenticated GitHub API.
+     */
+    gitHubUsername?: string | null;
   }
 
-  let { gitHubUserId }: Props = $props();
+  let { gitHubUserId, gitHubUsername = null }: Props = $props();
 
   let user = $state<GitHubUser | null | undefined>(undefined);
   let error = $state<string | null>(null);
 
   $effect(() => {
+    if (gitHubUsername) {
+      user = null;
+      error = null;
+      return;
+    }
+
     let cancelled = false;
     user = undefined;
     error = null;
@@ -32,22 +45,30 @@
   const avatarUrl = $derived(
     user?.avatarUrl ?? `https://avatars.githubusercontent.com/u/${gitHubUserId}?s=64`,
   );
+  const profileUrl = $derived(
+    user?.htmlUrl ?? (gitHubUsername ? `https://github.com/${gitHubUsername}` : null),
+  );
+  const displayLogin = $derived(gitHubUsername ?? user?.login ?? null);
 </script>
 
 <div class="user">
   <img class="avatar" src={avatarUrl} alt="" referrerpolicy="no-referrer" />
   <div class="info">
-    {#if user === undefined}
+    {#if displayLogin}
+      {#if profileUrl}
+        <a class="login typo-text-bold" href={profileUrl} target="_blank" rel="noreferrer">
+          {displayLogin}
+        </a>
+      {:else}
+        <span class="login typo-text-bold">{displayLogin}</span>
+      {/if}
+      <span class="id typo-text-small dim">#{gitHubUserId}</span>
+    {:else if user === undefined}
       <span class="login typo-text-bold">…</span>
       <span class="id typo-text-small dim">#{gitHubUserId}</span>
-    {:else if user === null}
+    {:else}
       <span class="login typo-text-bold">Unknown</span>
       <span class="id typo-text-small dim" title={error ?? undefined}>#{gitHubUserId}</span>
-    {:else}
-      <a class="login typo-text-bold" href={user.htmlUrl} target="_blank" rel="noreferrer">
-        {user.login}
-      </a>
-      <span class="id typo-text-small dim">#{gitHubUserId}</span>
     {/if}
   </div>
 </div>

--- a/src/routes/(pages)/wave/(base-layout)/admin/bans/components/github-user-by-id.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/admin/bans/components/github-user-by-id.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+  import { lookupGitHubUserById, type GitHubUser } from '$lib/utils/github/lookup-user';
+
+  interface Props {
+    gitHubUserId: number;
+  }
+
+  let { gitHubUserId }: Props = $props();
+
+  let user = $state<GitHubUser | null | undefined>(undefined);
+  let error = $state<string | null>(null);
+
+  $effect(() => {
+    let cancelled = false;
+    user = undefined;
+    error = null;
+    lookupGitHubUserById(gitHubUserId)
+      .then((u) => {
+        if (!cancelled) user = u;
+      })
+      .catch((e: unknown) => {
+        if (!cancelled) {
+          user = null;
+          error = e instanceof Error ? e.message : 'Lookup failed.';
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  });
+
+  const avatarUrl = $derived(
+    user?.avatarUrl ?? `https://avatars.githubusercontent.com/u/${gitHubUserId}?s=64`,
+  );
+</script>
+
+<div class="user">
+  <img class="avatar" src={avatarUrl} alt="" referrerpolicy="no-referrer" />
+  <div class="info">
+    {#if user === undefined}
+      <span class="login typo-text-bold">…</span>
+      <span class="id typo-text-small dim">#{gitHubUserId}</span>
+    {:else if user === null}
+      <span class="login typo-text-bold">Unknown</span>
+      <span class="id typo-text-small dim" title={error ?? undefined}>#{gitHubUserId}</span>
+    {:else}
+      <a class="login typo-text-bold" href={user.htmlUrl} target="_blank" rel="noreferrer">
+        {user.login}
+      </a>
+      <span class="id typo-text-small dim">#{gitHubUserId}</span>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .user {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    min-width: 0;
+  }
+
+  .avatar {
+    width: 2rem;
+    height: 2rem;
+    border-radius: 50%;
+    flex-shrink: 0;
+    background: var(--color-foreground-level-2);
+  }
+
+  .info {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+    min-width: 0;
+  }
+
+  .login {
+    color: var(--color-foreground);
+    text-decoration: none;
+  }
+
+  a.login:hover {
+    text-decoration: underline;
+  }
+
+  .dim {
+    color: var(--color-foreground-level-5);
+    font-family: var(--typeface-mono);
+  }
+</style>


### PR DESCRIPTION
Adds a new "Bans & Restrictions" tool under `/wave/admin/bans`, gated on the `manageBans` permission. Admins can ban or restrict a user by GitHub username (resolved against the public GitHub API to a numeric ID before being sent to wave, so users can be pre-emptively banned), see the list of currently active bans/restrictions with a type filter, and lift them.

The wave list endpoint only returns numeric GitHub IDs, so each row in the list lazily resolves the ID back to a login + avatar via GitHub's public API (cached in-memory).

Depends on the existing `manageBans` permission and the `/api/admin/bans` endpoints in wave.