### PR TITLE
feat(wave): per-Wave repo application limits in apply flow

### DIFF
--- a/src/lib/utils/wave/types/waveProgram.ts
+++ b/src/lib/utils/wave/types/waveProgram.ts
@@ -48,6 +48,8 @@ export const waveProgramDtoSchema = z.object({
   presetBudgetUSD: z.string(),
   repoPointsBudget: z.number().int().nullable(),
   orgPointsBudget: z.number().int().nullable(),
+  repoApplicationsLimitPerUser: z.number().int().nullable(),
+  repoApplicationsLimitPerOrg: z.number().int().nullable(),
   avatarUrl: z.url().nullable(),
   slug: z.string(),
   longDescription: z.string().nullable(),
@@ -141,6 +143,12 @@ export const waveProgramRepoWithDetailsDtoSchema = z.object({
   orgPointsUsed: z.number().int().optional(),
   orgPointsBudget: z.number().int().nullable().optional(),
   orgPointsRemaining: z.number().int().nullable().optional(),
+  userApplicationsUsed: z.number().int().optional(),
+  userApplicationsLimit: z.number().int().nullable().optional(),
+  userApplicationsRemaining: z.number().int().nullable().optional(),
+  orgApplicationsUsed: z.number().int().optional(),
+  orgApplicationsLimit: z.number().int().nullable().optional(),
+  orgApplicationsRemaining: z.number().int().nullable().optional(),
   pointsMultiplier: z.number().int().optional(),
   repo: z.object({
     stargazersCount: z.number().int().nullable().optional(),
@@ -327,3 +335,25 @@ export const waveDtoSchema = z.object({
   createdAt: z.coerce.date(),
 });
 export type WaveDto = z.infer<typeof waveDtoSchema>;
+
+// ===========================
+// Repo Application Limits
+// ===========================
+
+export const applicationLimitStatusSchema = z.object({
+  /** Applications counted toward the current wave cycle. */
+  used: z.number().int(),
+  /** Configured limit (null = unlimited). */
+  limit: z.number().int().nullable(),
+  /** Remaining slots (null = unlimited, can be negative if the limit was lowered). */
+  remaining: z.number().int().nullable(),
+});
+export type ApplicationLimitStatus = z.infer<typeof applicationLimitStatusSchema>;
+
+export const waveProgramApplicationLimitsDtoSchema = z.object({
+  /** Calling user's repo-application usage for the current wave cycle. */
+  perUser: applicationLimitStatusSchema,
+  /** Per-org usage for every org the calling user belongs to. */
+  perOrg: z.array(applicationLimitStatusSchema.extend({ orgId: z.uuid() })),
+});
+export type WaveProgramApplicationLimitsDto = z.infer<typeof waveProgramApplicationLimitsDtoSchema>;

--- a/src/lib/utils/wave/wavePrograms.ts
+++ b/src/lib/utils/wave/wavePrograms.ts
@@ -7,6 +7,7 @@ import {
 } from './types/pagination';
 import {
   batchApplyResponseSchema,
+  waveProgramApplicationLimitsDtoSchema,
   waveDtoSchema,
   waveFiltersSchema,
   waveProgramDtoSchema,
@@ -77,6 +78,13 @@ export async function batchApplyRepos(
         formData,
       }),
     }),
+  );
+}
+
+export async function getWaveProgramApplicationLimits(f = fetch, waveProgramId: string) {
+  return parseRes(
+    waveProgramApplicationLimitsDtoSchema,
+    await authenticatedCall(f, `/api/wave-programs/${waveProgramId}/repos/apply/limits`),
   );
 }
 

--- a/src/routes/(pages)/wave/(flows)/maintainer-onboarding/apply-to-wave-program/[waveProgramId]/+layout.ts
+++ b/src/routes/(pages)/wave/(flows)/maintainer-onboarding/apply-to-wave-program/[waveProgramId]/+layout.ts
@@ -1,13 +1,14 @@
 import { getPhoneVerificationRequired } from '$lib/utils/wave/users.js';
-import { getWaveProgram } from '$lib/utils/wave/wavePrograms.js';
+import { getWaveProgram, getWaveProgramApplicationLimits } from '$lib/utils/wave/wavePrograms.js';
 import { error, redirect } from '@sveltejs/kit';
 
 export const load = async ({ fetch, params, depends, url }) => {
   depends('wave:maintainer-onboarding-apply-to-wave');
 
-  const [waveProgram, phoneVerificationRequired] = await Promise.all([
+  const [waveProgram, phoneVerificationRequired, applicationLimits] = await Promise.all([
     getWaveProgram(fetch, params.waveProgramId),
     getPhoneVerificationRequired(fetch).catch(() => null),
+    getWaveProgramApplicationLimits(fetch, params.waveProgramId),
   ]);
 
   if (!waveProgram) {
@@ -23,5 +24,6 @@ export const load = async ({ fetch, params, depends, url }) => {
 
   return {
     waveProgram,
+    applicationLimits,
   };
 };

--- a/src/routes/(pages)/wave/(flows)/maintainer-onboarding/apply-to-wave-program/[waveProgramId]/+page.svelte
+++ b/src/routes/(pages)/wave/(flows)/maintainer-onboarding/apply-to-wave-program/[waveProgramId]/+page.svelte
@@ -1,71 +1,157 @@
 <script lang="ts">
-  import { goto } from '$app/navigation';
-  import AnnotationBox from '$lib/components/annotation-box/annotation-box.svelte';
   import Button from '$lib/components/button/button.svelte';
   import ArrowLeft from '$lib/components/icons/ArrowLeft.svelte';
   import ArrowRight from '$lib/components/icons/ArrowRight.svelte';
-  import ListSelect from '$lib/components/list-select/list-select.svelte';
-  import type { Items } from '$lib/components/list-select/list-select.types';
+  import AnnotationBox from '$lib/components/annotation-box/annotation-box.svelte';
   import Card from '$lib/components/wave/card/card.svelte';
-  import RepoBadge from '$lib/components/wave/repo-badge/repo-badge.svelte';
+  import GithubOrgBadge from '$lib/components/wave/github-org-badge/github-org-badge.svelte';
   import FlowStepWrapper from '../../../shared/flow-step-wrapper.svelte';
+  import type { ApplicationLimitStatus } from '$lib/utils/wave/types/waveProgram';
 
   let { data } = $props();
 
-  function checkAlreadyApplied(repoId: string) {
-    return data.ownWaveProgramRepos.data.some(
-      (ownWaveProgramRepo) =>
-        ownWaveProgramRepo.repo.id === repoId &&
-        ownWaveProgramRepo.waveProgramId === data.waveProgram.id,
-    );
-  }
+  const perUser = $derived(data.applicationLimits.perUser);
 
-  let items = $derived<Items>(
-    Object.fromEntries(
-      data.ownRepos
-        .sort((a, b) => a.gitHubRepoFullName.localeCompare(b.gitHubRepoFullName))
-        .map((repo) => [
-          repo.id,
-          {
-            type: 'selectable',
-            label: {
-              component: RepoBadge,
-              props: {
-                repo,
-                avatarUrl: data.ownOrgs.data.find((org) => org.org.id === repo.orgId)?.org
-                  .gitHubOrgAvatarUrl,
-              },
-            },
-            disabled: checkAlreadyApplied(repo.id),
-            text: checkAlreadyApplied(repo.id) ? 'Already applied' : undefined,
-            searchString: repo.gitHubRepoFullName,
-          },
-        ]),
-    ),
+  // The per-user limit is a single pool shared across every org, so it's the
+  // headline number. `null` = no personal limit.
+  let personalRemaining = $derived(
+    perUser.limit === null ? null : Math.max(perUser.remaining ?? 0, 0),
+  );
+  let perUserFull = $derived(perUser.limit !== null && personalRemaining === 0);
+
+  // Join the per-org usage rows with the org details so we can render names.
+  let orgRows = $derived(
+    data.applicationLimits.perOrg
+      .filter((row) => row.limit !== null)
+      .map((row) => ({
+        status: row,
+        org: data.ownOrgs.data.find((o) => o.org.id === row.orgId)?.org,
+      }))
+      .filter((row) => row.org !== undefined),
   );
 
-  let selected = $state<string[]>([]);
+  // Each repo counts against both the personal pool and its org, so an org only
+  // restricts you *further* when its own remaining is below your personal
+  // remaining. Orgs with more room than your personal cap can never be the
+  // binding limit, so we don't show them. When there's no personal limit, every
+  // org limit is binding.
+  let bindingOrgRows = $derived(
+    orgRows.filter(({ status }) => {
+      const orgRemaining = Math.max(status.remaining ?? 0, 0);
+      return personalRemaining === null || orgRemaining < personalRemaining;
+    }),
+  );
 
-  const STORAGE_KEY = `wave-apply-repos-${data.waveProgram.id}`;
+  let description = $derived.by(() => {
+    const name = data.waveProgram.name;
+    if (perUser.limit === null) {
+      return `${name} doesn't limit how many repos you can apply overall, but some of your organizations have their own per-cycle limit.`;
+    }
+    if (perUserFull) {
+      return `You've used all your repo applications for ${name} this Wave cycle. Your limit resets when the next Wave begins.`;
+    }
+    const n = personalRemaining ?? 0;
+    return `You can apply ${n} more ${
+      n === 1 ? 'repo' : 'repos'
+    } to ${name} this Wave cycle, across all your organizations.`;
+  });
 
-  function handleContinue() {
-    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(selected));
-    goto(`/wave/maintainer-onboarding/apply-to-wave-program/${data.waveProgram.id}/form`);
+  function orgRemainingLabel(status: ApplicationLimitStatus) {
+    const remaining = Math.max(status.remaining ?? 0, 0);
+    if (remaining === 0) return 'Org limit reached';
+    return `${remaining} of ${status.limit} remaining`;
+  }
+
+  function meterFraction(status: ApplicationLimitStatus) {
+    if (status.limit === null || status.limit === 0) return 0;
+    return Math.min(status.used / status.limit, 1);
+  }
+
+  function isFull(status: ApplicationLimitStatus) {
+    return status.limit !== null && (status.remaining ?? 0) <= 0;
   }
 </script>
 
-<FlowStepWrapper
-  headline="Pick repos to apply"
-  description="Choose which repos you'd like to apply to the {data.waveProgram.name} Wave Program."
->
-  <AnnotationBox>
-    Please apply related repos (e.g. backend, frontend, contracts for the same product) together.
-    You'll answer a few questions about them in the next step.
-  </AnnotationBox>
+<FlowStepWrapper headline="Application limits" {description}>
+  <Card style="text-align: left; width: 100%;">
+    <div class="limits">
+      {#if perUser.limit !== null}
+        <div class="limit-row">
+          <div class="limit-label">
+            <span class="typo-text-bold">Your applications</span>
+            <span class="typo-text-small subtle">Across all your organizations</span>
+          </div>
+          <div class="meter">
+            <div class="track">
+              <div
+                class="fill"
+                class:full={perUserFull}
+                style:width="{meterFraction(perUser) * 100}%"
+              ></div>
+            </div>
+            <span class="meter-label typo-text-small tnum" class:full={perUserFull}>
+              {Math.max(perUser.remaining ?? 0, 0)} of {perUser.limit} remaining
+            </span>
+          </div>
+        </div>
+      {/if}
 
-  <Card style="padding: 0; text-align: left; width: 100%;">
-    <ListSelect multiselect maxSelected={10} {items} bind:selected />
+      {#if bindingOrgRows.length > 0}
+        {#if perUser.limit !== null}
+          <div class="divider"></div>
+        {/if}
+        <div class="section-header">
+          <span class="typo-text-bold">Additional organization limits</span>
+          <span class="typo-text-small subtle">
+            {#if perUser.limit === null}
+              These organizations cap how many of their repos can be applied each Wave cycle, across
+              all their members — so you may be able to apply fewer repos from them than the counts
+              below suggest if other members have already applied.
+            {:else}
+              These organizations have fewer slots left than your personal limit, so they — not your
+              personal limit — are what restricts how many of their repos you can apply. The cap is
+              shared across all members of the organization.
+            {/if}
+          </span>
+        </div>
+        {#each bindingOrgRows as { status, org } (org!.id)}
+          <div class="limit-row">
+            <div class="limit-label">
+              <GithubOrgBadge org={org!} displayPersonalBadge={false} size="small" />
+            </div>
+            <span class="org-status typo-text-small tnum" class:full={isFull(status)}>
+              {orgRemainingLabel(status)}
+            </span>
+          </div>
+        {/each}
+      {/if}
+    </div>
   </Card>
+
+  {#if perUserFull}
+    <AnnotationBox type="warning">
+      You've reached your application limit for this Wave cycle, so you can't apply more repos right
+      now. Your limit resets when the next Wave begins.
+      <a
+        class="typo-link"
+        href="https://docs.drips.network/wave/maintainers/repo-application-limits"
+        target="_blank"
+        rel="noreferrer">Learn more</a
+      >
+    </AnnotationBox>
+  {:else}
+    <AnnotationBox type="info">
+      Limits reset at the start of each Wave cycle. Every repo you apply counts toward both your
+      personal limit and its organization's limit, and rejected applications still count for the
+      current cycle.
+      <a
+        class="typo-link"
+        href="https://docs.drips.network/wave/maintainers/repo-application-limits"
+        target="_blank"
+        rel="noreferrer">Learn more</a
+      >
+    </AnnotationBox>
+  {/if}
 
   {#snippet leftActions()}
     <Button icon={ArrowLeft} href="/wave/maintainer-onboarding/apply-to-wave-program"
@@ -76,9 +162,89 @@
   {#snippet actions()}
     <Button
       variant="primary"
-      disabled={selected.length === 0}
       icon={ArrowRight}
-      onclick={handleContinue}>Continue</Button
+      disabled={perUserFull}
+      href="/wave/maintainer-onboarding/apply-to-wave-program/{data.waveProgram.id}/select"
+      >Pick repos to apply</Button
     >
   {/snippet}
 </FlowStepWrapper>
+
+<style>
+  .limits {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .limit-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1.5rem;
+  }
+
+  .limit-label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+    min-width: 0;
+  }
+
+  .subtle {
+    color: var(--color-foreground-level-6);
+  }
+
+  .section-header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+  }
+
+  .divider {
+    height: 1px;
+    background-color: var(--color-foreground-level-2);
+    width: 100%;
+  }
+
+  .meter {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.25rem;
+    flex-shrink: 0;
+    min-width: 10rem;
+  }
+
+  .track {
+    width: 100%;
+    height: 0.5rem;
+    border-radius: 0.5rem;
+    background-color: var(--color-foreground-level-2);
+    overflow: hidden;
+  }
+
+  .fill {
+    height: 100%;
+    background-color: var(--color-primary-level-6);
+    transition: width 0.2s ease;
+  }
+
+  .fill.full {
+    background-color: var(--color-caution-level-6);
+  }
+
+  .meter-label {
+    color: var(--color-foreground-level-6);
+  }
+
+  .meter-label.full,
+  .org-status.full {
+    color: var(--color-caution-level-6);
+  }
+
+  .org-status {
+    color: var(--color-foreground-level-6);
+    flex-shrink: 0;
+  }
+</style>

--- a/src/routes/(pages)/wave/(flows)/maintainer-onboarding/apply-to-wave-program/[waveProgramId]/+page.ts
+++ b/src/routes/(pages)/wave/(flows)/maintainer-onboarding/apply-to-wave-program/[waveProgramId]/+page.ts
@@ -1,24 +1,25 @@
-import { getOrgs, getOwnRepos } from '$lib/utils/wave/orgs';
-import { getAllPaginated } from '$lib/utils/wave/getAllPaginated';
-import { getOwnWaveProgramRepos } from '$lib/utils/wave/wavePrograms.js';
+import { getOrgs } from '$lib/utils/wave/orgs';
 import { redirect } from '@sveltejs/kit';
 
-export const load = async ({ fetch, depends }) => {
-  depends('wave:maintainer-onboarding-apply-to-wave');
+export const load = async ({ fetch, params, parent }) => {
+  const { applicationLimits } = await parent();
 
-  const [ownRepos, ownOrgs, ownWaveProgramRepos] = await Promise.all([
-    getAllPaginated((page, limit) => getOwnRepos(fetch, { page, limit })),
-    getOrgs(fetch, { limit: 100 }),
-    getOwnWaveProgramRepos(fetch, { limit: 100 }),
-  ]);
+  // When the program imposes no limits at all, the limits step adds nothing —
+  // skip straight to repo selection.
+  const hasAnyLimit =
+    applicationLimits.perUser.limit !== null ||
+    applicationLimits.perOrg.some((org) => org.limit !== null);
 
-  if (ownRepos.length === 0) {
-    throw redirect(302, '/wave/maintainer-onboarding/install-app');
+  if (!hasAnyLimit) {
+    throw redirect(
+      302,
+      `/wave/maintainer-onboarding/apply-to-wave-program/${params.waveProgramId}/select`,
+    );
   }
 
+  const ownOrgs = await getOrgs(fetch, { limit: 100 });
+
   return {
-    ownRepos,
     ownOrgs,
-    ownWaveProgramRepos,
   };
 };

--- a/src/routes/(pages)/wave/(flows)/maintainer-onboarding/apply-to-wave-program/[waveProgramId]/form/+page.svelte
+++ b/src/routes/(pages)/wave/(flows)/maintainer-onboarding/apply-to-wave-program/[waveProgramId]/form/+page.svelte
@@ -37,7 +37,7 @@
     }
 
     if (repoIds.length === 0) {
-      goto(`/wave/maintainer-onboarding/apply-to-wave-program/${data.waveProgram.id}`);
+      goto(`/wave/maintainer-onboarding/apply-to-wave-program/${data.waveProgram.id}/select`);
     }
   });
 
@@ -120,11 +120,43 @@
       (forkJustification.trim().length >= 1 && forkJustification.length <= 5000),
   );
 
+  // Defense-in-depth: selection is already capped on the previous step, but
+  // re-check the configured application limits here so a stale/tampered
+  // sessionStorage selection surfaces a clear message instead of a raw 400.
+  let limitViolation = $derived.by<string | null>(() => {
+    const { perUser, perOrg } = data.applicationLimits;
+
+    if (perUser.limit !== null && (perUser.remaining ?? 0) < repoIds.length) {
+      return `You can only apply ${Math.max(perUser.remaining ?? 0, 0)} more ${
+        (perUser.remaining ?? 0) === 1 ? 'repo' : 'repos'
+      } this Wave cycle. Remove some repos to continue.`;
+    }
+
+    const countByOrg: Record<string, number> = {};
+    for (const repo of selectedRepos) {
+      countByOrg[repo.orgId] = (countByOrg[repo.orgId] ?? 0) + 1;
+    }
+    for (const [orgId, count] of Object.entries(countByOrg)) {
+      const status = perOrg.find((o) => o.orgId === orgId);
+      if (status && status.limit !== null && (status.remaining ?? 0) < count) {
+        return `One of your organizations has only ${Math.max(
+          status.remaining ?? 0,
+          0,
+        )} application ${
+          (status.remaining ?? 0) === 1 ? 'slot' : 'slots'
+        } left this Wave cycle. Remove some of its repos to continue.`;
+      }
+    }
+
+    return null;
+  });
+
   let formValid = $derived(
     plannedIssuesValid &&
       repoRelationshipValid &&
       upstreamRelationshipValid &&
-      forkJustificationValid,
+      forkJustificationValid &&
+      !limitViolation,
   );
 
   let previousParticipationItems: Items = {
@@ -384,6 +416,12 @@ There's no wrong answer. We need this context to review forks accurately.`}
       </div>
     </FormField>
 
+    {#if limitViolation}
+      <AnnotationBox type="error">
+        {limitViolation}
+      </AnnotationBox>
+    {/if}
+
     <AnnotationBox>
       By submitting this application, you confirm that all provided information is accurate.
       Inaccurate information may result in your application being rejected and could lead to
@@ -394,7 +432,7 @@ There's no wrong answer. We need this context to review forks accurately.`}
   {#snippet leftActions()}
     <Button
       icon={ArrowLeft}
-      href="/wave/maintainer-onboarding/apply-to-wave-program/{data.waveProgram.id}"
+      href="/wave/maintainer-onboarding/apply-to-wave-program/{data.waveProgram.id}/select"
       >Back to repo selection</Button
     >
   {/snippet}

--- a/src/routes/(pages)/wave/(flows)/maintainer-onboarding/apply-to-wave-program/[waveProgramId]/select/+page.svelte
+++ b/src/routes/(pages)/wave/(flows)/maintainer-onboarding/apply-to-wave-program/[waveProgramId]/select/+page.svelte
@@ -31,13 +31,15 @@
     perUser.remaining === null ? HARD_MAX : Math.min(HARD_MAX, Math.max(perUser.remaining, 0)),
   );
 
-  function checkAlreadyApplied(repoId: string) {
-    return data.ownWaveProgramRepos.data.some(
-      (ownWaveProgramRepo) =>
-        ownWaveProgramRepo.repo.id === repoId &&
-        ownWaveProgramRepo.waveProgramId === data.waveProgram.id,
-    );
-  }
+  // Repo IDs already applied to this program, for O(1) lookups while building
+  // the list.
+  let appliedRepoIds = $derived(
+    new Set(
+      data.ownWaveProgramRepos.data
+        .filter((r) => r.waveProgramId === data.waveProgram.id)
+        .map((r) => r.repo.id),
+    ),
+  );
 
   let selected = $state<string[]>([]);
 
@@ -61,10 +63,10 @@
 
   let items = $derived<Items>(
     Object.fromEntries(
-      data.ownRepos
+      [...data.ownRepos]
         .sort((a, b) => a.gitHubRepoFullName.localeCompare(b.gitHubRepoFullName))
         .map((repo) => {
-          const alreadyApplied = checkAlreadyApplied(repo.id);
+          const alreadyApplied = appliedRepoIds.has(repo.id);
           const slotsLeft = orgSlotsLeft(repo.orgId);
           const isSelected = selected.includes(repo.id);
           // Block selecting more repos from an org than it has slots left.

--- a/src/routes/(pages)/wave/(flows)/maintainer-onboarding/apply-to-wave-program/[waveProgramId]/select/+page.svelte
+++ b/src/routes/(pages)/wave/(flows)/maintainer-onboarding/apply-to-wave-program/[waveProgramId]/select/+page.svelte
@@ -1,0 +1,150 @@
+<script lang="ts">
+  import { goto } from '$app/navigation';
+  import AnnotationBox from '$lib/components/annotation-box/annotation-box.svelte';
+  import Button from '$lib/components/button/button.svelte';
+  import ArrowLeft from '$lib/components/icons/ArrowLeft.svelte';
+  import ArrowRight from '$lib/components/icons/ArrowRight.svelte';
+  import ListSelect from '$lib/components/list-select/list-select.svelte';
+  import type { Items } from '$lib/components/list-select/list-select.types';
+  import Card from '$lib/components/wave/card/card.svelte';
+  import RepoBadge from '$lib/components/wave/repo-badge/repo-badge.svelte';
+  import FlowStepWrapper from '../../../../shared/flow-step-wrapper.svelte';
+
+  let { data } = $props();
+
+  // Hard cap on a single batch, independent of any configured limit.
+  const HARD_MAX = 10;
+
+  const perUser = $derived(data.applicationLimits.perUser);
+  let orgStatusByOrgId = $derived(
+    new Map(data.applicationLimits.perOrg.map((o) => [o.orgId, o] as const)),
+  );
+
+  // Whether the dedicated limits step exists (it's skipped entirely when the
+  // program imposes no limits), so "back" lands on the right place.
+  let hasAnyLimit = $derived(
+    perUser.limit !== null || data.applicationLimits.perOrg.some((o) => o.limit !== null),
+  );
+
+  // Cap the whole selection to the user's remaining per-user slots (when limited).
+  let maxSelected = $derived(
+    perUser.remaining === null ? HARD_MAX : Math.min(HARD_MAX, Math.max(perUser.remaining, 0)),
+  );
+
+  function checkAlreadyApplied(repoId: string) {
+    return data.ownWaveProgramRepos.data.some(
+      (ownWaveProgramRepo) =>
+        ownWaveProgramRepo.repo.id === repoId &&
+        ownWaveProgramRepo.waveProgramId === data.waveProgram.id,
+    );
+  }
+
+  let selected = $state<string[]>([]);
+
+  // How many of the currently-selected repos belong to each org.
+  let selectedCountByOrg = $derived.by(() => {
+    const counts: Record<string, number> = {};
+    for (const id of selected) {
+      const repo = data.ownRepos.find((r) => r.id === id);
+      if (!repo) continue;
+      counts[repo.orgId] = (counts[repo.orgId] ?? 0) + 1;
+    }
+    return counts;
+  });
+
+  // New applications still allowed for an org this cycle (null = unlimited).
+  function orgSlotsLeft(orgId: string): number | null {
+    const status = orgStatusByOrgId.get(orgId);
+    if (!status || status.limit === null) return null;
+    return Math.max(status.remaining ?? 0, 0);
+  }
+
+  let items = $derived<Items>(
+    Object.fromEntries(
+      data.ownRepos
+        .sort((a, b) => a.gitHubRepoFullName.localeCompare(b.gitHubRepoFullName))
+        .map((repo) => {
+          const alreadyApplied = checkAlreadyApplied(repo.id);
+          const slotsLeft = orgSlotsLeft(repo.orgId);
+          const isSelected = selected.includes(repo.id);
+          // Block selecting more repos from an org than it has slots left.
+          const orgLimitReached =
+            !isSelected && slotsLeft !== null && (selectedCountByOrg[repo.orgId] ?? 0) >= slotsLeft;
+
+          return [
+            repo.id,
+            {
+              type: 'selectable',
+              label: {
+                component: RepoBadge,
+                props: {
+                  repo,
+                  avatarUrl: data.ownOrgs.data.find((org) => org.org.id === repo.orgId)?.org
+                    .gitHubOrgAvatarUrl,
+                },
+              },
+              disabled: alreadyApplied || orgLimitReached,
+              text: alreadyApplied
+                ? 'Already applied'
+                : orgLimitReached
+                  ? 'Org limit reached'
+                  : undefined,
+              searchString: repo.gitHubRepoFullName,
+            },
+          ];
+        }),
+    ),
+  );
+
+  const STORAGE_KEY = `wave-apply-repos-${data.waveProgram.id}`;
+
+  function handleContinue() {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(selected));
+    goto(`/wave/maintainer-onboarding/apply-to-wave-program/${data.waveProgram.id}/form`);
+  }
+</script>
+
+<FlowStepWrapper
+  headline="Pick repos to apply"
+  description="Choose which repos you'd like to apply to the {data.waveProgram.name} Wave Program."
+>
+  <AnnotationBox>
+    Please apply related repos (e.g. backend, frontend, contracts for the same product) together.
+    You'll answer a few questions about them in the next step.
+  </AnnotationBox>
+
+  {#if perUser.limit !== null}
+    <AnnotationBox type="info">
+      You can apply {Math.max(perUser.remaining ?? 0, 0)} more
+      {(perUser.remaining ?? 0) === 1 ? 'repo' : 'repos'} this Wave cycle. Repos from organizations that
+      have reached their limit can't be selected.
+    </AnnotationBox>
+  {/if}
+
+  <Card style="padding: 0; text-align: left; width: 100%;">
+    <ListSelect multiselect {maxSelected} {items} bind:selected />
+  </Card>
+
+  {#snippet leftActions()}
+    {#if hasAnyLimit}
+      <Button
+        icon={ArrowLeft}
+        href="/wave/maintainer-onboarding/apply-to-wave-program/{data.waveProgram.id}"
+        >Application limits</Button
+      >
+    {:else}
+      <Button icon={ArrowLeft} href="/wave/maintainer-onboarding/apply-to-wave-program"
+        >Choose Wave Program</Button
+      >
+    {/if}
+  {/snippet}
+
+  {#snippet actions()}
+    <Button
+      variant="primary"
+      disabled={selected.length === 0}
+      icon={ArrowRight}
+      onclick={handleContinue}>Continue</Button
+    >
+  {/snippet}
+</FlowStepWrapper>

--- a/src/routes/(pages)/wave/(flows)/maintainer-onboarding/apply-to-wave-program/[waveProgramId]/select/+page.ts
+++ b/src/routes/(pages)/wave/(flows)/maintainer-onboarding/apply-to-wave-program/[waveProgramId]/select/+page.ts
@@ -1,0 +1,24 @@
+import { getOrgs, getOwnRepos } from '$lib/utils/wave/orgs';
+import { getAllPaginated } from '$lib/utils/wave/getAllPaginated';
+import { getOwnWaveProgramRepos } from '$lib/utils/wave/wavePrograms.js';
+import { redirect } from '@sveltejs/kit';
+
+export const load = async ({ fetch, depends }) => {
+  depends('wave:maintainer-onboarding-apply-to-wave');
+
+  const [ownRepos, ownOrgs, ownWaveProgramRepos] = await Promise.all([
+    getAllPaginated((page, limit) => getOwnRepos(fetch, { page, limit })),
+    getOrgs(fetch, { limit: 100 }),
+    getOwnWaveProgramRepos(fetch, { limit: 100 }),
+  ]);
+
+  if (ownRepos.length === 0) {
+    throw redirect(302, '/wave/maintainer-onboarding/install-app');
+  }
+
+  return {
+    ownRepos,
+    ownOrgs,
+    ownWaveProgramRepos,
+  };
+};


### PR DESCRIPTION
Frontend for the per-Wave repo application limits (backend: wave PR #599 / issue #591). Adds a step that shows remaining limits per Wave cycle and enforces them up front in the rest of the apply flow.

## Summary

- **New "Application limits" step** at the start of the apply flow (`[waveProgramId]/`). Leads with the user's **personal** remaining applications for the cycle, and surfaces only the organizations whose own remaining slots are *lower* than the personal remaining (the only ones that can bind further). Auto-skips to repo selection when the Program has no limits configured, so unlimited Programs get zero added friction.
- **Repo selection moved to `[waveProgramId]/select/`** and now enforces limits up front: total selection is capped at the per-user remaining, and repos from an org that has reached its limit are disabled ("Org limit reached") dynamically as you select.
- **Form step**: defense-in-depth re-check against the limits (guards stale/tampered `sessionStorage`), disabling submit with a clear message instead of surfacing a raw 400.
- Limits are loaded once in `[waveProgramId]/+layout.ts` and shared across steps.
- Data layer: `getWaveProgramApplicationLimits()` client fn + `waveProgramApplicationLimitsDtoSchema`, plus the new limit fields on the program and batch-apply-response schemas.
- "Learn more" link points to the new docs page (drips-network/docs#61).

## Model

Per-user and per-org limits are **AND** constraints — each application counts toward both, and the per-user limit is a single pool shared across all of a user's orgs. The UI leads with the personal number so an org showing plenty of room doesn't imply you can apply more than your personal allowance permits.

## Test plan

- [x] `svelte-check`: 0 errors
- [x] `eslint` / `prettier`: clean
- [ ] Manual smoke: walk the three cases (personal limit with room, personal limit reached, no personal limit + org limits) and confirm enforcement in selection + form.

> Depends on backend wave PR #599 endpoints (`GET /repos/apply/limits`, batch-apply response fields).