### PR TITLE
feat(wave): cursor pagination for the issues list (#635)

### DIFF
--- a/src/lib/components/wave/issues-page/issues-page.svelte
+++ b/src/lib/components/wave/issues-page/issues-page.svelte
@@ -107,11 +107,25 @@
     filters: IssueFilters,
     sort: IssueSortByOption,
   ) {
-    const nextPage = pagination.page + 1;
+    // Prefer keyset/cursor pagination when the backend provides a cursor —
+    // it's O(limit) regardless of depth and stable across inserts. Fall back to
+    // page-based for sorts the backend doesn't cursor-paginate (e.g. points)
+    // and for older backends that don't return nextCursor.
+    if (pagination.nextCursor) {
+      return await getIssues(
+        undefined,
+        { cursor: pagination.nextCursor, limit: pagination.limit },
+        filters,
+        sort,
+      );
+    }
 
-    if (!nextPage) return null;
-
-    return await getIssues(undefined, { page: nextPage, limit: pagination.limit }, filters, sort);
+    return await getIssues(
+      undefined,
+      { page: pagination.page + 1, limit: pagination.limit },
+      filters,
+      sort,
+    );
   }
 
   let filtersOpen = $state<boolean>(false);

--- a/src/lib/utils/wave/types/pagination.ts
+++ b/src/lib/utils/wave/types/pagination.ts
@@ -7,6 +7,10 @@ export const paginationSchema = z.object({
   totalPages: z.number().int(),
   hasNextPage: z.boolean(),
   hasPreviousPage: z.boolean(),
+  // Opaque keyset cursor for the next page, or null when there is none. Only
+  // present on endpoints that support cursor pagination (e.g. /api/issues for
+  // createdAt/updatedAt sorts). Absent on offset-only responses.
+  nextCursor: z.string().nullable().optional(),
 });
 export type Pagination = z.infer<typeof paginationSchema>;
 
@@ -24,6 +28,8 @@ export type PaginationInput =
   | {
       page?: number;
       limit?: number;
+      /** Keyset cursor from a prior response's `pagination.nextCursor`. */
+      cursor?: string;
     }
   | undefined;
 
@@ -36,6 +42,10 @@ export function toPaginationParams(pagination?: PaginationInput): string {
 
   if (pagination?.limit !== undefined) {
     params.append('limit', pagination.limit.toString());
+  }
+
+  if (pagination?.cursor !== undefined) {
+    params.append('cursor', pagination.cursor);
   }
 
   return params.toString();

--- a/src/lib/utils/wave/types/pagination.unit.test.ts
+++ b/src/lib/utils/wave/types/pagination.unit.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { paginationSchema, toPaginationParams } from './pagination';
+
+describe('toPaginationParams', () => {
+  it('returns an empty string when no input is given', () => {
+    expect(toPaginationParams()).toBe('');
+    expect(toPaginationParams(undefined)).toBe('');
+  });
+
+  it('serializes page and limit', () => {
+    expect(toPaginationParams({ page: 2, limit: 10 })).toBe('page=2&limit=10');
+  });
+
+  it('serializes a cursor (limit before cursor)', () => {
+    expect(toPaginationParams({ cursor: 'abc123', limit: 10 })).toBe('limit=10&cursor=abc123');
+  });
+
+  it('url-encodes the cursor value', () => {
+    expect(toPaginationParams({ cursor: 'a b/c=' })).toBe('cursor=a+b%2Fc%3D');
+  });
+});
+
+describe('paginationSchema', () => {
+  const base = {
+    total: 3,
+    page: 1,
+    limit: 10,
+    totalPages: 1,
+    hasNextPage: false,
+    hasPreviousPage: false,
+  };
+
+  it('accepts a response without nextCursor (offset mode)', () => {
+    expect(paginationSchema.parse(base).nextCursor).toBeUndefined();
+  });
+
+  it('accepts a string nextCursor', () => {
+    expect(paginationSchema.parse({ ...base, nextCursor: 'abc' }).nextCursor).toBe('abc');
+  });
+
+  it('accepts a null nextCursor (last page)', () => {
+    expect(paginationSchema.parse({ ...base, nextCursor: null }).nextCursor).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Migrates the Wave issues list to **keyset/cursor pagination**, paging the infinite scroll via the backend's `pagination.nextCursor` instead of incrementing `page`.

Deep page-based scrolling drove the slow `OFFSET` query path on `GET /api/issues` that pinned DB pool connections and caused production 5xx incidents (drips-network/wave#635). Cursor pagination is O(limit) regardless of depth.

**Depends on** the backend PR drips-network/wave#637 (which adds `pagination.nextCursor` and `?cursor=`).

## What changed

- `types/pagination.ts`: optional `cursor` input param + `nextCursor` response field (`string | null`).
- `toPaginationParams` emits the `cursor` query param.
- `issues-page.svelte` `getMoreIssues`: prefers `pagination.nextCursor`; falls back to `page + 1` for sorts the backend doesn't cursor-paginate (`points`) and for older backends that don't return `nextCursor`.

## Backwards compatibility

Fully backwards-compatible and safe to deploy in either order relative to the backend: when no `nextCursor` is returned (old backend, or `points` sort) it transparently uses page-based loading. The infinite-scroll terminator (`hasNextPage`) and match-count badge (`total`) are unchanged — both are still returned by the backend in cursor mode.

## Testing

- New `types/pagination.unit.test.ts`: `toPaginationParams` cursor serialization/encoding; `paginationSchema` accepts string/null/absent `nextCursor`.
- `npm run test:unit` → 93 passed.
- `npm run check` → 0 errors. eslint/prettier clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)