### PR TITLE
wave: report T&C and privacy policy versions on login

### DIFF
--- a/src/lib/components/wave/log-in-button/log-in-button.svelte
+++ b/src/lib/components/wave/log-in-button/log-in-button.svelte
@@ -3,6 +3,7 @@
   import Button from '$lib/components/button/button.svelte';
   import Github from '$lib/components/icons/Github.svelte';
   import getOptionalEnvVar from '$lib/utils/get-optional-env-var/public';
+  import { PRIVACY_POLICY_VERSION, WAVE_TERMS_VERSION } from '$lib/utils/wave/legal-versions';
 
   let {
     backTo = page.url.pathname + page.url.search,
@@ -30,13 +31,32 @@
    * campaigns / communities etc.
    */
   let attributionRefParam = page.url.searchParams.get('ref');
+
+  /**
+   * Build the GitHub OAuth login URL with all the query params the wave
+   * backend round-trips through the OAuth `state` cookie. `termsVersion` and
+   * `privacyVersion` are required by the backend — they pin the consent
+   * record we write at login time to the exact document versions the user
+   * saw on screen.
+   */
+  function buildLoginHref(): string {
+    const parts: string[] = [
+      `termsVersion=${encodeURIComponent(WAVE_TERMS_VERSION)}`,
+      `privacyVersion=${encodeURIComponent(PRIVACY_POLICY_VERSION)}`,
+    ];
+
+    if (backTo) {
+      parts.push(`backTo=${encodeURIComponent(backTo)}`, `skipWelcome=${skipWelcome}`);
+    }
+
+    if (attributionRefParam) {
+      parts.push(`ref=${encodeURIComponent(attributionRefParam)}`);
+    }
+
+    return `${WAVE_API_URL}/api/auth/oauth/github/login?${parts.join('&')}`;
+  }
 </script>
 
-<Button
-  icon={Github}
-  {disabled}
-  variant={primary ? 'primary' : undefined}
-  href="{WAVE_API_URL}/api/auth/oauth/github/login{backTo
-    ? `?backTo=${encodeURIComponent(backTo)}&skipWelcome=${skipWelcome}${attributionRefParam ? `&ref=${encodeURIComponent(attributionRefParam)}` : ''}`
-    : ''}">{wordy ? 'Log in with GitHub' : 'Log in'}</Button
+<Button icon={Github} {disabled} variant={primary ? 'primary' : undefined} href={buildLoginHref()}
+  >{wordy ? 'Log in with GitHub' : 'Log in'}</Button
 >

--- a/src/lib/utils/wave/legal-versions.ts
+++ b/src/lib/utils/wave/legal-versions.ts
@@ -1,0 +1,19 @@
+/**
+ * Versions of the legal documents the user implicitly consents to when
+ * completing the Wave login flow. These are reported to the wave backend on
+ * every login so the consent record can be tied to the exact document version
+ * the user saw on screen.
+ *
+ * Bump these values whenever the Terms & Rules or Privacy Policy is materially
+ * updated. The backend treats `(userId, termsVersion, privacyVersion)` as a
+ * unique tuple — bumping a version produces a fresh consent row on the next
+ * login while preserving the timestamp of any earlier consent.
+ *
+ * Date-stamp format (YYYY-MM-DD) matches the date the version went live.
+ */
+
+/** Wave Terms & Rules: https://docs.drips.network/wave/terms-and-rules */
+export const WAVE_TERMS_VERSION = '2026-04-27';
+
+/** Drips Privacy Policy: /legal/privacy */
+export const PRIVACY_POLICY_VERSION = '2026-04-27';

--- a/src/lib/utils/wave/legal-versions.ts
+++ b/src/lib/utils/wave/legal-versions.ts
@@ -1,13 +1,21 @@
 /**
  * Versions of the legal documents the user implicitly consents to when
  * completing the Wave login flow. These are reported to the wave backend on
- * every login so the consent record can be tied to the exact document version
+ * every login so the consent record is tied to exactly the document version
  * the user saw on screen.
  *
  * Bump these values whenever the Terms & Rules or Privacy Policy is materially
  * updated. The backend treats `(userId, termsVersion, privacyVersion)` as a
  * unique tuple — bumping a version produces a fresh consent row on the next
  * login while preserving the timestamp of any earlier consent.
+ *
+ * To keep "what was displayed" and "what was recorded" in lockstep, the
+ * privacy policy page imports `PRIVACY_POLICY_VERSION` for its effective-
+ * date line — so updating the doc text and bumping the constant happen in
+ * the same diff. The Wave Terms & Rules document lives off-repo at
+ * docs.drips.network, so `WAVE_TERMS_VERSION` is maintained by hand: bump
+ * it (and any displayed copy in the login flow) whenever the external doc
+ * is materially updated.
  *
  * Date-stamp format (YYYY-MM-DD) matches the date the version went live.
  */
