### PR TITLE
fix(wave): stop issue hover from refetching the whole issues list

### DIFF
--- a/src/lib/components/wave/issues-page/components/issues-list/components/issues-list-item.svelte
+++ b/src/lib/components/wave/issues-page/components/issues-list/components/issues-list-item.svelte
@@ -192,7 +192,7 @@
 
   <svelte:element
     this={selectable ? 'a' : 'div'}
-    href="/wave/maintainers/issues/{issue.id}?{page.url.searchParams}"
+    href="{pathPrefix}{issue.id}?{page.url.searchParams}"
     class="details"
   >
     {#if badges.length > 0}

--- a/src/lib/components/wave/issues-page/issues-page.svelte
+++ b/src/lib/components/wave/issues-page/issues-page.svelte
@@ -55,7 +55,6 @@
     noOfPreappliedFilters,
     filtersMode,
     availableSortByOptions,
-    isViewingIssue,
     headMetaTitle,
     currentWaveProgram,
     emptyStateAnnotation,
@@ -91,7 +90,6 @@
     filtersMode: 'maintainer' | 'contributor' | 'wave';
 
     availableSortByOptions: IssueSortByOption[];
-    isViewingIssue: boolean;
 
     headMetaTitle: string;
 
@@ -101,6 +99,11 @@
     /** Annotation to show when there are no issues */
     emptyStateAnnotation?: string;
   } = $props();
+
+  // Derived from the route rather than passed through the layout load — otherwise the load
+  // function would track the issueId param and refetch the whole issues list on every
+  // navigation to (or hover-preload of) a single issue.
+  let isViewingIssue = $derived(page.params.issueId !== undefined);
 
   async function getMoreIssues(
     pagination: Pagination,

--- a/src/lib/components/wave/issues-page/load-fns/issues-page-layout-load.ts
+++ b/src/lib/components/wave/issues-page/load-fns/issues-page-layout-load.ts
@@ -17,7 +17,6 @@ export const issuesPageLayoutLoad = async (
     url,
     depends,
     parent,
-    params,
   }: {
     fetch: typeof global.fetch;
     url: URL;
@@ -27,7 +26,6 @@ export const issuesPageLayoutLoad = async (
       waveProgram?: { id: string; slug: string };
       waves?: { data: Array<{ status: 'upcoming' | 'active' | 'ended' }> };
     }>;
-    params: { issueId?: string };
   },
   config: (user: WaveLoggedInUser | null) => {
     requireLogin?: boolean;
@@ -121,8 +119,6 @@ export const issuesPageLayoutLoad = async (
     (await getWavePrograms(fetch, { limit: 100 })).data,
   ]);
 
-  const isViewingIssue = params.issueId !== undefined;
-
   return {
     issues,
     appliedFilters: filters,
@@ -138,7 +134,6 @@ export const issuesPageLayoutLoad = async (
     viewKey,
     availableSortByOptions: availableSortByOptions ?? ['updatedAt', 'createdAt'],
     allowAddToWaveProgram: allowAddToWaveProgram ?? false,
-    isViewingIssue,
     headMetaTitle,
     showNewApplicationsBadge,
     currentWaveProgram: waveProgram,


### PR DESCRIPTION
Hovering an issue in the wave issue list kicked off the full issues list query (`/api/issues?...`) instead of fetching just that issue.

The issue detail route is nested under the issues list layout, whose load fetches the whole list via `getIssues`. That load also read `params.issueId` (to compute `isViewingIssue`), so SvelteKit tracked it as a dependency and reran the entire layout load — refetching the list — every time `issueId` changed. Combined with `data-sveltekit-preload-data="hover"`, that meant every hover refetched the list.

Fix derives `isViewingIssue` reactively from the route in `issues-page.svelte` instead, so the layout load no longer depends on `issueId`. Also fixes the list item's inner (selectable-mode) link, which hardcoded the maintainers path instead of using the context-aware `pathPrefix`.