### PR TITLE
wave: orgs section on maintainer Orgs & Repos page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16301,17 +16301,6 @@
         }
       }
     },
-    "node_modules/@web3-onboard/common/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@web3-onboard/core": {
       "version": "2.24.1",
       "resolved": "https://registry.npmjs.org/@web3-onboard/core/-/core-2.24.1.tgz",
@@ -16474,17 +16463,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@web3-onboard/core/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@web3-onboard/injected-wallets": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16301,6 +16301,17 @@
         }
       }
     },
+    "node_modules/@web3-onboard/common/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@web3-onboard/core": {
       "version": "2.24.1",
       "resolved": "https://registry.npmjs.org/@web3-onboard/core/-/core-2.24.1.tgz",
@@ -16463,6 +16474,17 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@web3-onboard/core/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@web3-onboard/injected-wallets": {

--- a/src/lib/components/tooltip/tooltip.svelte
+++ b/src/lib/components/tooltip/tooltip.svelte
@@ -33,7 +33,7 @@
     top: 0,
   });
 
-  const TOOLTIP_MARGIN = 0;
+  const TOOLTIP_MARGIN = 8;
 
   async function show() {
     tooltipPos = {

--- a/src/lib/components/tooltip/tooltip.svelte
+++ b/src/lib/components/tooltip/tooltip.svelte
@@ -62,7 +62,11 @@
     if (hovering) {
       hoverTimeout = setTimeout(show, 400);
     } else {
-      hide();
+      // Grace period before hiding lets the cursor cross the gap from the
+      // trigger to the portaled tooltip body (which is no longer a DOM
+      // descendant of the trigger, so its hover doesn't keep us open
+      // automatically — see the portal action below).
+      hoverTimeout = setTimeout(hide, 150);
     }
   }
 
@@ -167,6 +171,10 @@
       style:left={`${tooltipPos.left}px`}
       style:right={`${tooltipPos.right}px`}
       style:top={`${tooltipPos.top}px`}
+      onpointerover={(e) => {
+        if (!disabled && e.pointerType !== 'touch') handleHover(true);
+      }}
+      onpointerleave={() => !disabled && handleHover(false)}
       onclick={stopPropagation(bubble('click'))}
       onkeydown={stopPropagation(bubble('keydown'))}
     >

--- a/src/lib/components/tooltip/tooltip.svelte
+++ b/src/lib/components/tooltip/tooltip.svelte
@@ -126,6 +126,24 @@
       window.removeEventListener('resize', updatePosIfExpanded);
     };
   });
+
+  // Portal the expanded tooltip to <body> so its z-index isn't trapped inside
+  // a stacking context created by an ancestor (e.g. `view-transition-name`).
+  function portal(node: HTMLElement) {
+    const original = node.parentNode;
+    document.body.appendChild(node);
+    return {
+      destroy() {
+        if (original && node.parentNode === document.body) {
+          try {
+            original.appendChild(node);
+          } catch {
+            node.remove();
+          }
+        }
+      },
+    };
+  }
 </script>
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
@@ -142,6 +160,7 @@
   {#if expanded}
     <!-- svelte-ignore a11y_no_static_element_interactions -->
     <div
+      use:portal
       transition:fade={{ duration: 200 }}
       bind:this={contentElem}
       class="expanded-tooltip"
@@ -186,7 +205,7 @@
   }
 
   .tooltip-content {
-    z-index: 10;
+    z-index: 1000;
     box-shadow: var(--elevation-medium);
     background-color: var(--color-background);
     border-radius: 1rem 0 1rem 1rem;

--- a/src/lib/components/tooltip/tooltip.svelte
+++ b/src/lib/components/tooltip/tooltip.svelte
@@ -60,6 +60,7 @@
     clearTimeout(hoverTimeout);
 
     if (hovering) {
+      if (expanded) return;
       hoverTimeout = setTimeout(show, 400);
     } else {
       // Grace period before hiding lets the cursor cross the gap from the

--- a/src/lib/components/wave/issues-page/components/update-complexity-modal.svelte
+++ b/src/lib/components/wave/issues-page/components/update-complexity-modal.svelte
@@ -45,8 +45,18 @@
     return pointsDelta > waveProgramRepo.pointsRemaining;
   });
 