@@ -16,4 +24,4 @@
 export const WAVE_TERMS_VERSION = '2026-04-27';
 
 /** Drips Privacy Policy: /legal/privacy */
-export const PRIVACY_POLICY_VERSION = '2026-04-27';
+export const PRIVACY_POLICY_VERSION = '2026-04-29';

--- a/src/routes/(pages)/(lp)/legal/privacy/+page.svelte
+++ b/src/routes/(pages)/(lp)/legal/privacy/+page.svelte
@@ -1,5 +1,15 @@
 <script>
   import HeadMeta from '$lib/components/head-meta/head-meta.svelte';
+  import { PRIVACY_POLICY_VERSION } from '$lib/utils/wave/legal-versions';
+
+  // Format the YYYY-MM-DD constant as a human-readable date in the
+  // effective-date line below. Co-locating the display string with the
+  // constant guarantees that what the user sees and what we record on
+  // login consent come from the same source.
+  const effectiveDate = new Date(`${PRIVACY_POLICY_VERSION}T00:00:00Z`).toLocaleDateString(
+    'en-US',
+    { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' },
+  );
 </script>
 
 <HeadMeta title="Data & Privacy Policy" />
@@ -931,7 +941,7 @@
 
   <section>
     <h2>Validity and amendment of this privacy policy</h2>
-    <p>This privacy policy is currently valid and effective as of April 29, 2026.</p>
+    <p>This privacy policy is currently valid and effective as of {effectiveDate}.</p>
     <p>
       Due to the further development of the Drips Services or due to changes in legal or regulatory
       requirements, it may become necessary to amend this privacy policy. In this case, we will


### PR DESCRIPTION
## Summary

- Adds `src/lib/utils/wave/legal-versions.ts`: a single source of truth for the version strings of the Wave Terms & Rules and Privacy Policy. The login button appends both as query params on the wave OAuth login URL so the backend can persist a click-wrap consent record (drips-network/wave#537).
- Refactors the URL construction in `log-in-button.svelte` into a small `buildLoginHref` helper that always emits `termsVersion` + `privacyVersion`, plus the existing `backTo` / `skipWelcome` / `ref` when applicable.
- Drives the "effective as of …" line on `/legal/privacy` from the same `PRIVACY_POLICY_VERSION` constant. Updating the policy text and bumping the recorded version are now one diff — display and transport can't drift.

## Why FE-reported (not server-side) versions

The wave backend stores whatever this PR sends. We record the **rendered** version because that is the value the user actually saw on screen, which is what click-wrap defensibility hinges on. A server-side resolution path would let the BE config drift ahead of the FE during partial deploys and record values the user never saw — the opposite of what the audit record is for.

The state isn't HMAC-signed. A determined client could submit a wrong version, but tampering only deflates the user's *own* recorded version, which is self-defeating: re-prompt enforcement is forward-looking off the live constant on the next sensitive action. This matches industry click-wrap norms (GitHub, Stripe, Apple).

## Coordination with backend

Pairs with drips-network/wave#537. The wave backend now **requires** `termsVersion` and `privacyVersion` query params on `GET /api/auth/oauth/github/login` and rejects missing values with a 400 *before* the GitHub redirect. Deploy this PR **before** the wave PR — otherwise every login attempt 400s until the FE catches up.

## Test plan

- [ ] `npm run lint` clean on the changed files
- [ ] `npm run check` shows no new errors/warnings on changed files
- [ ] Manual: load `/wave/login`, click "Log in with GitHub", inspect the URL — confirm `termsVersion=2026-04-27&privacyVersion=2026-04-29` is present
- [ ] Manual: load `/legal/privacy`, scroll to bottom — confirm the effective date reads "April 29, 2026" (rendered from the constant)
- [ ] Manual (post-merge with wave): complete login end-to-end, confirm a `tc_consents` row is written with both versions
- [ ] Manual: log out, bump `PRIVACY_POLICY_VERSION` locally, log in again — confirm a new `tc_consents` row appears with the bumped version while the old one's `consented_at` is preserved