### PR TITLE
feat(wave-admin): UI for managing waves; split current/upcoming display

### DIFF
--- a/src/lib/utils/wave/wavePrograms.ts
+++ b/src/lib/utils/wave/wavePrograms.ts
@@ -227,6 +227,49 @@ export async function getWaves(
   );
 }
 
+export async function manualCreateWave(
+  f = fetch,
+  waveProgramId: string,
+  data: { startDate: Date; endDate: Date; budgetUSD?: string },
+) {
+  return parseRes(
+    waveDtoSchema,
+    await authenticatedCall(f, `/api/wave-programs/${waveProgramId}/waves/manual-create`, {
+      method: 'POST',
+      body: JSON.stringify({
+        startDate: data.startDate.toISOString(),
+        endDate: data.endDate.toISOString(),
+        ...(data.budgetUSD !== undefined ? { budgetUSD: data.budgetUSD } : {}),
+      }),
+    }),
+  );
+}
+
+export async function deleteWave(f = fetch, waveProgramId: string, waveId: string) {
+  await authenticatedCall(f, `/api/wave-programs/${waveProgramId}/waves/${waveId}`, {
+    method: 'DELETE',
+  });
+}
+
+export async function updateWave(
+  f = fetch,
+  waveProgramId: string,
+  waveId: string,
+  data: { startDate?: Date; endDate?: Date; budgetUSD?: string },
+) {
+  return parseRes(
+    waveDtoSchema,
+    await authenticatedCall(f, `/api/wave-programs/${waveProgramId}/waves/${waveId}`, {
+      method: 'PATCH',
+      body: JSON.stringify({
+        ...(data.startDate ? { startDate: data.startDate.toISOString() } : {}),
+        ...(data.endDate ? { endDate: data.endDate.toISOString() } : {}),
+        ...(data.budgetUSD !== undefined ? { budgetUSD: data.budgetUSD } : {}),
+      }),
+    }),
+  );
+}
+
 export async function updateWaveProgramIssueComplexity(
   f = fetch,
   waveProgramId: string,

--- a/src/routes/(pages)/wave/(base-layout)/[waveProgramSlug]/+page.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/[waveProgramSlug]/+page.svelte
@@ -20,15 +20,13 @@
   let { data }: PageProps = $props();
   const { waveProgram, waves } = $derived(data);
 
-  let upcomingWave = $derived(waves.data.find((wave) => wave.status === 'upcoming') ?? null);
   let activeWave = $derived(waves.data.find((wave) => wave.status === 'active') ?? null);
-  let upcomingOrActiveWave = $derived(upcomingWave ?? activeWave);
-
-  let otherWaves = $derived(
-    waves.data.filter((wave) => wave.id !== (upcomingOrActiveWave?.id ?? '')),
+  let upcomingWaves = $derived(
+    waves.data
+      .filter((wave) => wave.status === 'upcoming')
+      .sort((a, b) => a.startDate.getTime() - b.startDate.getTime()),
   );
-
-  let waveActive = $derived(activeWave !== null);
+  let pastWaves = $derived(waves.data.filter((wave) => wave.status === 'ended'));
 
   let shareImageUrl = $derived(`/api/share-images/wave-program/${waveProgram.id}.png`);
 </script>
@@ -103,14 +101,29 @@
     </div>
   {/if}
 
-  <section>
-    <div class="divider">
-      <OrDivider text={waveActive ? 'Current Wave' : 'Upcoming Wave'} />
-    </div>
+  {#if activeWave}
+    <section>
+      <div class="divider">
+        <OrDivider text="Current Wave" />
+      </div>
+      <WaveCard wave={activeWave} {waveProgram} />
+    </section>
+  {/if}
 
-    {#if upcomingOrActiveWave}
-      <WaveCard wave={upcomingOrActiveWave} {waveProgram} />
-    {:else}
+  {#if upcomingWaves.length > 0}
+    <section>
+      <div class="divider">
+        <OrDivider text="Upcoming Waves" />
+      </div>
+      {#each upcomingWaves as wave (wave.id)}
+        <WaveCard {wave} {waveProgram} />
+      {/each}
+    </section>
+  {:else if !activeWave}
+    <section>
+      <div class="divider">
+        <OrDivider text="Upcoming Waves" />
+      </div>
       <Card>
         <div class="empty typo-text">
           There are no active or upcoming Waves at the moment. Consider subscribing to our email
@@ -124,20 +137,20 @@
           </div>
         </div>
       </Card>
-    {/if}
-  </section>
+    </section>
+  {/if}
 
-  <section>
-    {#if otherWaves.length > 0}
+  {#if pastWaves.length > 0}
+    <section>
       <div class="divider">
         <OrDivider text="Explore past waves" />
       </div>
-    {/if}
 
-    {#each otherWaves as wave (wave.id)}
-      <WaveCard {wave} {waveProgram} />
-    {/each}
-  </section>
+      {#each pastWaves as wave (wave.id)}
+        <WaveCard {wave} {waveProgram} />
+      {/each}
+    </section>
+  {/if}
 </div>
 
 <style>

--- a/src/routes/(pages)/wave/(base-layout)/admin/+page.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/admin/+page.svelte
@@ -44,6 +44,15 @@
           },
         ]
       : []),
+    ...(data.user.permissions?.includes('manageWaves')
+      ? [
+          {
+            name: 'Waves',
+            description: 'Schedule new waves and edit existing waves for any wave program.',
+            href: '/wave/admin/waves',
+          },
+        ]
+      : []),
     ...(data.user.permissions?.includes('manageBans')
       ? [
           {

--- a/src/routes/(pages)/wave/(base-layout)/admin/waves/+page.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/admin/waves/+page.svelte
@@ -1,0 +1,173 @@
+<script lang="ts">
+  import { invalidate } from '$app/navigation';
+  import HeadMeta from '$lib/components/head-meta/head-meta.svelte';
+  import Breadcrumbs from '$lib/components/breadcrumbs/breadcrumbs.svelte';
+  import Section from '$lib/components/section/section.svelte';
+  import Button from '$lib/components/button/button.svelte';
+  import Refresh from '$lib/components/icons/Refresh.svelte';
+
+  let { data } = $props();
+
+  let wavePrograms = $derived(data.wavePrograms);
+  let refreshing = $state(false);
+
+  async function refresh() {
+    refreshing = true;
+    await invalidate('wave:admin:waves');
+    refreshing = false;
+  }
+</script>
+
+<HeadMeta title="Waves | Admin | Wave" />
+
+<div class="page">
+  <Breadcrumbs crumbs={[{ label: 'Admin', href: '/wave/admin' }, { label: 'Waves' }]} />
+  <Section
+    header={{
+      label: 'Wave Programs',
+      actions: [
+        {
+          label: 'Refresh',
+          icon: Refresh,
+          disabled: refreshing,
+          handler: refresh,
+        },
+      ],
+    }}
+    skeleton={{
+      loaded: true,
+      empty: wavePrograms.length === 0,
+      emptyStateEmoji: '🌊',
+      emptyStateHeadline: 'No wave programs',
+      emptyStateText: 'There are no wave programs to manage.',
+    }}
+  >
+    <div class="list">
+      {#each wavePrograms as program (program.id)}
+        <div class="row">
+          <div class="left">
+            {#if program.avatarUrl}
+              <img class="avatar" src={program.avatarUrl} alt="" />
+            {:else}
+              <div class="avatar avatar-fallback">{program.name.slice(0, 1).toUpperCase()}</div>
+            {/if}
+            <div class="info">
+              <span class="typo-text-bold">{program.name}</span>
+              <div class="meta typo-text-small">
+                <span class="dim"
+                  >{program.waveCount} {program.waveCount === 1 ? 'wave' : 'waves'}</span
+                >
+                <span class="dim">·</span>
+                <span class="dim"
+                  >every {program.waveDurationDays}d on day {program.waveDayOfMonth}</span
+                >
+                {#if program.paused}
+                  <span class="dim">·</span>
+                  <span class="badge paused">paused</span>
+                {/if}
+              </div>
+            </div>
+          </div>
+          <div class="actions">
+            <Button size="small" href={`/wave/admin/waves/${program.id}`}>Manage Waves</Button>
+          </div>
+        </div>
+      {/each}
+    </div>
+  </Section>
+</div>
+
+<style>
+  .page {
+    display: flex;
+    max-width: 90rem;
+    margin: 0 auto;
+    width: 100%;
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+
+  .list {
+    display: flex;
+    flex-direction: column;
+    border: 1px solid var(--color-foreground-level-2);
+    border-radius: 1rem 0 1rem 1rem;
+    overflow: hidden;
+  }
+
+  .row {
+    padding: 1rem;
+    border-bottom: 1px solid var(--color-foreground-level-2);
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    align-items: center;
+  }
+
+  .row:last-child {
+    border-bottom: none;
+  }
+
+  .left {
+    display: flex;
+    gap: 0.75rem;
+    align-items: center;
+    min-width: 0;
+    flex: 1;
+  }
+
+  .avatar {
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 0.5rem;
+    object-fit: cover;
+    flex-shrink: 0;
+  }
+
+  .avatar-fallback {
+    background: var(--color-foreground-level-2);
+    color: var(--color-foreground-level-6);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: bold;
+  }
+
+  .info {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    min-width: 0;
+  }
+
+  .meta {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    flex-wrap: wrap;
+  }
+
+  .dim {
+    color: var(--color-foreground-level-5);
+  }
+
+  .badge {
+    text-transform: uppercase;
+    font-size: 0.625rem;
+    letter-spacing: 0.05em;
+    padding: 0.125rem 0.5rem;
+    border-radius: 0.5rem;
+    font-family: var(--typeface-mono);
+  }
+
+  .badge.paused {
+    background: var(--color-caution-level-1);
+    color: var(--color-caution-level-6);
+  }
+
+  .actions {
+    display: flex;
+    gap: 0.5rem;
+    flex-shrink: 0;
+  }
+</style>

--- a/src/routes/(pages)/wave/(base-layout)/admin/waves/+page.ts
+++ b/src/routes/(pages)/wave/(base-layout)/admin/waves/+page.ts
@@ -1,0 +1,21 @@
+import { getWavePrograms } from '$lib/utils/wave/wavePrograms';
+import { getAllPaginated } from '$lib/utils/wave/getAllPaginated';
+import { redirect } from '@sveltejs/kit';
+
+export const load = async ({ parent, fetch, depends }) => {
+  depends('wave:admin:waves');
+
+  const { user } = await parent();
+
+  if (!user.permissions?.includes('manageWaves')) {
+    throw redirect(302, '/wave/admin');
+  }
+
+  const wavePrograms = await getAllPaginated((page, limit) =>
+    getWavePrograms(fetch, { page, limit }),
+  );
+
+  return {
+    wavePrograms,
+  };
+};

--- a/src/routes/(pages)/wave/(base-layout)/admin/waves/[waveProgramId]/+page.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/admin/waves/[waveProgramId]/+page.svelte
@@ -1,0 +1,230 @@
+<script lang="ts">
+  import { invalidate } from '$app/navigation';
+  import HeadMeta from '$lib/components/head-meta/head-meta.svelte';
+  import Breadcrumbs from '$lib/components/breadcrumbs/breadcrumbs.svelte';
+  import Section from '$lib/components/section/section.svelte';
+  import Button from '$lib/components/button/button.svelte';
+  import Refresh from '$lib/components/icons/Refresh.svelte';
+  import Plus from '$lib/components/icons/Plus.svelte';
+  import Trash from '$lib/components/icons/Trash.svelte';
+  import modal from '$lib/stores/modal';
+  import doWithConfirmationModal from '$lib/utils/do-with-confirmation-modal';
+  import doWithErrorModal from '$lib/utils/do-with-error-modal';
+  import { deleteWave } from '$lib/utils/wave/wavePrograms';
+  import type { WaveDto } from '$lib/utils/wave/types/waveProgram';
+  import CreateWaveModal from './components/create-wave-modal.svelte';
+  import EditWaveModal from './components/edit-wave-modal.svelte';
+
+  let { data } = $props();
+
+  let waveProgram = $derived(data.waveProgram);
+  let waves = $derived(data.waves);
+  let refreshing = $state(false);
+
+  async function refresh() {
+    refreshing = true;
+    await invalidate('wave:admin:waves:program');
+    refreshing = false;
+  }
+
+  function openCreateModal() {
+    modal.show(CreateWaveModal, undefined, {
+      waveProgramId: waveProgram.id,
+      presetBudgetUSD: waveProgram.presetBudgetUSD,
+      onCreated: refresh,
+    });
+  }
+
+  function openEditModal(wave: WaveDto) {
+    modal.show(EditWaveModal, undefined, {
+      waveProgramId: waveProgram.id,
+      wave,
+      onUpdated: refresh,
+    });
+  }
+
+  async function confirmDelete(wave: WaveDto) {
+    const message = `Delete Wave #${wave.waveNumber}? This cannot be undone. Only upcoming waves can be deleted.`;
+    await doWithConfirmationModal(message, async () => {
+      await doWithErrorModal(() => deleteWave(fetch, waveProgram.id, wave.id), undefined, {
+        message: `Wave #${wave.waveNumber} deleted.`,
+        confetti: false,
+      });
+      await refresh();
+    });
+  }
+
+  function formatDate(date: Date) {
+    return date.toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+  }
+
+  function formatBudget(usd: number) {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD',
+      maximumFractionDigits: 0,
+    }).format(usd);
+  }
+</script>
+
+<HeadMeta title="{waveProgram.name} | Waves | Admin | Wave" />
+
+<div class="page">
+  <Breadcrumbs
+    crumbs={[
+      { label: 'Admin', href: '/wave/admin' },
+      { label: 'Waves', href: '/wave/admin/waves' },
+      { label: waveProgram.name },
+    ]}
+  />
+  <Section
+    header={{
+      label: `Waves for ${waveProgram.name}`,
+      actions: [
+        {
+          label: 'Refresh',
+          icon: Refresh,
+          disabled: refreshing,
+          handler: refresh,
+        },
+        {
+          label: 'Schedule wave',
+          icon: Plus,
+          variant: 'primary',
+          handler: openCreateModal,
+        },
+      ],
+    }}
+    skeleton={{
+      loaded: true,
+      empty: waves.length === 0,
+      emptyStateEmoji: '🌊',
+      emptyStateHeadline: 'No waves yet',
+      emptyStateText: 'Schedule the first wave for this program.',
+    }}
+  >
+    <div class="list">
+      {#each waves as wave (wave.id)}
+        <div class="row">
+          <div class="left">
+            <span class="typo-text-bold">Wave #{wave.waveNumber}</span>
+            <div class="meta typo-text-small">
+              <span
+                class="badge"
+                class:upcoming={wave.status === 'upcoming'}
+                class:active={wave.status === 'active'}
+                class:ended={wave.status === 'ended'}
+              >
+                {wave.status}
+              </span>
+              <span class="dim">·</span>
+              <span class="dim">{formatDate(wave.startDate)} – {formatDate(wave.endDate)}</span>
+              <span class="dim">·</span>
+              <span class="dim">{formatBudget(wave.budgetUSD)} budget</span>
+            </div>
+          </div>
+          <div class="actions">
+            {#if wave.status !== 'ended'}
+              <Button size="small" variant="ghost" onclick={() => openEditModal(wave)}>
+                {wave.status === 'active' ? 'Extend' : 'Edit'}
+              </Button>
+            {/if}
+            {#if wave.status === 'upcoming'}
+              <Button
+                size="small"
+                variant="destructive"
+                icon={Trash}
+                onclick={() => confirmDelete(wave)}>Delete</Button
+              >
+            {/if}
+          </div>
+        </div>
+      {/each}
+    </div>
+  </Section>
+</div>
+
+<style>
+  .page {
+    display: flex;
+    max-width: 90rem;
+    margin: 0 auto;
+    width: 100%;
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+
+  .list {
+    display: flex;
+    flex-direction: column;
+    border: 1px solid var(--color-foreground-level-2);
+    border-radius: 1rem 0 1rem 1rem;
+    overflow: hidden;
+  }
+
+  .row {
+    padding: 1rem;
+    border-bottom: 1px solid var(--color-foreground-level-2);
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    align-items: center;
+  }
+
+  .row:last-child {
+    border-bottom: none;
+  }
+
+  .left {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    min-width: 0;
+    flex: 1;
+  }
+
+  .meta {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    flex-wrap: wrap;
+  }
+
+  .dim {
+    color: var(--color-foreground-level-5);
+  }
+
+  .badge {
+    text-transform: uppercase;
+    font-size: 0.625rem;
+    letter-spacing: 0.05em;
+    padding: 0.125rem 0.5rem;
+    border-radius: 0.5rem;
+    font-family: var(--typeface-mono);
+  }
+
+  .badge.upcoming {
+    background: var(--color-primary-level-1);
+    color: var(--color-primary-level-6);
+  }
+
+  .badge.active {
+    background: var(--color-positive-level-1);
+    color: var(--color-positive-level-6);
+  }
+
+  .badge.ended {
+    background: var(--color-foreground-level-2);
+    color: var(--color-foreground-level-6);
+  }
+
+  .actions {
+    display: flex;
+    gap: 0.5rem;
+    flex-shrink: 0;
+  }
+</style>

--- a/src/routes/(pages)/wave/(base-layout)/admin/waves/[waveProgramId]/+page.ts
+++ b/src/routes/(pages)/wave/(base-layout)/admin/waves/[waveProgramId]/+page.ts
@@ -1,0 +1,31 @@
+import { getWaveProgram, getWaves } from '$lib/utils/wave/wavePrograms';
+import { getAllPaginated } from '$lib/utils/wave/getAllPaginated';
+import { error, redirect } from '@sveltejs/kit';
+
+export const load = async ({ parent, fetch, depends, params }) => {
+  depends('wave:admin:waves:program');
+
+  const { user } = await parent();
+
+  if (!user.permissions?.includes('manageWaves')) {
+    throw redirect(302, '/wave/admin');
+  }
+
+  const waveProgram = await getWaveProgram(fetch, params.waveProgramId);
+
+  if (!waveProgram) {
+    throw error(404, 'Wave program not found');
+  }
+
+  const waves = await getAllPaginated((page, limit) =>
+    getWaves(fetch, waveProgram.id, { page, limit }),
+  );
+
+  // Sort by waveNumber descending (newest first)
+  waves.sort((a, b) => b.waveNumber - a.waveNumber);
+
+  return {
+    waveProgram,
+    waves,
+  };
+};

--- a/src/routes/(pages)/wave/(base-layout)/admin/waves/[waveProgramId]/components/create-wave-modal.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/admin/waves/[waveProgramId]/components/create-wave-modal.svelte
@@ -1,0 +1,116 @@
+<script lang="ts">
+  import Button from '$lib/components/button/button.svelte';
+  import TextInput from '$lib/components/text-input/text-input.svelte';
+  import DateInput from '$lib/components/date-picker/DateInput.svelte';
+  import FormField from '$lib/components/form-field/form-field.svelte';
+  import StandaloneFlowStepLayout from '$lib/components/standalone-flow-step-layout/standalone-flow-step-layout.svelte';
+  import AnnotationBox from '$lib/components/annotation-box/annotation-box.svelte';
+  import Plus from '$lib/components/icons/Plus.svelte';
+  import modal from '$lib/stores/modal';
+  import { manualCreateWave } from '$lib/utils/wave/wavePrograms';
+
+  interface Props {
+    waveProgramId: string;
+    presetBudgetUSD: string;
+    onCreated: () => void;
+  }
+
+  let { waveProgramId, presetBudgetUSD, onCreated }: Props = $props();
+
+  let startDate = $state<Date | null>(null);
+  let endDate = $state<Date | null>(null);
+  let budgetUSD = $state<string>(presetBudgetUSD);
+  let submitting = $state(false);
+  let error = $state<string | null>(null);
+
+  const BUDGET_PATTERN = /^\d+(\.\d{1,2})?$/;
+
+  const budgetValid = $derived(BUDGET_PATTERN.test(budgetUSD));
+  const datesValid = $derived(
+    startDate !== null && endDate !== null && endDate.getTime() > startDate.getTime(),
+  );
+  const canSubmit = $derived(budgetValid && datesValid && !submitting);
+
+  const budgetValidationState = $derived.by(() => {
+    if (budgetUSD.length === 0) return undefined;
+    if (!BUDGET_PATTERN.test(budgetUSD)) {
+      return { type: 'invalid' as const, message: 'Must be a decimal number, e.g. "50000.00".' };
+    }
+    return { type: 'valid' as const };
+  });
+
+  async function handleSubmit() {
+    if (!canSubmit || !startDate || !endDate) return;
+
+    submitting = true;
+    error = null;
+
+    try {
+      await manualCreateWave(fetch, waveProgramId, {
+        startDate,
+        endDate,
+        budgetUSD,
+      });
+      onCreated();
+      modal.hide();
+    } catch (e) {
+      error = e instanceof Error ? e.message : 'An unexpected error occurred.';
+    } finally {
+      submitting = false;
+    }
+  }
+</script>
+
+<div class="modal">
+  <StandaloneFlowStepLayout
+    headline="Schedule new wave"
+    description="Create a new wave for this wave program. End date must be after start date and the range must not overlap with any existing wave."
+  >
+    <div class="fields">
+      <FormField title="Start date" type="div">
+        <DateInput bind:value={startDate} timePrecision="minute" />
+      </FormField>
+
+      <FormField title="End date" type="div">
+        <DateInput bind:value={endDate} timePrecision="minute" />
+      </FormField>
+
+      <FormField
+        title="Budget (USD)"
+        description="Total budget for this wave, in USD. Defaults to the wave program's preset budget."
+        validationState={budgetValidationState}
+      >
+        <TextInput bind:value={budgetUSD} placeholder="50000.00" />
+      </FormField>
+    </div>
+
+    {#if error}
+      <AnnotationBox type="error">{error}</AnnotationBox>
+    {/if}
+
+    {#snippet actions()}
+      <Button variant="normal" disabled={submitting} onclick={modal.hide}>Cancel</Button>
+      <Button
+        variant="primary"
+        icon={Plus}
+        loading={submitting}
+        disabled={!canSubmit}
+        onclick={handleSubmit}
+      >
+        Schedule
+      </Button>
+    {/snippet}
+  </StandaloneFlowStepLayout>
+</div>
+
+<style>
+  .modal {
+    padding: 1rem;
+  }
+
+  .fields {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+</style>

--- a/src/routes/(pages)/wave/(base-layout)/admin/waves/[waveProgramId]/components/edit-wave-modal.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/admin/waves/[waveProgramId]/components/edit-wave-modal.svelte
@@ -1,0 +1,148 @@
+<script lang="ts">
+  import Button from '$lib/components/button/button.svelte';
+  import TextInput from '$lib/components/text-input/text-input.svelte';
+  import DateInput from '$lib/components/date-picker/DateInput.svelte';
+  import FormField from '$lib/components/form-field/form-field.svelte';
+  import StandaloneFlowStepLayout from '$lib/components/standalone-flow-step-layout/standalone-flow-step-layout.svelte';
+  import AnnotationBox from '$lib/components/annotation-box/annotation-box.svelte';
+  import modal from '$lib/stores/modal';
+  import { updateWave } from '$lib/utils/wave/wavePrograms';
+  import type { WaveDto } from '$lib/utils/wave/types/waveProgram';
+
+  interface Props {
+    waveProgramId: string;
+    wave: WaveDto;
+    onUpdated: () => void;
+  }
+
+  let { waveProgramId, wave, onUpdated }: Props = $props();
+
+  // Active waves are extend-only: start date and budget are locked,
+  // and the end date can only be moved later (not earlier than the current end).
+  const isActive = wave.status === 'active';
+  const originalEndDate = new Date(wave.endDate);
+
+  let startDate = $state<Date | null>(new Date(wave.startDate));
+  let endDate = $state<Date | null>(new Date(wave.endDate));
+  let budgetUSD = $state<string>(String(wave.budgetUSD));
+  let submitting = $state(false);
+  let error = $state<string | null>(null);
+
+  const BUDGET_PATTERN = /^\d+(\.\d{1,2})?$/;
+
+  const budgetValid = $derived(BUDGET_PATTERN.test(budgetUSD));
+  const datesValid = $derived(
+    startDate !== null &&
+      endDate !== null &&
+      endDate.getTime() > startDate.getTime() &&
+      (!isActive || endDate.getTime() >= originalEndDate.getTime()),
+  );
+
+  const changes = $derived.by(() => {
+    const out: { startDate?: Date; endDate?: Date; budgetUSD?: string } = {};
+    if (!isActive && startDate && startDate.getTime() !== new Date(wave.startDate).getTime()) {
+      out.startDate = startDate;
+    }
+    if (endDate && endDate.getTime() !== originalEndDate.getTime()) {
+      out.endDate = endDate;
+    }
+    if (!isActive && budgetUSD !== String(wave.budgetUSD)) {
+      out.budgetUSD = budgetUSD;
+    }
+    return out;
+  });
+
+  const hasChanges = $derived(Object.keys(changes).length > 0);
+  const canSubmit = $derived(budgetValid && datesValid && hasChanges && !submitting);
+
+  const endDateValidationState = $derived.by(() => {
+    if (!isActive || !endDate) return undefined;
+    if (endDate.getTime() < originalEndDate.getTime()) {
+      return {
+        type: 'invalid' as const,
+        message: 'Active waves can only be extended — the end date cannot be moved earlier.',
+      };
+    }
+    return undefined;
+  });
+
+  const budgetValidationState = $derived.by(() => {
+    if (budgetUSD.length === 0) return undefined;
+    if (!BUDGET_PATTERN.test(budgetUSD)) {
+      return { type: 'invalid' as const, message: 'Must be a decimal number, e.g. "50000.00".' };
+    }
+    return { type: 'valid' as const };
+  });
+
+  async function handleSubmit() {
+    if (!canSubmit) return;
+
+    submitting = true;
+    error = null;
+
+    try {
+      await updateWave(fetch, waveProgramId, wave.id, changes);
+      onUpdated();
+      modal.hide();
+    } catch (e) {
+      error = e instanceof Error ? e.message : 'An unexpected error occurred.';
+    } finally {
+      submitting = false;
+    }
+  }
+</script>
+
+<div class="modal">
+  <StandaloneFlowStepLayout
+    headline={isActive ? `Extend Wave #${wave.waveNumber}` : `Edit Wave #${wave.waveNumber}`}
+    description={isActive
+      ? 'This wave is currently active, so it can only be extended. Move the end date later — start date and budget are locked.'
+      : 'Adjust the schedule or budget for this wave. End date must be after start date and the range must not overlap with any other wave.'}
+  >
+    <div class="fields">
+      <FormField title="Start date" type="div" disabled={isActive}>
+        <DateInput bind:value={startDate} timePrecision="minute" disabled={isActive} />
+      </FormField>
+
+      <FormField title="End date" type="div" validationState={endDateValidationState}>
+        <DateInput
+          bind:value={endDate}
+          timePrecision="minute"
+          min={isActive ? originalEndDate : undefined}
+        />
+      </FormField>
+
+      <FormField
+        title="Budget (USD)"
+        description="Total budget for this wave, in USD."
+        validationState={budgetValidationState}
+        disabled={isActive}
+      >
+        <TextInput bind:value={budgetUSD} placeholder="50000.00" disabled={isActive} />
+      </FormField>
+    </div>
+
+    {#if error}
+      <AnnotationBox type="error">{error}</AnnotationBox>
+    {/if}
+
+    {#snippet actions()}
+      <Button variant="normal" disabled={submitting} onclick={modal.hide}>Cancel</Button>
+      <Button variant="primary" loading={submitting} disabled={!canSubmit} onclick={handleSubmit}>
+        {isActive ? 'Extend wave' : 'Save changes'}
+      </Button>
+    {/snippet}
+  </StandaloneFlowStepLayout>
+</div>
+
+<style>
+  .modal {
+    padding: 1rem;
+  }
+
+  .fields {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+</style>


### PR DESCRIPTION
## Summary

Front-end for the new wave-admin endpoints (see matching wave PR: drips-network/wave#624), plus a small fix to the public wave program page so a current wave and an upcoming wave can both show at the same time.

### Admin
- New \"Waves\" card on `/wave/admin` (gated on `manageWaves`).
- `/wave/admin/waves` — lists wave programs with a \"Manage Waves\" link each.
- `/wave/admin/waves/[waveProgramId]` — lists scheduled waves with status badges and per-row actions:
  - **Schedule wave** (header action) opens a modal with start/end dates and a budget input pre-filled from the program's preset.
  - **Edit** (upcoming) opens the edit modal with all fields editable.
  - **Extend** (active) reuses the edit modal but locks start date + budget; end-date picker is clamped via \`min\` to the current end and validates inline.
  - **Delete** (upcoming only) — destructive variant, behind a confirmation modal + standard error-modal wrapper.
  - Ended waves are read-only — no actions.
- New API client helpers in \`wavePrograms.ts\`: \`manualCreateWave\`, \`updateWave\`, \`deleteWave\`.

### Public wave program page
- Previously: \`upcomingWave ?? activeWave\` collapsed both into one slot, so a program with both an active wave **and** an upcoming wave showed only the upcoming one.
- Now: separate \"Current Wave\" and \"Upcoming Waves\" sections.
- Upcoming section is hidden when there's a current wave but nothing scheduled (matches the user's preference — no noisy \"nothing here\" card alongside the live wave).
- The existing newsletter/Discord empty state is preserved for the no-active + no-upcoming case.

## Test plan

- [ ] As a user with the \`manageWaves\` permission, open \`/wave/admin\` and confirm the new \"Waves\" card appears.
- [ ] As a user without it, confirm the card does not appear and \`/wave/admin/waves\` redirects to \`/wave/admin\`.
- [ ] Schedule a new wave — confirm 201 and that it appears in the list with status \"upcoming\".
- [ ] Edit an upcoming wave — change start date, end date, budget independently.
- [ ] Try to edit an active wave — confirm start + budget are disabled, end-date picker cannot select a date earlier than the current end.
- [ ] Try to edit an ended wave — confirm no edit button shows.
- [ ] Delete an upcoming wave — confirmation, success toast, list refresh.
- [ ] Confirm no delete button on active / ended waves.
- [ ] Public page: navigate to a wave program with an active wave but no upcoming → only \"Current Wave\" shows.
- [ ] Public page: with active **and** upcoming → both sections show, current on top.
- [ ] Public page: with no active or upcoming → the newsletter/Discord empty state still renders.