### PR TITLE
wave: update explore page highlight copy

### DIFF
--- a/src/routes/(pages)/app/(app)/components/default-explore-page.svelte
+++ b/src/routes/(pages)/app/(app)/components/default-explore-page.svelte
@@ -27,7 +27,6 @@
   import FeatureCard from './feature-card.svelte';
   import Button from '$lib/components/button/button.svelte';
   import ArrowCounterClockwiseHeart from '$lib/components/icons/ArrowCounterClockwiseHeart.svelte';
-  import PulsatingCircle from '$lib/components/pulsating-circle/pulsating-circle.svelte';
   import ArrowBoxUpRight from '$lib/components/icons/ArrowBoxUpRight.svelte';
 
   interface Props {
@@ -85,16 +84,13 @@
 
 <div class="explore">
   <FeatureCard imageUrl="/assets/wave/wave-hp.png">
-    <div class="highlight-badge typo-header-5">
-      <PulsatingCircle pulseColor="rgba(255,255,255,0.5)" />
-      CONTRIBUTOR REWARDS
-    </div>
+    <div class="highlight-badge typo-header-5">CONTRIBUTOR REWARDS</div>
 
     <div>
       <h2 style:margin-bottom="0.25rem">Drips Wave</h2>
       <p>
-        Open-source ecosystems use Drips Wave to run recurring contribution sprints. During these
-        Waves, contributors receive Points, for which they earn rewards.
+        Open-source ecosystems use Drips Wave to run recurring one-week contribution sprints. During
+        these Waves, contributors receive Points, for which they earn rewards.
       </p>
     </div>
 
@@ -174,17 +170,11 @@
   {/if}
 
   <FeatureCard imageUrl="/assets/blog-images/rpgf/rpgf-filecoin-launch.png">
-    <div class="highlight-badge typo-header-5">
-      <PulsatingCircle pulseColor="rgba(255,255,255,0.5)" />
-      RETROPGF ROUND
-    </div>
+    <div class="highlight-badge typo-header-5">RETROPGF ROUND</div>
 
     <div>
       <h2 style:margin-bottom="0.25rem">Filecoin RetroPGF-3 on Drips</h2>
-      <p>
-        Filecoin's largest RetroPGF round to date used Drips' end-to-end RetroPGF platform for
-        applications, voting, and distribution.
-      </p>
+      <p>Filecoin's largest RetroPGF round to date used Drips' end-to-end RetroPGF platform.</p>
     </div>
 
     {#snippet actions()}

--- a/src/routes/(pages)/app/(app)/components/default-explore-page.svelte
+++ b/src/routes/(pages)/app/(app)/components/default-explore-page.svelte
@@ -87,14 +87,14 @@
   <FeatureCard imageUrl="/assets/wave/wave-hp.png">
     <div class="highlight-badge typo-header-5">
       <PulsatingCircle pulseColor="rgba(255,255,255,0.5)" />
-      NEW
+      CONTRIBUTOR REWARDS
     </div>
 
     <div>
-      <h2 style:margin-bottom="0.25rem">Introducing Drips Wave</h2>
+      <h2 style:margin-bottom="0.25rem">Drips Wave</h2>
       <p>
-        With Drips Wave, open-source ecosystems run recurring one-week contribution sprints. During
-        these Waves, contributors receive Points, for which they earn rewards.
+        Open-source ecosystems use Drips Wave to run recurring contribution sprints. During these
+        Waves, contributors receive Points, for which they earn rewards.
       </p>
     </div>
 
@@ -176,14 +176,14 @@
   <FeatureCard imageUrl="/assets/blog-images/rpgf/rpgf-filecoin-launch.png">
     <div class="highlight-badge typo-header-5">
       <PulsatingCircle pulseColor="rgba(255,255,255,0.5)" />
-      LIVE NOW
+      RETROPGF ROUND
     </div>
 
     <div>
       <h2 style:margin-bottom="0.25rem">Filecoin RetroPGF-3 on Drips</h2>
       <p>
-        Filecoin's largest RetroPGF round to date is now live on Drips' new end-to-end RetroPGF
-        platform.
+        Filecoin's largest RetroPGF round to date used Drips' end-to-end RetroPGF platform for
+        applications, voting, and distribution.
       </p>
     </div>
 
@@ -192,7 +192,7 @@
         variant="primary"
         icon={ArrowBoxUpRight}
         href="https://filecoin.drips.network/app/rpgf/rounds/fil-retropgf-3"
-        target="_blank">Check it out</Button
+        target="_blank">View the round</Button
       >
       <Button
         icon={ArrowCounterClockwiseHeart}


### PR DESCRIPTION
Closes #1881.

## Summary
Updates the main app explore page highlight cards so they no longer describe Drips Wave as new or Filecoin RetroPGF-3 as currently live.

## Changes
- Replaces the Drips Wave badge and heading with ongoing-program wording.
- Updates the Filecoin RetroPGF-3 badge, description, and CTA to describe the round retrospectively.
- Keeps both cards pointing to their existing destination URLs.

## Verification
- `npx prettier --check src/routes/(pages)/app/(app)/components/default-explore-page.svelte`
- `git diff --check`