### PR TITLE
wave: require KYC to apply for issues + KYC prompt step

### DIFF
--- a/src/lib/components/text-area/text-area.svelte
+++ b/src/lib/components/text-area/text-area.svelte
@@ -12,6 +12,7 @@
     textareaStyle?: string | undefined;
     value?: string | undefined | null;
     placeholder?: string | undefined;
+    disabled?: boolean;
     validationState?: TextInputValidationState;
     onchange?: (event: Event) => void;
     onclick?: (event: Event) => void;
@@ -26,6 +27,7 @@
     textareaStyle = undefined,
     value = $bindable(),
     placeholder = undefined,
+    disabled = false,
     validationState = {
       type: 'unvalidated',
     },
@@ -70,6 +72,7 @@
     class="typo-text"
     class:resizable
     {placeholder}
+    {disabled}
     {onchange}
     {onclick}
     {oninput}

--- a/src/routes/(pages)/wave/(base-layout)/settings/profile/+page.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/settings/profile/+page.svelte
@@ -79,7 +79,7 @@
     >
       <div class="description">
         <ExclamationCircle style="fill: var(--color-caution-level-6);" />
-        Verify your identity now to be eligible for Wave rewards.
+        Verify your identity now to participate in a Wave.
       </div>
       <Button icon={ArrowRight} href="/wave/kyc" variant="primary">Verify identity</Button>
     </div>