+  let orgBudgetExceeded = $derived.by(() => {
+    if (!waveProgramRepo) return false;
+    if (pointsDelta <= 0) return false;
+    const remaining = waveProgramRepo.orgPointsRemaining;
+    if (remaining === null || remaining === undefined) return false;
+    return pointsDelta > remaining;
+  });
+
   let canSubmit = $derived(
-    (initialComplexity ? activeComplexity !== initialComplexity : true) && !budgetExceeded,
+    (initialComplexity ? activeComplexity !== initialComplexity : true) &&
+      !budgetExceeded &&
+      !orgBudgetExceeded,
   );
 
   async function handleSubmit() {
@@ -147,6 +157,30 @@
         of {waveProgramRepo.pointsBudget} points used, with {waveProgramRepo.pointsRemaining} remaining
         — but this change would require
         {pointsDelta} additional points. Review the remaining budget for your repos on the
+        <a
+          href="/wave/maintainers/repos?status=approved"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="typo-link">Orgs & Repos</a
+        >
+        screen.
+        <a
+          href="https://docs.drips.network/wave/maintainers/points-budgets"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="typo-link">Learn more</a
+        >
+      </AnnotationBox>
+    {/if}
+
+    {#if orgBudgetExceeded && waveProgramRepo}
+      <AnnotationBox type="error">
+        Increasing complexity to this level would exceed
+        <strong>{waveProgramRepo.org.gitHubOrgLogin}</strong>'s points budget for this Wave (shared
+        across all of the org's approved repos). Currently {waveProgramRepo.orgPointsUsed} of
+        {waveProgramRepo.orgPointsBudget} points used, with {waveProgramRepo.orgPointsRemaining}
+        remaining — but this change would require {pointsDelta} additional points. Review the remaining
+        budget for your orgs on the
         <a
           href="/wave/maintainers/repos?status=approved"
           target="_blank"

--- a/src/lib/flows/wave/add-issues-to-wave-program/configure-details.svelte
+++ b/src/lib/flows/wave/add-issues-to-wave-program/configure-details.svelte
@@ -66,6 +66,15 @@
     canFit: number; // how many issues can fit within remaining budget
   }
 
+  interface OrgBudgetInfo {
+    orgId: string;
+    orgLogin: string;
+    issueCount: number;
+    pointsNeeded: number;
+    pointsRemaining: number | null;
+    pointsBudget: number | null;
+  }
+
   const firstWaveId = wavePrograms.find((w) =>
     waveProgramRepos.some((wpr) => wpr.waveProgramId === w.id),
   )?.id;
@@ -112,6 +121,61 @@
     return infos;
   });
 
+  // Group eligible issues by org (only counting issues from repos approved for the
+  // selected wave), so we can compare against each org's shared per-wave budget.
+  let orgBudgetInfos = $derived.by((): OrgBudgetInfo[] => {
+    const selectedWaveId = selectedWaveIds[0];
+    if (!selectedWaveId) return [];
+
+    const repoInfoByRepoId = new SvelteMap<
+      string,
+      {
+        orgId: string;
+        orgLogin: string;
+        orgRemaining: number | null;
+        orgBudget: number | null;
+      }
+    >();
+    for (const wpr of waveProgramRepos) {
+      if (wpr.waveProgramId !== selectedWaveId || wpr.status !== 'approved') continue;
+      repoInfoByRepoId.set(wpr.repo.id, {
+        orgId: wpr.org.id,
+        orgLogin: wpr.org.gitHubOrgLogin,
+        orgRemaining: wpr.orgPointsRemaining ?? null,
+        orgBudget: wpr.orgPointsBudget ?? null,
+      });
+    }
+
+    const byOrg = new SvelteMap<
+      string,
+      { orgLogin: string; count: number; remaining: number | null; budget: number | null }
+    >();
+    for (const issue of eligibleIssues) {
+      const info = repoInfoByRepoId.get(issue.repo.id);
+      if (!info) continue;
+      const existing = byOrg.get(info.orgId);
+      if (existing) {
+        existing.count += 1;
+      } else {
+        byOrg.set(info.orgId, {
+          orgLogin: info.orgLogin,
+          count: 1,
+          remaining: info.orgRemaining,
+          budget: info.orgBudget,
+        });
+      }
+    }
+
+    return [...byOrg.entries()].map(([orgId, v]) => ({
+      orgId,
+      orgLogin: v.orgLogin,
+      issueCount: v.count,
+      pointsNeeded: v.count * pointsPerIssue,
+      pointsRemaining: v.remaining,
+      pointsBudget: v.budget,
+    }));
+  });
+
   // Repos that are not approved for the selected wave program
   let unapprovedRepoIssues = $derived.by(() => {
     const selectedWaveId = selectedWaveIds[0];
@@ -126,38 +190,50 @@
     return eligibleIssues.filter((issue) => !approvedRepoIds.has(issue.repo.id));
   });
 
