### PR TITLE
fix(wave): swap repos-page org dropdown to lightweight one-shot endpoint

### DIFF
--- a/src/lib/components/wave/repos-filter-bar/repos-filter-bar.svelte
+++ b/src/lib/components/wave/repos-filter-bar/repos-filter-bar.svelte
@@ -3,7 +3,7 @@
   import Cross from '$lib/components/icons/Cross.svelte';
   import type {
     Tag,
-    WaveProgramOrgDto,
+    WaveProgramOrgFilterOptionDto,
     WaveProgramReposFilters,
     WaveProgramReposSortBy,
   } from '$lib/utils/wave/types/waveProgram';
@@ -26,7 +26,7 @@
   interface Props {
     filters: WaveProgramReposFilters;
     onFiltersChange: (filters: WaveProgramReposFilters) => void;
-    loadOrgs?: () => Promise<WaveProgramOrgDto[]>;
+    loadOrgs?: () => Promise<WaveProgramOrgFilterOptionDto[]>;
     loadTags?: () => Promise<Tag[]>;
   }
 

--- a/src/lib/utils/wave/types/waveProgram.ts
+++ b/src/lib/utils/wave/types/waveProgram.ts
@@ -249,6 +249,19 @@ export const waveProgramOrgDtoSchema = z.object({
 });
 export type WaveProgramOrgDto = z.infer<typeof waveProgramOrgDtoSchema>;
 
+export const waveProgramOrgFilterOptionDtoSchema = z.object({
+  id: z.uuid(),
+  gitHubOrgLogin: z.string(),
+  gitHubOrgName: z.string().nullable(),
+  gitHubOrgAvatarUrl: z.string().nullable(),
+  approvedRepoCount: z.number().int(),
+});
+export type WaveProgramOrgFilterOptionDto = z.infer<typeof waveProgramOrgFilterOptionDtoSchema>;
+
+export const waveProgramOrgFilterOptionsResponseDtoSchema = z.object({
+  data: z.array(waveProgramOrgFilterOptionDtoSchema),
+});
+
 export const waveProgramOrgsFiltersSchema = filterSchema(
   z.object({
     search: z.string().optional(),

--- a/src/lib/utils/wave/wavePrograms.ts
+++ b/src/lib/utils/wave/wavePrograms.ts
@@ -12,6 +12,7 @@ import {
   waveProgramDtoSchema,
   waveProgramIssueWithDetailsDtoSchema,
   waveProgramOrgDtoSchema,
+  waveProgramOrgFilterOptionsResponseDtoSchema,
   waveProgramOrgsFiltersSchema,
   waveProgramReposFiltersSchema,
   waveProgramRepoWithDetailsDtoSchema,
@@ -119,6 +120,13 @@ export async function getWaveProgramOrgs(
       f,
       `/api/wave-programs/${waveProgramId}/orgs?${toPaginationParams(pagination)}&${toFilterParams(waveProgramOrgsFiltersSchema, filters)}`,
     ),
+  );
+}
+
+export async function getWaveProgramOrgFilterOptions(f = fetch, waveProgramId: string) {
+  return parseRes(
+    waveProgramOrgFilterOptionsResponseDtoSchema,
+    await authenticatedCall(f, `/api/wave-programs/${waveProgramId}/orgs/filter-options`),
   );
 }
 

--- a/src/routes/(pages)/wave/(base-layout)/[waveProgramSlug]/repos/+page.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/[waveProgramSlug]/repos/+page.svelte
@@ -14,7 +14,10 @@
     WaveProgramRepoWithDetailsDto,
   } from '$lib/utils/wave/types/waveProgram';
   import type { Pagination } from '$lib/utils/wave/types/pagination';
-  import { getWaveProgramRepos, getWaveProgramOrgs } from '$lib/utils/wave/wavePrograms.js';
+  import {
+    getWaveProgramRepos,
+    getWaveProgramOrgFilterOptions,
+  } from '$lib/utils/wave/wavePrograms.js';
   import { getTags } from '$lib/utils/wave/tags.js';
   import { getAllPaginated } from '$lib/utils/wave/getAllPaginated.js';
   import type { Snapshot } from './$types.js';
@@ -24,8 +27,7 @@
   let { data } = $props();
   const { repos: initialRepos, waveProgram, filters } = $derived(data);
 
-  const loadOrgs = () =>
-    getAllPaginated((page, limit) => getWaveProgramOrgs(fetch, waveProgram.id, { page, limit }));
+  const loadOrgs = async () => (await getWaveProgramOrgFilterOptions(fetch, waveProgram.id)).data;
 
   const loadTags = () =>
     getAllPaginated((page, limit) => getTags(fetch, { page, pageSize: limit }));


### PR DESCRIPTION
Pairs with drips-network/wave#632, which addresses drips-network/wave issue #627.

## Summary

- The `/wave/<slug>/repos` page's Org filter dropdown was chaining `getAllPaginated(getWaveProgramOrgs, limit=100)` against the heavy `/api/wave-programs/:id/orgs` endpoint (full DTO with `contactInfo`, sequential round-trips per page). On a wave with many orgs (Stellar) this looked "forever-loading" to the user.
- Swap to `getWaveProgramOrgFilterOptions` (new) which calls `GET /api/wave-programs/:id/orgs/filter-options`. That endpoint returns every option in one Redis-cached response with only the fields the dropdown actually needs.
- Frontend types updated for the new lightweight DTO; `loadOrgs` prop on `ReposFilterBar` re-typed accordingly (no behavior change — it still only reads `id` + `gitHubOrgLogin`).
- The multi-tag selection bug (`tagId=uuid1,uuid2` → 500) is fixed on the backend in the paired PR; no frontend change was needed there.

## Test plan

- [x] `svelte-check` clean (0 errors)
- [x] Locally against the paired backend, open `/wave/stellar/repos`:
  - [x] Open the Org filter — dropdown loads near-instantly
  - [x] Open the Tag filter, select multiple tags — repo list reflects an OR match (any-of)
  - [x] Confirm no regressions on the existing Language filter