### PR TITLE
wave: add latest news section to explore page, polish hero card

### DIFF
--- a/src/lib/components/blog/post-card/post-card.svelte
+++ b/src/lib/components/blog/post-card/post-card.svelte
@@ -23,6 +23,7 @@
     first?: boolean;
     link?: boolean;
     shareButton?: boolean;
+    hideCategory?: boolean;
   }
 
   let {
@@ -40,6 +41,7 @@
     first = false,
     link = true,
     shareButton = false,
+    hideCategory = false,
   }: Props = $props();
 
   let formattedDate = $derived(
@@ -68,11 +70,13 @@
     <div>
       {#if first}
         <h1>{title}</h1>
+      {:else if compact}
+        <h2 class="pixelated line-clamp-2">{title}</h2>
       {:else}
         <h1 class="pixelated">{title}</h1>
       {/if}
       <p class="metadata" style:color="var(--color-foreground-level-5)">
-        {#if categories?.length}
+        {#if categories?.length && !hideCategory}
           <svelte:element
             this={link ? 'span' : 'a'}
             class="category-badge"
@@ -92,7 +96,7 @@
         {/if}
         <span>{formattedDate}</span>
       </p>
-      <p>{excerpt}</p>
+      <p class="excerpt" class:line-clamp-3={compact}>{excerpt}</p>
     </div>
     {#if shareButton}
       <div style:width="fit-content">
@@ -206,6 +210,10 @@
 
   .post.first .cover-image {
     height: auto;
+  }
+
+  .post.compact {
+    border-radius: 1rem 0 1rem 1rem;
   }
 
   .post.compact .cover-image {

--- a/src/routes/(pages)/app/(app)/components/latest-news-section.svelte
+++ b/src/routes/(pages)/app/(app)/components/latest-news-section.svelte
@@ -9,15 +9,31 @@
   interface Props {
     blogPosts: z.infer<typeof postsListingSchema>;
     title?: string;
+    compact?: boolean;
+    maxPosts?: number;
+    hideCategory?: boolean;
+    actionLabel?: string;
+    actionHref?: string;
+    actionNewTab?: boolean;
+    cardsNewTab?: boolean;
   }
 
-  let { blogPosts, title = 'Latest news' }: Props = $props();
+  let {
+    blogPosts,
+    title = 'Latest news',
+    compact = false,
+    maxPosts = 2,
+    hideCategory = false,
+    actionLabel = 'Read the blog',
+    actionHref = '/blog',
+    actionNewTab = true,
+    cardsNewTab = true,
+  }: Props = $props();
 
-  // 2 latest posts. Sort by date
   let sortedPosts = $derived(
     blogPosts
       .toSorted((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
-      .slice(0, 2),
+      .slice(0, maxPosts),
   );
 </script>
 
@@ -27,18 +43,18 @@
     label: title,
     actions: [
       {
-        label: 'Read the blog',
-        href: '/blog',
-        target: '_blank',
+        label: actionLabel,
+        href: actionHref,
+        target: actionNewTab ? '_blank' : undefined,
         icon: EyeOpenIcon,
       },
     ],
   }}
   skeleton={{ loaded: true, horizontalScroll: false }}
 >
-  <div class="posts-grid">
-    {#each sortedPosts as post}
-      <PostCard newTab {...post} />
+  <div class="posts-grid" class:compact>
+    {#each sortedPosts as post (post.slug)}
+      <PostCard newTab={cardsNewTab} {compact} {hideCategory} {...post} />
     {/each}
   </div>
 </Section>
@@ -49,6 +65,10 @@
     grid-template-columns: auto auto;
     gap: 1rem;
     padding: 4px 2px;
+  }
+
+  .posts-grid.compact {
+    grid-template-columns: repeat(auto-fill, minmax(24rem, 1fr));
   }
 
   @media (max-width: 767px) {

--- a/src/routes/(pages)/wave/(base-layout)/+layout.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/+layout.svelte
@@ -196,6 +196,14 @@
     min-width: 0;
   }
 
+  .content :global(.section-skeleton) {
+    margin: 0 -1rem;
+  }
+
+  .content :global(.section-skeleton .inner-wrapper) {
+    padding: 0 1rem;
+  }
+
   .content.sidenavExpanded {
     transform: translateX(6rem);
     filter: blur(2px);

--- a/src/routes/(pages)/wave/(base-layout)/+page.server.ts
+++ b/src/routes/(pages)/wave/(base-layout)/+page.server.ts
@@ -1,0 +1,8 @@
+import { fetchBlogPosts } from '$lib/utils/blog-posts';
+
+export const load = async () => {
+  const allPosts = await fetchBlogPosts();
+  const blogPosts = allPosts.filter((p) => p.categories.includes('wave'));
+
+  return { blogPosts };
+};

--- a/src/routes/(pages)/wave/(base-layout)/+page.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/+page.svelte
@@ -7,13 +7,14 @@
   import File from '$lib/components/icons/File.svelte';
   import Wave from '$lib/components/icons/Wave.svelte';
   import PulsatingCircle from '$lib/components/pulsating-circle/pulsating-circle.svelte';
-  import OrDivider from '$lib/components/rpgf-results-card/components/or-divider.svelte';
+  import SectionHeader from '$lib/components/section-header/section-header.svelte';
   import Card from '$lib/components/wave/card/card.svelte';
   import WaveAvatar from '$lib/components/wave/wave-program-avatar/wave-program-avatar.svelte';
   import { INBOUND_LEAD_FORM_URL } from '$lib/constants';
   import formatDate from '$lib/utils/format-date';
   import type { WaveDto } from '$lib/utils/wave/types/waveProgram';
   import FeatureCard from '../../app/(app)/components/feature-card.svelte';
+  import LatestNewsSection from '../../app/(app)/components/latest-news-section.svelte';
 
   let { data } = $props();
 
@@ -42,46 +43,65 @@
     {/snippet}
   </FeatureCard>
 
-  <OrDivider text="Wave programs" />
+  <div class="section">
+    <SectionHeader icon={Wave} label="Wave programs" />
 
-  {#each data.wavePrograms.data as waveProgram (waveProgram.id)}
-    {@const upcomingWave: WaveDto | null = data.upcomingWaves[waveProgram.id]}
-    <a href="/wave/{waveProgram.slug}" class="wave-program-item">
-      <WaveAvatar {waveProgram} size={128} />
+    <div class="wave-program-list">
+      {#each data.wavePrograms.data as waveProgram (waveProgram.id)}
+        {@const upcomingWave: WaveDto | null = data.upcomingWaves[waveProgram.id]}
+        <a href="/wave/{waveProgram.slug}" class="wave-program-item">
+          <div class="bg"></div>
+          <WaveAvatar {waveProgram} size={128} />
 
-      <div class="details">
-        {#if upcomingWave}
-          <div class="next-wave-badge">
-            {#if upcomingWave.startDate > now}
-              Next Wave starts {formatDate(upcomingWave.startDate, 'onlyDay')}
-            {:else if upcomingWave.endDate > now}
-              <PulsatingCircle />
-              Active Wave until {formatDate(upcomingWave.endDate, 'onlyDay')}
+          <div class="details">
+            {#if upcomingWave}
+              <div class="next-wave-badge">
+                {#if upcomingWave.startDate > now}
+                  Next Wave starts {formatDate(upcomingWave.startDate, 'onlyDay')}
+                {:else if upcomingWave.endDate > now}
+                  <PulsatingCircle />
+                  Active Wave until {formatDate(upcomingWave.endDate, 'onlyDay')}
+                {/if}
+              </div>
             {/if}
+            <h1>{waveProgram.name}</h1>
+            <p style:color="var(--color-foreground-level-6)">{waveProgram.description}</p>
           </div>
-        {/if}
-        <h1>{waveProgram.name}</h1>
-        <p style:color="var(--color-foreground-level-6)">{waveProgram.description}</p>
-      </div>
 
-      <ChevronRight />
-    </a>
-  {/each}
+          <ChevronRight />
+        </a>
+      {/each}
+    </div>
 
-  {#if data.wavePrograms.data.length === 0}
-    <Card>
-      <div class="empty typo-text">
-        There are no active Wave Programs at the moment. Consider subscribing to our email
-        newsletter and joining our Discord for announcements.
+    {#if data.wavePrograms.data.length === 0}
+      <Card>
+        <div class="empty typo-text">
+          There are no active Wave Programs at the moment. Consider subscribing to our email
+          newsletter and joining our Discord for announcements.
 
-        <div class="actions">
-          <Button icon={Email} href="/wave/newsletter">Subscribe to newsletter</Button>
-          <Button icon={Discord} href="https://discord.gg/drips" target="_blank"
-            >Join our Discord</Button
-          >
+          <div class="actions">
+            <Button icon={Email} href="/wave/newsletter">Subscribe to newsletter</Button>
+            <Button icon={Discord} href="https://discord.gg/drips" target="_blank"
+              >Join our Discord</Button
+            >
+          </div>
         </div>
-      </div>
-    </Card>
+      </Card>
+    {/if}
+  </div>
+
+  {#if data.blogPosts.length > 0}
+    <LatestNewsSection
+      blogPosts={data.blogPosts}
+      title="Latest News & Resources"
+      compact
+      hideCategory
+      maxPosts={8}
+      actionLabel="View all"
+      actionHref="/blog/wave"
+      actionNewTab={false}
+      cardsNewTab={false}
+    />
   {/if}
 </div>
 
@@ -89,10 +109,22 @@
   .page {
     display: flex;
     flex-direction: column;
-    gap: 2rem;
+    gap: 3rem;
     max-width: 90rem;
     margin: 0 auto;
     width: 100%;
+  }
+
+  .section {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+
+  .wave-program-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
   }
 
   .empty {
@@ -124,6 +156,27 @@
       transform 0.2s,
       box-shadow 0.2s;
     flex-wrap: wrap;
+    position: relative;
+    overflow: hidden;
+  }
+
+  .wave-program-item .bg {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 8rem;
+    background: linear-gradient(
+      to right,
+      color-mix(in srgb, var(--color-primary-level-1) 60%, transparent),
+      transparent
+    );
+    z-index: 0;
+  }
+
+  .wave-program-item > :global(*:not(.bg)) {
+    position: relative;
+    z-index: 1;
   }
 
   .details {

--- a/src/routes/(pages)/wave/(base-layout)/+page.ts
+++ b/src/routes/(pages)/wave/(base-layout)/+page.ts
@@ -1,7 +1,7 @@
 import type { WaveDto } from '$lib/utils/wave/types/waveProgram.js';
 import { getWavePrograms, getWaves } from '$lib/utils/wave/wavePrograms';
 
-export const load = async ({ fetch }) => {
+export const load = async ({ fetch, data }) => {
   // todo(wave): pagination
   const wavePrograms = await getWavePrograms(fetch, { limit: 100 });
 
@@ -21,6 +21,7 @@ export const load = async ({ fetch }) => {
   );
 
   return {
+    ...data,
     wavePrograms,
     upcomingWaves,
   };

--- a/src/routes/(pages)/wave/(base-layout)/[waveProgramSlug]/+page.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/[waveProgramSlug]/+page.svelte
@@ -200,9 +200,13 @@
     top: 0;
     left: 0;
     width: 100%;
-    height: 5rem;
+    height: 8rem;
     border-radius: 1rem 0 0 0;
-    background-color: var(--color-primary-level-1);
+    background: linear-gradient(
+      to bottom,
+      color-mix(in srgb, var(--color-primary-level-1) 60%, transparent),
+      transparent
+    );
     z-index: 0;
   }
 


### PR DESCRIPTION
Adds a wave-only "Latest News & Resources" section to the wave explore page, scoped to posts tagged `wave`. Reuses `LatestNewsSection` with a few new props: `compact` (smaller cards in an auto-fill grid), `hideCategory` (since everything here is wave already), `actionLabel`/`actionHref`/`actionNewTab`, `cardsNewTab`, and `maxPosts`. Defaults preserve the existing main app explore behavior.

Also tidied up the rest of the page while in there:

- Wave program cards now have a soft lavender gradient fading in from the left edge — same idea as the strip on the wave detail hero, just rotated.
- Detail hero strip now uses the same gradient fade instead of a hard cut.
- Replaced the "Wave programs" `OrDivider` with a `SectionHeader` for consistency with the news section below.
- Restructured the explore page so each section (header + content) has tighter internal spacing than between-section spacing.
- Compact post cards use `h2` titles with `line-clamp-2`, excerpts with `line-clamp-3`, and a smaller `1rem 0 1rem 1rem` border radius matching the program cards.

Last bit: `Section`'s skeleton uses `-2.5rem` horizontal margins to bleed into the parent's padding (which the main app has). The wave layout has way less, so any `Section` overflowed horizontally. Scoped an override in the wave layout to use `-1rem` margins matching the available padding — fixes overflow everywhere `Section` is used inside wave, not just on the explore page.

Cleaned up a stale `{#each}` lint error that was pre-existing in `latest-news-section.svelte` while in there too.