-  // Issues that will actually be submitted, respecting per-repo budget limits
-  // and excluding issues from repos not approved for the selected wave
+  // Issues that will actually be submitted, respecting both per-repo and per-org budget
+  // limits, and excluding issues from repos not approved for the selected wave
   let submittableIssues = $derived.by(() => {
     const selectedWaveId = selectedWaveIds[0];
     if (!selectedWaveId) return [];
 
-    const approvedRepoIds = new SvelteSet(
-      waveProgramRepos
-        .filter((wpr) => wpr.waveProgramId === selectedWaveId && wpr.status === 'approved')
-        .map((wpr) => wpr.repo.id),
-    );
+    const wprByRepoId = new SvelteMap<string, WaveProgramRepoWithDetailsDto>();
+    for (const wpr of waveProgramRepos) {
+      if (wpr.waveProgramId !== selectedWaveId || wpr.status !== 'approved') continue;
+      wprByRepoId.set(wpr.repo.id, wpr);
+    }
 
     const canFitByRepo = new SvelteMap<string, number>();
-    for (const info of repoBudgetInfos) {
-      canFitByRepo.set(info.repoId, info.canFit);
+    for (const info of repoBudgetInfos) canFitByRepo.set(info.repoId, info.canFit);
+
+    // Running per-org remaining points across the loop; null means unbounded.
+    const orgRemainingByOrgId = new SvelteMap<string, number | null>();
+    for (const wpr of wprByRepoId.values()) {
+      if (!orgRemainingByOrgId.has(wpr.org.id)) {
+        orgRemainingByOrgId.set(wpr.org.id, wpr.orgPointsRemaining ?? null);
+      }
     }
 
     const result: IssueDetailsDto[] = [];
     const countByRepo = new SvelteMap<string, number>();
 
     for (const issue of eligibleIssues) {
+      const wpr = wprByRepoId.get(issue.repo.id);
+      if (!wpr) continue;
+
       const repoId = issue.repo.id;
-
-      // Skip issues from repos not approved for the selected wave
-      if (!approvedRepoIds.has(repoId)) continue;
-
       const maxForRepo = canFitByRepo.get(repoId) ?? Infinity;
       const usedSoFar = countByRepo.get(repoId) ?? 0;
+      if (usedSoFar >= maxForRepo) continue;
 
-      if (usedSoFar < maxForRepo) {
-        result.push(issue);
-        countByRepo.set(repoId, usedSoFar + 1);
+      const orgRemaining = orgRemainingByOrgId.get(wpr.org.id);
+      if (orgRemaining !== null && orgRemaining !== undefined && orgRemaining < pointsPerIssue) {
+        continue;
+      }
+
+      result.push(issue);
+      countByRepo.set(repoId, usedSoFar + 1);
+      if (orgRemaining !== null && orgRemaining !== undefined) {
+        orgRemainingByOrgId.set(wpr.org.id, orgRemaining - pointsPerIssue);
       }
     }
 
@@ -166,6 +242,10 @@
 
   let budgetExceededRepos = $derived(
     repoBudgetInfos.filter((r) => r.pointsRemaining !== null && r.pointsNeeded > r.pointsRemaining),
+  );
+
+  let budgetExceededOrgs = $derived(
+    orgBudgetInfos.filter((o) => o.pointsRemaining !== null && o.pointsNeeded > o.pointsRemaining),
   );
 
   let allBlocked = $derived(submittableIssues.length === 0 && eligibleIssues.length > 0);
@@ -292,9 +372,46 @@
 
   {#if allBlocked}
     <AnnotationBox type="error">
-      {#if repoBudgetInfos.length === 1}
+      {#if budgetExceededOrgs.length > 0 && budgetExceededRepos.length === 0}
+        {#if budgetExceededOrgs.length === 1}
+          {@const org = budgetExceededOrgs[0]}
+          <strong>{org.orgLogin}</strong> has no remaining points budget for this Wave ({org.pointsRemaining}
+          of {org.pointsBudget} points remaining, shared across all the org's approved repos). You cannot
+          add more issues until the current Wave ends. Review the remaining budget for your orgs on the
+          <a
+            href="/wave/maintainers/repos?status=approved"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="typo-link">Orgs & Repos</a
+          >
+          screen.
+          <a
+            href="https://docs.drips.network/wave/maintainers/points-budgets"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="typo-link">Learn more</a
+          >
+        {:else}
+          None of the selected orgs have enough remaining points budget to add issues at this
+          complexity. Wait until the current Wave ends. Review the remaining budget for your orgs on
+          the
+          <a
+            href="/wave/maintainers/repos?status=approved"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="typo-link">Orgs & Repos</a
+          >
+          screen.
+          <a
+            href="https://docs.drips.network/wave/maintainers/points-budgets"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="typo-link">Learn more</a
+          >
+        {/if}
+      {:else if repoBudgetInfos.length === 1}
         {@const repo = repoBudgetInfos[0]}
-        <strong>{repo.repoName}</strong> has no remaining points budget for this wave ({repo.pointsRemaining}
+        <strong>{repo.repoName}</strong> has no remaining points budget for this Wave ({repo.pointsRemaining}
         of {repo.pointsBudget} points remaining). You cannot add more issues until the current Wave ends.
         Review the remaining budget for your repos on the
         <a
@@ -328,7 +445,7 @@
         >
       {/if}
     </AnnotationBox>
-  {:else if budgetExceededRepos.length > 0}
+  {:else if budgetExceededRepos.length > 0 || budgetExceededOrgs.length > 0}
     {@const skippedCount = eligibleIssues.length - submittableIssues.length}
     <AnnotationBox type="warning">
       {#each budgetExceededRepos as repo (repo.repoName)}
@@ -341,8 +458,16 @@
             at this complexity.{/if}
         </div>
       {/each}
+      {#each budgetExceededOrgs as org (org.orgId)}
+        <div class="budget-warning-row">
+          <strong>{org.orgLogin}</strong> (org): {org.issueCount} issue{org.issueCount > 1
+            ? 's'
+            : ''} selected ({org.pointsNeeded} points) but only {org.pointsRemaining} of {org.pointsBudget}
+          points remaining across the org's approved repos. Some issues will be skipped at this complexity.
+        </div>
+      {/each}
       {skippedCount} issue{skippedCount > 1 ? 's' : ''} will be skipped. Review the remaining budget
-      for your repos on the
+      for your repos and orgs on the
       <a
         href="/wave/maintainers/repos?status=approved"
         target="_blank"

--- a/src/lib/utils/wave/bans.ts
+++ b/src/lib/utils/wave/bans.ts
@@ -50,7 +50,12 @@ export async function listBans(
 
 export async function banGitHubUser(
   f = fetch,
-  data: { gitHubUserId: number; type: RestrictionType; reason?: string },
+  data: {
+    gitHubUserId: number;
+    type: RestrictionType;
+    reason?: string;
+    skipNotification?: boolean;
+  },
 ) {
   const res = await authenticatedCall(f, '/api/admin/bans', {
     method: 'POST',

--- a/src/lib/utils/wave/types/waveProgram.ts
+++ b/src/lib/utils/wave/types/waveProgram.ts
@@ -47,6 +47,7 @@ export const waveProgramDtoSchema = z.object({
   waveDurationDays: z.number().int(),
   presetBudgetUSD: z.string(),
   repoPointsBudget: z.number().int().nullable(),
+  orgPointsBudget: z.number().int().nullable(),
   avatarUrl: z.url().nullable(),
   slug: z.string(),
   longDescription: z.string().nullable(),
@@ -136,6 +137,10 @@ export const waveProgramRepoWithDetailsDtoSchema = z.object({
   pointsUsed: z.number().int(),
   pointsBudget: z.number().int().nullable(),
   pointsRemaining: z.number().int().nullable(),
+  pointsBudgetOverride: z.number().int().nullable().optional(),
+  orgPointsUsed: z.number().int().optional(),
+  orgPointsBudget: z.number().int().nullable().optional(),
+  orgPointsRemaining: z.number().int().nullable().optional(),
   pointsMultiplier: z.number().int().optional(),
   repo: z.object({
     stargazersCount: z.number().int().nullable().optional(),

--- a/src/routes/(pages)/wave/(base-layout)/admin/bans/components/create-ban-modal.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/admin/bans/components/create-ban-modal.svelte
@@ -4,6 +4,7 @@
   import TextArea from '$lib/components/text-area/text-area.svelte';
   import Dropdown from '$lib/components/dropdown/dropdown.svelte';
   import FormField from '$lib/components/form-field/form-field.svelte';
+  import Checkbox from '$lib/components/checkbox/checkbox.svelte';
   import StandaloneFlowStepLayout from '$lib/components/standalone-flow-step-layout/standalone-flow-step-layout.svelte';
   import AnnotationBox from '$lib/components/annotation-box/annotation-box.svelte';
   import modal from '$lib/stores/modal';
@@ -27,6 +28,7 @@
   let username = $state('');
   let type = $state<string>('ban');
   let reason = $state('');
+  let skipNotification = $state(false);
 
   let resolvedUser = $state<GitHubUser | null | undefined>(undefined);
   let lookupError = $state<string | null>(null);
@@ -91,6 +93,7 @@
         gitHubUserId: resolvedUser.id,
         type: type as RestrictionType,
         reason: reason.trim() ? reason.trim() : undefined,
+        skipNotification,
       });
       onCreated();
       modal.hide();
@@ -150,6 +153,13 @@
 
       <FormField title="Reason" description="Optional. Up to 500 characters.">
         <TextArea bind:value={reason} placeholder="Why is this user being banned or restricted?" />
+      </FormField>
+
+      <FormField
+        title="Notification"
+        description="Use for non-punitive restrictions, e.g. locking down an old account during a support-led account migration."
+      >
+        <Checkbox bind:checked={skipNotification} label="Don't notify the user via email" />
       </FormField>
     </div>
 

--- a/src/routes/(pages)/wave/(base-layout)/maintainers/repos/+page.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/maintainers/repos/+page.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
   import Breadcrumbs from '$lib/components/breadcrumbs/breadcrumbs.svelte';
+  import Button from '$lib/components/button/button.svelte';
   import HeadMeta from '$lib/components/head-meta/head-meta.svelte';
   import Ledger from '$lib/components/icons/Ledger.svelte';
+  import Orgs from '$lib/components/icons/Orgs.svelte';
   import Plus from '$lib/components/icons/Plus.svelte';
   import Section from '$lib/components/section/section.svelte';
   import RepoBadge from '$lib/components/wave/repo-badge/repo-badge.svelte';
+  import OrgPreviewCard from '$lib/components/wave/org-preview-card/org-preview-card.svelte';
   import WaveBadge from '$lib/components/wave/wave-program-badge/wave-program-badge.svelte';
   import MultiSelectFilter from '$lib/components/wave/repos-filter-bar/multi-select-filter.svelte';
   import Tooltip from '$lib/components/tooltip/tooltip.svelte';
@@ -15,7 +18,75 @@
 
   let { data } = $props();
 
-  let { wavePrograms, waveProgramRepos, statusFilter } = $derived(data);
+  let { wavePrograms, waveProgramRepos, approvedWaveProgramRepos, statusFilter } = $derived(data);
+
+  type OrgEntry = {
+    org: WaveProgramRepoWithDetailsDto['org'];
+    waveProgramId: string;
+    orgPointsBudget: number | null;
+    orgPointsUsed: number;
+    orgPointsRemaining: number | null;
+  };
+
+  // One entry per (waveProgramId, orgId) from the user's approved repos.
+  // Each approved repo carries the org's per-wave-program budget, so picking one
+  // repo per (waveProgramId, orgId) is enough to drive the gauge.
+  let orgEntries: OrgEntry[] = $derived.by(() => {
+    const seen: Record<string, true> = {};
+    const entries: OrgEntry[] = [];
+    for (const r of approvedWaveProgramRepos.data) {
+      const key = `${r.waveProgramId}:${r.org.id}`;
+      if (seen[key]) continue;
+      seen[key] = true;
+      entries.push({
+        org: r.org,
+        waveProgramId: r.waveProgramId,
+        orgPointsBudget: r.orgPointsBudget ?? null,
+        orgPointsUsed: r.orgPointsUsed ?? 0,
+        orgPointsRemaining: r.orgPointsRemaining ?? null,
+      });
+    }
+    return entries;
+  });
+
+  // Distinct wave programs the user has any approved repo in. Drives the
+  // wave-program dropdown in the Orgs section.
+  let orgsWavePrograms = $derived(
+    wavePrograms.data.filter((wp) => orgEntries.some((e) => e.waveProgramId === wp.id)),
+  );
+
+  let selectedOrgsWaveProgramId = $state<string | null>(null);
+
+  // Default the selection to the first available wave program. Reset if the
+  // current selection is no longer in the list.
+  $effect(() => {
+    if (orgsWavePrograms.length === 0) {
+      selectedOrgsWaveProgramId = null;
+      return;
+    }
+    if (
+      selectedOrgsWaveProgramId === null ||
+      !orgsWavePrograms.some((wp) => wp.id === selectedOrgsWaveProgramId)
+    ) {
+      selectedOrgsWaveProgramId = orgsWavePrograms[0].id;
+    }
+  });
+
+  let orgsWaveProgramOptions = $derived(
+    Promise.resolve(orgsWavePrograms.map((wp) => ({ value: wp.id, label: wp.name }))),
+  );
+
+  let orgsForSelectedWave = $derived(
+    selectedOrgsWaveProgramId
+      ? orgEntries
+          .filter((e) => e.waveProgramId === selectedOrgsWaveProgramId)
+          .sort((a, b) => a.org.gitHubOrgLogin.localeCompare(b.org.gitHubOrgLogin))
+      : [],
+  );
+
+  function handleOrgsWaveProgramChange(values: string[]) {
+    if (values.length > 0) selectedOrgsWaveProgramId = values[0];
+  }
 
   const statusOptions = Promise.resolve([
     { value: 'approved', label: 'Approved' },
@@ -92,13 +163,14 @@
   style:view-transition-class="element-handover"
 >
   <Breadcrumbs crumbs={[{ label: 'Maintainer Dashboard' }, { label: 'Orgs & Repos' }]} />
+
   <Section
     header={{
-      label: 'Repo Applications',
-      icon: Ledger,
+      label: 'Orgs',
+      icon: Orgs,
       actions: [
         {
-          label: 'Add repos',
+          label: 'Add org',
           icon: Plus,
           variant: 'primary',
           disabled: false,
@@ -106,71 +178,175 @@
         },
       ],
       infoTooltip:
-        "Before you can add issues to a Wave, the source repo must be accepted by the Wave's organizers. This list shows the status of your repo applications.",
+        "All orgs on Drips Wave you're a member of, alongside their points limit for the selected Wave Program.",
     }}
     skeleton={{
       loaded: true,
-      empty: waveProgramRepos.pagination.total === 0 && !statusFilter,
-      emptyStateEmoji: '🫙',
-      emptyStateHeadline: 'No repo applications yet',
-      emptyStateText: 'Add a repo and apply it to a Wave Program to get started.',
+      empty: orgEntries.length === 0,
+      emptyStateEmoji: '🏢',
+      emptyStateHeadline: 'No orgs yet',
+      emptyStateText: "Once one of your org's repos is approved for a Wave, it'll show up here.",
       horizontalScroll: true,
     }}
   >
-    <div class="filter-row">
-      <div class="filter-item">
-        <span class="filter-label typo-text-small">Status</span>
-        <div class="filter-dropdown">
-          <MultiSelectFilter
-            optionsPromise={statusOptions}
-            selectedValues={selectedStatus}
-            onchange={handleStatusChange}
-            placeholder="All"
-            singleSelect
-          />
-        </div>
-      </div>
-    </div>
-
-    {#if waveProgramRepos.data.length === 0 && statusFilter}
-      <div class="filtered-empty-state">
-        <p class="typo-text-small-bold">No {statusFilter} repos</p>
-        <p class="typo-text-small" style:color="var(--color-foreground-level-5)">
-          None of your repos have this status.
-        </p>
-      </div>
-    {:else if waveProgramRepos.data.length > 0}
-      <div class="list-header typo-header-5">
-        <span></span>
-        <div class="header-right">
-          <div class="header-budget">
-            <span>Points budget</span>
-            <Tooltip>
-              <InfoCircle
-                style="height: 1rem; width: 1rem; fill: var(--color-foreground-level-5);"
-              />
-              {#snippet tooltip_content()}
-                <span class="typo-text-small"
-                  >Each approved repo can use up to the program's per-repo points budget per wave. <a
-                    href="https://docs.drips.network/wave/maintainers/points-budgets"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="typo-link">Learn more</a
-                  ></span
-                >
-              {/snippet}
-            </Tooltip>
+    {#if orgEntries.length > 0}
+      <div class="filter-row">
+        <div class="filter-item">
+          <span class="filter-label typo-text-small">Wave Program</span>
+          <div class="filter-dropdown">
+            <MultiSelectFilter
+              optionsPromise={orgsWaveProgramOptions}
+              selectedValues={selectedOrgsWaveProgramId ? [selectedOrgsWaveProgramId] : []}
+              onchange={handleOrgsWaveProgramChange}
+              placeholder="Select wave"
+              singleSelect
+            />
           </div>
-          <span class="header-status">Status</span>
         </div>
       </div>
-      <div class="repo-applications-list">
-        {#each waveProgramRepos.data as repoApplication (repoApplication.id)}
-          {@render waveProgramRepo(repoApplication)}
+
+      <div class="orgs-grid">
+        {#each orgsForSelectedWave as entry (entry.org.id)}
+          {@const budgetSet = entry.orgPointsBudget !== null}
+          {@const overBudget =
+            budgetSet && entry.orgPointsRemaining !== null && entry.orgPointsRemaining <= 0}
+          {@const lowBudget =
+            budgetSet &&
+            entry.orgPointsRemaining !== null &&
+            entry.orgPointsRemaining > 0 &&
+            entry.orgPointsRemaining <= (entry.orgPointsBudget ?? 0) * 0.2}
+          <OrgPreviewCard
+            org={{
+              id: entry.org.id,
+              gitHubOrgLogin: entry.org.gitHubOrgLogin,
+              gitHubOrgAvatarUrl: entry.org.gitHubOrgAvatarUrl,
+              contactInfo: null,
+            }}
+          >
+            {#snippet actions()}
+              <div class="org-card-footer">
+                <div class="org-card-budget">
+                  <span class="org-card-budget-label typo-text-small">
+                    <span style:color="var(--color-foreground-level-5)">Points budget</span>
+                    <Tooltip>
+                      <InfoCircle
+                        style="height: 0.875rem; width: 0.875rem; fill: var(--color-foreground-level-5);"
+                      />
+                      {#snippet tooltip_content()}
+                        <span class="typo-text-small"
+                          >Each org has a points budget per Wave, shared across all of the org's
+                          approved repos. <a
+                            href="https://docs.drips.network/wave/maintainers/points-budgets"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="typo-link">Learn more</a
+                          ></span
+                        >
+                      {/snippet}
+                    </Tooltip>
+                  </span>
+                  {#if budgetSet}
+                    <span
+                      class="budget typo-text-small"
+                      class:over-budget={overBudget}
+                      class:low-budget={lowBudget}
+                    >
+                      {entry.orgPointsUsed} / {entry.orgPointsBudget}
+                    </span>
+                  {:else}
+                    <span class="budget typo-text-small">&mdash;</span>
+                  {/if}
+                </div>
+                <Button size="small" href={`/wave/orgs/${entry.org.id}`}>View org</Button>
+              </div>
+            {/snippet}
+          </OrgPreviewCard>
         {/each}
       </div>
     {/if}
   </Section>
+
+  <div style:margin-top="2rem">
+    <Section
+      header={{
+        label: 'Repo Applications',
+        icon: Ledger,
+        actions: [
+          {
+            label: 'Apply repo',
+            icon: Plus,
+            variant: 'primary',
+            disabled: false,
+            href: `/wave/maintainer-onboarding/review-repos`,
+          },
+        ],
+        infoTooltip:
+          "Before you can add issues to a Wave, the source repo must be accepted by the Wave's organizers. This list shows the status of your repo applications.",
+      }}
+      skeleton={{
+        loaded: true,
+        empty: waveProgramRepos.pagination.total === 0 && !statusFilter,
+        emptyStateEmoji: '🫙',
+        emptyStateHeadline: 'No repo applications yet',
+        emptyStateText: 'Add a repo and apply it to a Wave Program to get started.',
+        horizontalScroll: true,
+      }}
+    >
+      <div class="filter-row">
+        <div class="filter-item">
+          <span class="filter-label typo-text-small">Status</span>
+          <div class="filter-dropdown">
+            <MultiSelectFilter
+              optionsPromise={statusOptions}
+              selectedValues={selectedStatus}
+              onchange={handleStatusChange}
+              placeholder="All"
+              singleSelect
+            />
+          </div>
+        </div>
+      </div>
+
+      {#if waveProgramRepos.data.length === 0 && statusFilter}
+        <div class="filtered-empty-state">
+          <p class="typo-text-small-bold">No {statusFilter} repos</p>
+          <p class="typo-text-small" style:color="var(--color-foreground-level-5)">
+            None of your repos have this status.
+          </p>
+        </div>
+      {:else if waveProgramRepos.data.length > 0}
+        <div class="list-header typo-header-5">
+          <span></span>
+          <div class="header-right">
+            <div class="header-budget">
+              <span>Points budget</span>
+              <Tooltip>
+                <InfoCircle
+                  style="height: 1rem; width: 1rem; fill: var(--color-foreground-level-5);"
+                />
+                {#snippet tooltip_content()}
+                  <span class="typo-text-small"
+                    >Each approved repo can use up to the program's per-repo points budget per Wave. <a
+                      href="https://docs.drips.network/wave/maintainers/points-budgets"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="typo-link">Learn more</a
+                    ></span
+                  >
+                {/snippet}
+              </Tooltip>
+            </div>
+            <span class="header-status">Status</span>
+          </div>
+        </div>
+        <div class="repo-applications-list">
+          {#each waveProgramRepos.data as repoApplication (repoApplication.id)}
+            {@render waveProgramRepo(repoApplication)}
+          {/each}
+        </div>
+      {/if}
+    </Section>
+  </div>
 </div>
 
 <style>
@@ -298,7 +474,7 @@
   .budget {
     width: 6rem;
     text-align: right;
-    color: var(--color-foreground-level-5);
+    color: var(--color-foreground);
   }
 
   .budget.over-budget {
@@ -313,5 +489,38 @@
     width: 6rem;
     text-align: right;
     white-space: nowrap;
+  }
+
+  .orgs-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(20rem, 1fr));
+    gap: 1rem;
+    isolation: isolate;
+  }
+
+  .org-card-footer {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 1rem;
+    width: 100%;
+  }
+
+  .org-card-budget {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    min-width: 0;
+  }
+
+  .org-card-budget .budget {
+    width: auto;
+    text-align: left;
+  }
+
+  .org-card-budget-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
   }
 </style>

--- a/src/routes/(pages)/wave/(base-layout)/maintainers/repos/+page.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/maintainers/repos/+page.svelte
@@ -183,7 +183,7 @@
     skeleton={{
       loaded: true,
       empty: orgEntries.length === 0,
-      emptyStateEmoji: '🏢',
+      emptyStateEmoji: '🫙',
       emptyStateHeadline: 'No orgs yet',
       emptyStateText: "Once one of your org's repos is approved for a Wave, it'll show up here.",
       horizontalScroll: true,

--- a/src/routes/(pages)/wave/(base-layout)/maintainers/repos/+page.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/maintainers/repos/+page.svelte
@@ -178,7 +178,7 @@
         },
       ],
       infoTooltip:
-        "All orgs on Drips Wave you're a member of, alongside their points limit for the selected Wave Program.",
+        "Orgs you're a member of that have at least one repo approved in the selected Wave Program, alongside each org's points limit for that Wave.",
     }}
     skeleton={{
       loaded: true,

--- a/src/routes/(pages)/wave/(base-layout)/maintainers/repos/+page.ts
+++ b/src/routes/(pages)/wave/(base-layout)/maintainers/repos/+page.ts
@@ -1,3 +1,4 @@
+import { getAllPaginated } from '$lib/utils/wave/getAllPaginated.js';
 import { getOwnWaveProgramRepos, getWavePrograms } from '$lib/utils/wave/wavePrograms.js';
 import { waveProgramRepoStatusSchema } from '$lib/utils/wave/types/waveProgram.js';
 
@@ -9,7 +10,7 @@ export const load = async ({ fetch, depends, url }) => {
     ? (waveProgramRepoStatusSchema.safeParse(rawStatus).data ?? null)
     : null;
 
-  const [waveProgramRepos, approvedWaveProgramRepos, wavePrograms] = await Promise.all([
+  const [waveProgramRepos, approvedWaveProgramReposData, wavePrograms] = await Promise.all([
     // todo(wave): pagination
     getOwnWaveProgramRepos(
       fetch,
@@ -19,16 +20,26 @@ export const load = async ({ fetch, depends, url }) => {
     // Always fetch approved repos regardless of the page filter — the Orgs
     // section is derived from these and shouldn't change when the user filters
     // the repo applications list.
-    statusFilter === 'approved'
-      ? null
-      : getOwnWaveProgramRepos(fetch, { limit: 100 }, { status: 'approved' }),
+    getAllPaginated((page, limit) =>
+      getOwnWaveProgramRepos(fetch, { page, limit }, { status: 'approved' }),
+    ),
     // todo(wave): Only fetch waves included in the repos list
     getWavePrograms(fetch, { limit: 100 }),
   ]);
 
   return {
     waveProgramRepos,
-    approvedWaveProgramRepos: approvedWaveProgramRepos ?? waveProgramRepos,
+    approvedWaveProgramRepos: {
+      data: approvedWaveProgramReposData,
+      pagination: {
+        total: approvedWaveProgramReposData.length,
+        page: 1,
+        limit: approvedWaveProgramReposData.length,
+        totalPages: 1,
+        hasNextPage: false,
+        hasPreviousPage: false,
+      },
+    },
     wavePrograms,
     statusFilter,
   };

--- a/src/routes/(pages)/wave/(base-layout)/maintainers/repos/+page.ts
+++ b/src/routes/(pages)/wave/(base-layout)/maintainers/repos/+page.ts
@@ -9,19 +9,26 @@ export const load = async ({ fetch, depends, url }) => {
     ? (waveProgramRepoStatusSchema.safeParse(rawStatus).data ?? null)
     : null;
 
-  const [waveProgramRepos, wavePrograms] = await Promise.all([
+  const [waveProgramRepos, approvedWaveProgramRepos, wavePrograms] = await Promise.all([
     // todo(wave): pagination
     getOwnWaveProgramRepos(
       fetch,
       { limit: 100 },
       statusFilter ? { status: statusFilter } : undefined,
     ),
+    // Always fetch approved repos regardless of the page filter — the Orgs
+    // section is derived from these and shouldn't change when the user filters
+    // the repo applications list.
+    statusFilter === 'approved'
+      ? null
+      : getOwnWaveProgramRepos(fetch, { limit: 100 }, { status: 'approved' }),
     // todo(wave): Only fetch waves included in the repos list
     getWavePrograms(fetch, { limit: 100 }),
   ]);
 
   return {
     waveProgramRepos,
+    approvedWaveProgramRepos: approvedWaveProgramRepos ?? waveProgramRepos,
     wavePrograms,
     statusFilter,
   };


### PR DESCRIPTION
## Summary

- Adds an **Orgs** section to `/wave/maintainers/repos` that lists each org the user has at least one approved repo in, with a per-Wave-Program points budget gauge (used / total, with low/over-budget colors). A dropdown picks which Wave Program to show limits for; defaults to the first one the user participates in.
- Picks up the new `orgPointsBudget` / `orgPointsUsed` / `orgPointsRemaining` fields from the wave backend (per-org points cap, drips-network/wave#590).
- Renames the Repo Applications header action from **Add repos** to **Apply repo** and points it straight at `/wave/maintainer-onboarding/review-repos`. New **Add org** action on the Orgs section links to `install-app`.
- Tooltip popup now portals itself to `<body>` on show, so its `z-index` escapes the page's `view-transition-name` stacking context and renders above the sidenav instead of behind it.
- Tiny `package-lock.json` cleanup: drops two duplicate nested `zod` entries under `@web3-onboard/*`.
- Includes an unrelated commit to add a checkbox to an admin panel. Shouldn't be on this PR, but whatever, we are fine with it.

## Test plan

- [x] Sign in as a maintainer with approved repos in at least one Wave Program.
- [x] Visit `/wave/maintainers/repos` — confirm the new Orgs section renders above Repo Applications, one card per org, with the budget gauge.
- [x] Switch the Wave Program dropdown — confirm cards/orgs and budget figures update for the selected wave.
- [x] Hover the (i) icon next to "Points budget" inside a card — tooltip should render above the sidenav (previously was hidden behind it on this page).
- [x] Click **Apply repo** — should land on `/wave/maintainer-onboarding/review-repos`.
- [x] Click **Add org** — should land on `/wave/maintainer-onboarding/install-app`.
- [x] Visit as a user with no approved repos — Orgs section shows the empty state.