--- a/src/routes/(pages)/wave/(flows)/[waveProgramSlug]/issues/[issueId]/apply/+layout.ts
+++ b/src/routes/(pages)/wave/(flows)/[waveProgramSlug]/issues/[issueId]/apply/+layout.ts
@@ -40,7 +40,7 @@ export const load = async ({ fetch, params, parent, url }) => {
     getApplicationQuota(fetch, waveProgram.id).catch(() => null),
     getOrgAssignmentQuota(fetch, waveProgram.id, issue.repo.org.id).catch(() => null),
     getPhoneVerificationRequired(fetch).catch(() => null),
-    getKycStatus(fetch).catch(() => null),
+    getKycStatus(fetch),
   ]);
 
   const previousApplication = await getIssueApplications(
@@ -60,7 +60,7 @@ export const load = async ({ fetch, params, parent, url }) => {
   }
 
   const isKycVerified =
-    kycStatus && kycStatus.status === 'applicantReviewed' && kycStatus.reviewAnswer === 'GREEN';
+    kycStatus.status === 'applicantReviewed' && kycStatus.reviewAnswer === 'GREEN';
 
   const upcomingWave = upcomingWaves.data[0] ?? null;
 

--- a/src/routes/(pages)/wave/(flows)/[waveProgramSlug]/issues/[issueId]/apply/+layout.ts
+++ b/src/routes/(pages)/wave/(flows)/[waveProgramSlug]/issues/[issueId]/apply/+layout.ts
@@ -5,6 +5,7 @@ import {
 } from '$lib/utils/wave/issues.js';
 import { getPhoneVerificationRequired } from '$lib/utils/wave/users.js';
 import { getWaves } from '$lib/utils/wave/wavePrograms.js';
+import { getKycStatus } from '$lib/utils/wave/kyc.js';
 import { redirect } from '@sveltejs/kit';
 
 export const load = async ({ fetch, params, parent, url }) => {
@@ -12,28 +13,35 @@ export const load = async ({ fetch, params, parent, url }) => {
 
   const { issueId } = params;
 
-  const [waves, upcomingWaves, applicationQuota, orgAssignmentQuota, phoneVerificationRequired] =
-    await Promise.all([
-      getWaves(
-        fetch,
-        waveProgram.id,
-        {},
-        {
-          status: 'active',
-        },
-      ),
-      getWaves(
-        fetch,
-        waveProgram.id,
-        { limit: 1 },
-        {
-          status: 'upcoming',
-        },
-      ),
-      getApplicationQuota(fetch, waveProgram.id).catch(() => null),
-      getOrgAssignmentQuota(fetch, waveProgram.id, issue.repo.org.id).catch(() => null),
-      getPhoneVerificationRequired(fetch).catch(() => null),
-    ]);
+  const [
+    waves,
+    upcomingWaves,
+    applicationQuota,
+    orgAssignmentQuota,
+    phoneVerificationRequired,
+    kycStatus,
+  ] = await Promise.all([
+    getWaves(
+      fetch,
+      waveProgram.id,
+      {},
+      {
+        status: 'active',
+      },
+    ),
+    getWaves(
+      fetch,
+      waveProgram.id,
+      { limit: 1 },
+      {
+        status: 'upcoming',
+      },
+    ),
+    getApplicationQuota(fetch, waveProgram.id).catch(() => null),
+    getOrgAssignmentQuota(fetch, waveProgram.id, issue.repo.org.id).catch(() => null),
+    getPhoneVerificationRequired(fetch).catch(() => null),
+    getKycStatus(fetch).catch(() => null),
+  ]);
 
   const previousApplication = await getIssueApplications(
     fetch,
@@ -51,6 +59,9 @@ export const load = async ({ fetch, params, parent, url }) => {
     );
   }
 
+  const isKycVerified =
+    kycStatus && kycStatus.status === 'applicantReviewed' && kycStatus.reviewAnswer === 'GREEN';
+
   const upcomingWave = upcomingWaves.data[0] ?? null;
 
   return {
@@ -59,5 +70,6 @@ export const load = async ({ fetch, params, parent, url }) => {
     upcomingWave,
     applicationQuota,
     orgAssignmentQuota,
+    isKycVerified,
   };
 };

--- a/src/routes/(pages)/wave/(flows)/[waveProgramSlug]/issues/[issueId]/apply/+page.svelte
+++ b/src/routes/(pages)/wave/(flows)/[waveProgramSlug]/issues/[issueId]/apply/+page.svelte
@@ -202,6 +202,20 @@
       </div>
     </FormField>
   {:else}
+    {#if !data.isKycVerified}
+      <AnnotationBox type="error">
+        <span class="typo-text-small-bold">Identity verification (KYC) required</span><br />
+        Get identity verification out of the way now so you're ready to apply as soon as the next Wave
+        goes live — and so there are no delays when it's time to withdraw any rewards you earn.
+        {#snippet actions()}
+          <Button
+            href={`/wave/kyc?backTo=${encodeURIComponent(page.url.pathname + page.url.search)}`}
+          >
+            Verify identity
+          </Button>
+        {/snippet}
+      </AnnotationBox>
+    {/if}
     <AnnotationBox>
       {data.waveProgram.name} does not have an active Wave at the moment, so applications cannot be submitted.<br
       />

--- a/src/routes/(pages)/wave/(flows)/[waveProgramSlug]/issues/[issueId]/apply/+page.svelte
+++ b/src/routes/(pages)/wave/(flows)/[waveProgramSlug]/issues/[issueId]/apply/+page.svelte
@@ -183,6 +183,7 @@
       <TextArea
         bind:value={applicationText}
         placeholder="I would like to work on this issue because..."
+        disabled={!data.isKycVerified}
         onblur={() => (beenFocussed = true)}
       />
       <div class="char-count">
@@ -197,9 +198,11 @@
       type="div"
       disabled={!data.isKycVerified}
     >
-      <div class="turnstile-wrapper">
-        <Turnstile ontoken={(t) => (turnstileToken = t)} />
-      </div>
+      {#if data.isKycVerified}
+        <div class="turnstile-wrapper">
+          <Turnstile ontoken={(t) => (turnstileToken = t)} />
+        </div>
+      {/if}
     </FormField>
   {:else}
     {#if !data.isKycVerified}

--- a/src/routes/(pages)/wave/(flows)/[waveProgramSlug]/issues/[issueId]/apply/+page.svelte
+++ b/src/routes/(pages)/wave/(flows)/[waveProgramSlug]/issues/[issueId]/apply/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
+  import { page } from '$app/state';
   import AnnotationBox from '$lib/components/annotation-box/annotation-box.svelte';
   import Button from '$lib/components/button/button.svelte';
   import FormField from '$lib/components/form-field/form-field.svelte';
@@ -131,26 +132,41 @@
       {/snippet}
     </AnnotationBox>
   {:else if waveProgramHasActiveWave}
-    <AnnotationBox type="info">
-      <span class="typo-text-small-bold"
-        >You have {data.applicationQuota?.remaining} of {data.applicationQuota?.limit} application {data
-          .applicationQuota?.limit === 1
-          ? 'slot'
-          : 'slots'} remaining in this Wave.</span
-      >
-      You can free up more slots by resolving assigned issues or withdrawing pending applications.
-
-      {#snippet actions()}
-        <Button
-          href="https://docs.drips.network/wave/contributors/solving-issues-and-earning-rewards#application-limits"
-          target="_blank">Learn more</Button
+    {#if !data.isKycVerified}
+      <AnnotationBox type="error">
+        <span class="typo-text-small-bold">Identity verification (KYC) required</span><br />
+        To withdraw the rewards you'll earn from completing this issue, you need a verified identity.
+        We ask for it before you apply so there are no delays when it's time to cash out.
+        {#snippet actions()}
+          <Button
+            href={`/wave/kyc?backTo=${encodeURIComponent(page.url.pathname + page.url.search)}`}
+          >
+            Verify identity
+          </Button>
+        {/snippet}
+      </AnnotationBox>
+    {/if}
+    {#if data.isKycVerified}
+      <AnnotationBox type="info">
+        <span class="typo-text-small-bold"
+          >You have {data.applicationQuota?.remaining} of {data.applicationQuota?.limit} application
+          {data.applicationQuota?.limit === 1 ? 'slot' : 'slots'} remaining in this Wave.</span
         >
-      {/snippet}
-    </AnnotationBox>
+        You can free up more slots by resolving assigned issues or withdrawing pending applications.
+
+        {#snippet actions()}
+          <Button
+            href="https://docs.drips.network/wave/contributors/solving-issues-and-earning-rewards#application-limits"
+            target="_blank">Learn more</Button
+          >
+        {/snippet}
+      </AnnotationBox>
+    {/if}
     <FormField
       title="Application Text*"
       description="Explain why you'd like to work on this issue and list any relevant experience."
       type="div"
+      disabled={!data.isKycVerified}
       validationState={textValid
         ? { type: 'valid' }
         : beenFocussed
@@ -179,6 +195,7 @@
       title="Verification*"
       description="Confirm you're not a robot with a quick check."
       type="div"
+      disabled={!data.isKycVerified}
     >
       <div class="turnstile-wrapper">
         <Turnstile ontoken={(t) => (turnstileToken = t)} />
@@ -216,13 +233,25 @@
 
   {#snippet actions()}
     {#if !data.user?.restricted && waveProgramHasActiveWave && !data.alreadyApplied && !data.isOwnIssue && !data.issue.completedAt && !data.issue.assignedApplicant && (data.applicationQuota?.remaining ?? 0) > 0 && (data.orgAssignmentQuota?.remaining ?? 0) > 0}
-      <Button
-        loading={submitting}
-        variant="primary"
-        disabled={!valid}
-        icon={Proposals}
-        onclick={handleSubmit}>Apply to issue</Button
+      <div
+        style:display="flex"
+        style:flex-direction="column"
+        style:align-items="flex-end"
+        style:gap="0.5rem"
       >
+        <Button
+          loading={submitting}
+          variant="primary"
+          disabled={!valid || !data.isKycVerified}
+          icon={Proposals}
+          onclick={handleSubmit}>Apply to issue</Button
+        >
+        {#if !data.isKycVerified}
+          <span class="typo-text-small" style:color="var(--color-negative-level-6)">
+            You must complete identity verification (KYC) before applying.
+          </span>
+        {/if}
+      </div>
     {/if}
   {/snippet}
 </FlowStepWrapper>

--- a/src/routes/(pages)/wave/(flows)/kyc-required/+page.svelte
+++ b/src/routes/(pages)/wave/(flows)/kyc-required/+page.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+  import AnnotationBox from '$lib/components/annotation-box/annotation-box.svelte';
+  import Button from '$lib/components/button/button.svelte';
+  import HeadMeta from '$lib/components/head-meta/head-meta.svelte';
+  import FlowStepWrapper from '../shared/flow-step-wrapper.svelte';
+  import ArrowRight from '$lib/components/icons/ArrowRight.svelte';
+  import LockAndKeyEmoji from '$lib/components/icons/🔐.svelte';
+
+  let { data } = $props();
+</script>
+
+<HeadMeta title="Verify your identity | Wave" />
+
+<FlowStepWrapper
+  icon={LockAndKeyEmoji}
+  headline="Verify your identity"
+  description="Verify your identity now so you can withdraw the rewards you earn from completing issues. This usually takes less than 5 minutes."
+>
+  <div class="container">
+    <AnnotationBox type="warning">
+      <span class="typo-text-small-bold"
+        >A verified identity is required for applying to issues</span
+      >
+      to avoid problems during reward withdrawals later.
+      {#snippet actions()}
+        <Button
+          href="https://docs.drips.network/wave/contributors/solving-issues-and-earning-rewards#verifying-your-identity"
+          target="_blank">Learn more</Button
+        >
+      {/snippet}
+    </AnnotationBox>
+    <div class="action-options">
+      <Button
+        variant="primary"
+        size="large"
+        icon={ArrowRight}
+        href={`/wave/kyc?backTo=${encodeURIComponent(data.backTo)}`}
+      >
+        Verify identity
+      </Button>
+      <Button variant="ghost" href={data.backTo}>Skip for now</Button>
+    </div>
+  </div>
+</FlowStepWrapper>
+
+<style>
+  .container {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+    width: 100%;
+    max-width: 32rem;
+    margin: 0 auto;
+  }
+
+  .action-options {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+    width: 100%;
+  }
+
+  :global(.action-options a) {
+    width: 100%;
+    justify-content: center;
+  }
+</style>

--- a/src/routes/(pages)/wave/(flows)/kyc-required/+page.ts
+++ b/src/routes/(pages)/wave/(flows)/kyc-required/+page.ts
@@ -11,8 +11,11 @@ export const load = async ({ url, fetch }) => {
     const kycStatus = await getKycStatus(fetch);
     const isKycVerified =
       kycStatus.status === 'applicantReviewed' && kycStatus.reviewAnswer === 'GREEN';
+    // RED users have already attempted KYC; the "please verify" pitch on this
+    // page is misleading for them. Mirror the login callback's behavior.
+    const isKycRejected = kycStatus.reviewAnswer === 'RED';
 
-    if (isKycVerified) {
+    if (isKycVerified || isKycRejected) {
       throw redirect(302, safeBackTo);
     }
   } catch (err) {

--- a/src/routes/(pages)/wave/(flows)/kyc-required/+page.ts
+++ b/src/routes/(pages)/wave/(flows)/kyc-required/+page.ts
@@ -1,10 +1,9 @@
-import isSafePath from '$lib/utils/safe-path';
+import { safeParseBackToParam } from '$lib/utils/safe-path';
 import { getKycStatus } from '$lib/utils/wave/kyc.js';
 import { redirect } from '@sveltejs/kit';
 
 export const load = async ({ url, fetch }) => {
-  const backTo = url.searchParams.get('backTo') || '/wave';
-  const safeBackTo = isSafePath(backTo) ? backTo : '/wave';
+  const safeBackTo = safeParseBackToParam(url) || '/wave';
 
   try {
     const kycStatus = await getKycStatus(fetch);

--- a/src/routes/(pages)/wave/(flows)/kyc-required/+page.ts
+++ b/src/routes/(pages)/wave/(flows)/kyc-required/+page.ts
@@ -17,11 +17,17 @@ export const load = async ({ url, fetch }) => {
       throw redirect(302, safeBackTo);
     }
   } catch (err) {
+    // Preserve our own 302 redirect above.
     if (err && typeof err === 'object' && 'status' in err && err.status === 302) {
       throw err;
     }
-    // If not authenticated or other error, redirect to login
-    throw redirect(302, `/wave/login?backTo=${encodeURIComponent(url.pathname + url.search)}`);
+    // Only auth failures send the user to login. Real outages (5xx, network,
+    // parsing) should bubble up so we don't mask them behind a login screen
+    // or create redirect loops for already-authenticated users.
+    if (err && typeof err === 'object' && 'status' in err && err.status === 401) {
+      throw redirect(302, `/wave/login?backTo=${encodeURIComponent(url.pathname + url.search)}`);
+    }
+    throw err;
   }
 
   return {

--- a/src/routes/(pages)/wave/(flows)/kyc-required/+page.ts
+++ b/src/routes/(pages)/wave/(flows)/kyc-required/+page.ts
@@ -1,0 +1,29 @@
+import isSafePath from '$lib/utils/safe-path';
+import { getKycStatus } from '$lib/utils/wave/kyc.js';
+import { redirect } from '@sveltejs/kit';
+
+export const load = async ({ url, fetch }) => {
+  const backTo = url.searchParams.get('backTo') || '/wave';
+  const decoded = decodeURIComponent(backTo || '');
+  const safeBackTo = isSafePath(decoded) ? decoded : '/wave';
+
+  try {
+    const kycStatus = await getKycStatus(fetch);
+    const isKycVerified =
+      kycStatus.status === 'applicantReviewed' && kycStatus.reviewAnswer === 'GREEN';
+
+    if (isKycVerified) {
+      throw redirect(302, safeBackTo);
+    }
+  } catch (err) {
+    if (err && typeof err === 'object' && 'status' in err && err.status === 302) {
+      throw err;
+    }
+    // If not authenticated or other error, redirect to login
+    throw redirect(302, `/wave/login?backTo=${encodeURIComponent(url.pathname + url.search)}`);
+  }
+
+  return {
+    backTo: safeBackTo,
+  };
+};

--- a/src/routes/(pages)/wave/(flows)/kyc-required/+page.ts
+++ b/src/routes/(pages)/wave/(flows)/kyc-required/+page.ts
@@ -4,8 +4,7 @@ import { redirect } from '@sveltejs/kit';
 
 export const load = async ({ url, fetch }) => {
   const backTo = url.searchParams.get('backTo') || '/wave';
-  const decoded = decodeURIComponent(backTo || '');
-  const safeBackTo = isSafePath(decoded) ? decoded : '/wave';
+  const safeBackTo = isSafePath(backTo) ? backTo : '/wave';
 
   try {
     const kycStatus = await getKycStatus(fetch);

--- a/src/routes/(pages)/wave/(flows)/login/callback/+page.svelte
+++ b/src/routes/(pages)/wave/(flows)/login/callback/+page.svelte
@@ -13,6 +13,23 @@
 
   let error = $state<boolean>(false);
 
+  // If backTo already points at /wave/kyc-required (e.g. the user was bounced
+  // through login from that page), unwrap the inner backTo so we don't nest
+  // kyc-required inside itself. Loop with a small cap as defense against
+  // pathological deep nesting left over from earlier bugs.
+  function unwrapKycRequiredBackTo(rawBackTo: string): string {
+    let current = rawBackTo;
+    for (let i = 0; i < 5 && current.startsWith('/wave/kyc-required'); i++) {
+      try {
+        const u = new URL(current, page.url.origin);
+        current = u.searchParams.get('backTo') || '/wave';
+      } catch {
+        return '/wave';
+      }
+    }
+    return current;
+  }
+
   onMount(async () => {
     try {
       const { newUser: isNewUser } = await performLogin(page.url);
@@ -37,7 +54,8 @@
         // rejected, the "please verify your identity" pitch is misleading — they
         // already tried.
         if (!isKycVerified && !isKycRejected) {
-          const kycRequiredBackTo = `/wave/kyc-required?backTo=${encodeURIComponent(backTo || '')}`;
+          const target = unwrapKycRequiredBackTo(backTo || '');
+          const kycRequiredBackTo = `/wave/kyc-required?backTo=${encodeURIComponent(target)}`;
           if (isNewUser && !skipWelcome) {
             return goto(`/wave/welcome?backTo=${encodeURIComponent(kycRequiredBackTo)}`);
           }

--- a/src/routes/(pages)/wave/(flows)/login/callback/+page.svelte
+++ b/src/routes/(pages)/wave/(flows)/login/callback/+page.svelte
@@ -18,20 +18,31 @@
       const { newUser: isNewUser } = await performLogin(page.url);
       await invalidateAll();
 
-      const kycStatus = await getKycStatus();
-      const isKycVerified =
-        kycStatus.status === 'applicantReviewed' && kycStatus.reviewAnswer === 'GREEN';
-      const isKycRejected = kycStatus.reviewAnswer === 'RED';
+      // KYC status is best-effort during login — if the call fails, skip the
+      // kyc-required nudge rather than breaking the entire login flow.
+      let kycStatus: Awaited<ReturnType<typeof getKycStatus>> | undefined;
+      try {
+        kycStatus = await getKycStatus();
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.warn('Failed to fetch KYC status during login callback:', err);
+      }
 
-      // Only nudge users who haven't been through verification yet. If KYC was
-      // rejected, the "please verify your identity" pitch is misleading — they
-      // already tried.
-      if (!isKycVerified && !isKycRejected) {
-        const kycRequiredBackTo = `/wave/kyc-required?backTo=${encodeURIComponent(backTo || '')}`;
-        if (isNewUser && !skipWelcome) {
-          return goto(`/wave/welcome?backTo=${encodeURIComponent(kycRequiredBackTo)}`);
+      if (kycStatus) {
+        const isKycVerified =
+          kycStatus.status === 'applicantReviewed' && kycStatus.reviewAnswer === 'GREEN';
+        const isKycRejected = kycStatus.reviewAnswer === 'RED';
+
+        // Only nudge users who haven't been through verification yet. If KYC was
+        // rejected, the "please verify your identity" pitch is misleading — they
+        // already tried.
+        if (!isKycVerified && !isKycRejected) {
+          const kycRequiredBackTo = `/wave/kyc-required?backTo=${encodeURIComponent(backTo || '')}`;
+          if (isNewUser && !skipWelcome) {
+            return goto(`/wave/welcome?backTo=${encodeURIComponent(kycRequiredBackTo)}`);
+          }
+          return goto(kycRequiredBackTo);
         }
-        return goto(kycRequiredBackTo);
       }
 
       if (isNewUser && !skipWelcome) {

--- a/src/routes/(pages)/wave/(flows)/login/callback/+page.svelte
+++ b/src/routes/(pages)/wave/(flows)/login/callback/+page.svelte
@@ -6,6 +6,7 @@
   import Spinner from '$lib/components/spinner/spinner.svelte';
   import Button from '$lib/components/button/button.svelte';
   import { AccountSuspendedError } from '$lib/utils/wave/call';
+  import { getKycStatus } from '$lib/utils/wave/kyc';
 
   let { data } = $props();
   let { backTo, skipWelcome } = $derived(data);
@@ -16,6 +17,22 @@
     try {
       const { newUser: isNewUser } = await performLogin(page.url);
       await invalidateAll();
+
+      const kycStatus = await getKycStatus();
+      const isKycVerified =
+        kycStatus.status === 'applicantReviewed' && kycStatus.reviewAnswer === 'GREEN';
+      const isKycRejected = kycStatus.reviewAnswer === 'RED';
+
+      // Only nudge users who haven't been through verification yet. If KYC was
+      // rejected, the "please verify your identity" pitch is misleading — they
+      // already tried.
+      if (!isKycVerified && !isKycRejected) {
+        const kycRequiredBackTo = `/wave/kyc-required?backTo=${encodeURIComponent(backTo || '')}`;
+        if (isNewUser && !skipWelcome) {
+          return goto(`/wave/welcome?backTo=${encodeURIComponent(kycRequiredBackTo)}`);
+        }
+        return goto(kycRequiredBackTo);
+      }
 
       if (isNewUser && !skipWelcome) {
         return goto(`/wave/welcome?backTo=${encodeURIComponent(backTo || '')}`);

--- a/src/routes/(pages)/wave/(flows)/support/+page.svelte
+++ b/src/routes/(pages)/wave/(flows)/support/+page.svelte
@@ -25,7 +25,7 @@
     <AnnotationBox type="info" centered>
       <span class="typo-text-small-bold"
         >We do our best to respond to all requests as quickly as possible.</span
-      > Nevertheless, please allow up to two business days for a response.
+      > Nevertheless, please allow a few business days for a response in complex cases.
     </AnnotationBox>
   </div>
 


### PR DESCRIPTION
## Summary

Frontend companion to [drips-network/wave#596](https://github.com/drips-network/wave/pull/596) for [drips-network/wave#592](https://github.com/drips-network/wave/issues/592). Pushes KYC earlier in the contributor funnel: blocks the apply page when the user is not verified, and surfaces a dedicated "Verify your identity" step once after login.

- **New `/wave/kyc-required` step**: yellow warning AnnotationBox + primary "Verify identity" / ghost "Skip for now" buttons. Reachable only from the post-login redirect (and direct nav). Self-resolves if the user is already verified.
- **Login callback**: after login, redirects non-verified users to `/wave/kyc-required`. RED-reviewed (rejected) users skip the prompt — the "please verify your identity" pitch is misleading for them.
- **Apply page**:
  - `apply/+layout.ts` fetches KYC status and returns `isKycVerified`. No redirect — the apply page is reachable, just blocked.
  - `apply/+page.svelte` shows a red `Identity verification (KYC) required` AnnotationBox with a "Verify identity" action; both FormFields (application text + Turnstile) get `disabled` so the wrapper greys out and ignores input; the application-slots info box is hidden in this state. Backend 403 still guards submission.
- **Settings/profile**: tiny copy tweak on the existing KYC nudge to align with the new gate framing.
- **Support page**: unrelated one-line response-time copy tweak.

## Test plan

- [x] Logged out → log in as a user without KYC → expect `/wave/kyc-required` after the callback (wrapping the welcome flow for new users).
- [x] Same flow as a RED-reviewed user → expect direct redirect to `backTo`, no kyc-required step.
- [x] Navigate directly to `/wave/<slug>/issues/<id>/apply` without KYC → expect the red KYC AnnotationBox, disabled form, no slots info box; "Verify identity" button links to `/wave/kyc?backTo=…`.
- [x] Complete KYC, return to the apply page → form renders live, slots AnnotationBox returns, submit works.
- [x] On `/wave/kyc-required`: "Skip for now" lands on `backTo`; "Verify identity" lands on `/wave/kyc?backTo=…`.
- [x] Visit `/wave/kyc-required` directly while already verified → expect redirect to `backTo`.

## Note

The "Learn more" link in the warning AnnotationBox points to `docs.drips.network/wave/contributors/solving-issues-and-earning-rewards#verifying-your-identity` — that docs section needs to be authored before merge / shortly after.