### PR TITLE
feat(wave): require KYC to apply repos to a wave program

### DIFF
--- a/src/routes/(pages)/wave/(flows)/kyc-required/+page.svelte
+++ b/src/routes/(pages)/wave/(flows)/kyc-required/+page.svelte
@@ -19,7 +19,7 @@
   <div class="container">
     <AnnotationBox type="warning">
       <span class="typo-text-small-bold"
-        >A verified identity is required for applying to issues</span
+        >A verified identity is required for applying to issues and applying repos to a Wave Program</span
       >
       to avoid problems during reward withdrawals later.
       {#snippet actions()}

--- a/src/routes/(pages)/wave/(flows)/kyc/success/+page.svelte
+++ b/src/routes/(pages)/wave/(flows)/kyc/success/+page.svelte
@@ -15,18 +15,13 @@
 >
   <AnnotationBox type="info">
     We will notify you via email once your KYC has been approved. This is usually fast, but may take
-    1-3 business days. You can check on the status of your identity verification anytime in
+    1-3 business days. You can check on the status of your identity verification anytime in Profile
     Settings.
-
-    <p style:margin-top="1rem" class="typo-text-small-bold">
-      If you haven't already, please ensure you have any relevant payout addresses configured in
-      order to be eligible for Wave rewards.
-    </p>
   </AnnotationBox>
 
   {#snippet actions()}
     <Button variant="primary" icon={ArrowRight} href="/wave/settings/identity-and-payments">
-      Review payout settings
+      Profile settings
     </Button>
   {/snippet}
 </FlowStepWrapper>

--- a/src/routes/(pages)/wave/(flows)/maintainer-onboarding/apply-to-wave-program/[waveProgramId]/form/+page.svelte
+++ b/src/routes/(pages)/wave/(flows)/maintainer-onboarding/apply-to-wave-program/[waveProgramId]/form/+page.svelte
@@ -298,6 +298,7 @@ Describe the types of work you'd post — bug fixes, new features, documentation
       <TextArea
         bind:value={plannedIssuesDescription}
         placeholder="We plan to add issues related to..."
+        disabled={!data.isKycVerified}
         onblur={() => touch('plannedIssues')}
       />
       <div class="char-count">
@@ -326,6 +327,7 @@ Describe the types of work you'd post — bug fixes, new features, documentation
         <TextArea
           bind:value={repoRelationshipDescription}
           placeholder="These repos are related because..."
+          disabled={!data.isKycVerified}
           onblur={() => touch('repoRelationship')}
         />
         <div class="char-count">
@@ -360,6 +362,7 @@ Describe the types of work you'd post — bug fixes, new features, documentation
         <TextArea
           bind:value={upstreamRelationshipDescription}
           placeholder="The relationship to the upstream repo is..."
+          disabled={!data.isKycVerified}
           onblur={() => touch('upstreamRelationship')}
         />
         <div class="char-count">
@@ -391,6 +394,7 @@ There's no wrong answer. We need this context to review forks accurately.`}
         <TextArea
           bind:value={forkJustification}
           placeholder="We are applying with this fork because..."
+          disabled={!data.isKycVerified}
           onblur={() => touch('forkJustification')}
         />
         <div class="char-count">
@@ -412,7 +416,12 @@ There's no wrong answer. We need this context to review forks accurately.`}
           {#each supportingLinks as link, i (link)}
             <li>
               <span class="typo-text link-url">{link}</span>
-              <Button size="small" icon={Trash} onclick={() => removeLink(i)}>Remove</Button>
+              <Button
+                size="small"
+                icon={Trash}
+                disabled={!data.isKycVerified}
+                onclick={() => removeLink(i)}>Remove</Button
+              >
             </li>
           {/each}
         </ul>
@@ -421,7 +430,7 @@ There's no wrong answer. We need this context to review forks accurately.`}
         <TextInput
           bind:value={newLink}
           placeholder={supportingLinks.length >= 10 ? 'Link limit reached' : 'https://...'}
-          disabled={supportingLinks.length >= 10}
+          disabled={supportingLinks.length >= 10 || !data.isKycVerified}
           onkeydown={(e) => {
             if (e.key === 'Enter') {
               e.preventDefault();
@@ -432,7 +441,7 @@ There's no wrong answer. We need this context to review forks accurately.`}
         <Button
           size="large"
           icon={Plus}
-          disabled={!newLinkIsValid || supportingLinks.length >= 10}
+          disabled={!newLinkIsValid || supportingLinks.length >= 10 || !data.isKycVerified}
           onclick={addLink}>Add link</Button
         >
       </div>

--- a/src/routes/(pages)/wave/(flows)/maintainer-onboarding/apply-to-wave-program/[waveProgramId]/form/+page.svelte
+++ b/src/routes/(pages)/wave/(flows)/maintainer-onboarding/apply-to-wave-program/[waveProgramId]/form/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { beforeNavigate, goto } from '$app/navigation';
+  import { page } from '$app/state';
   import AnnotationBox from '$lib/components/annotation-box/annotation-box.svelte';
   import Button from '$lib/components/button/button.svelte';
   import ArrowLeft from '$lib/components/icons/ArrowLeft.svelte';
@@ -246,15 +247,31 @@
       {/snippet}
     </AnnotationBox>
   {:else}
+    {#if !data.isKycVerified}
+      <AnnotationBox type="error">
+        <span class="typo-text-small-bold">Identity verification (KYC) required</span><br />
+        A verified identity is required to apply repositories to a Wave Program to protect program integrity.
+        After your identity has been verified, return here to continue.
+        {#snippet actions()}
+          <Button
+            href={`/wave/kyc?backTo=${encodeURIComponent(page.url.pathname + page.url.search)}`}
+          >
+            Verify identity
+          </Button>
+        {/snippet}
+      </AnnotationBox>
+    {/if}
     <FormField
       title="Previous participation"
       description="Have you previously participated in any of the following programs? Select all that apply."
       type="div"
+      disabled={!data.isKycVerified}
     >
       <Card style="padding: 0; text-align: left; width: 100%;">
         <ListSelect
           multiselect
           searchable={false}
+          blockInteraction={!data.isKycVerified}
           items={previousParticipationItems}
           bind:selected={previousParticipation}
         />
@@ -267,6 +284,7 @@
 
 Describe the types of work you'd post — bug fixes, new features, documentation, testing, etc.`}
       type="div"
+      disabled={!data.isKycVerified}
       validationState={touched['plannedIssues'] && !plannedIssuesValid
         ? {
             type: 'invalid',
@@ -294,6 +312,7 @@ Describe the types of work you'd post — bug fixes, new features, documentation
         title="Repo relationship*"
         description="You selected multiple repos. Please describe how they are related to each other."
         type="div"
+        disabled={!data.isKycVerified}
         validationState={touched['repoRelationship'] && !repoRelationshipValid
           ? {
               type: 'invalid',
@@ -327,6 +346,7 @@ Describe the types of work you'd post — bug fixes, new features, documentation
         title="Upstream relationship*"
         description="Describe the relationship between your fork(s) and the upstream repo(s)."
         type="div"
+        disabled={!data.isKycVerified}
         validationState={touched['upstreamRelationship'] && !upstreamRelationshipValid
           ? {
               type: 'invalid',
@@ -357,6 +377,7 @@ Describe the types of work you'd post — bug fixes, new features, documentation
 
 There's no wrong answer. We need this context to review forks accurately.`}
         type="div"
+        disabled={!data.isKycVerified}
         validationState={touched['forkJustification'] && !forkJustificationValid
           ? {
               type: 'invalid',
@@ -384,6 +405,7 @@ There's no wrong answer. We need this context to review forks accurately.`}
       title="Supporting links"
       description="Provide links to resources relevant to your project (e.g. website, documentation, social media, deployed contracts). Up to 10 links."
       type="div"
+      disabled={!data.isKycVerified}
     >
       {#if supportingLinks.length > 0}
         <ul class="links-list">
@@ -439,13 +461,25 @@ There's no wrong answer. We need this context to review forks accurately.`}
 
   {#snippet actions()}
     {#if !data.user?.restricted}
-      <Button
-        variant="primary"
-        disabled={!formValid}
-        icon={CheckCircle}
-        loading={applying}
-        onclick={handleApply}>Apply selected repos</Button
+      <div
+        style:display="flex"
+        style:flex-direction="column"
+        style:align-items="flex-end"
+        style:gap="0.5rem"
       >
+        <Button
+          variant="primary"
+          disabled={!formValid || !data.isKycVerified}
+          icon={CheckCircle}
+          loading={applying}
+          onclick={handleApply}>Apply selected repos</Button
+        >
+        {#if !data.isKycVerified}
+          <span class="typo-text-small" style:color="var(--color-negative-level-6)">
+            You must complete identity verification (KYC) before applying.
+          </span>
+        {/if}
+      </div>
     {/if}
   {/snippet}
 </FlowStepWrapper>

--- a/src/routes/(pages)/wave/(flows)/maintainer-onboarding/apply-to-wave-program/[waveProgramId]/form/+page.ts
+++ b/src/routes/(pages)/wave/(flows)/maintainer-onboarding/apply-to-wave-program/[waveProgramId]/form/+page.ts
@@ -1,10 +1,18 @@
 import { getOwnRepos } from '$lib/utils/wave/orgs';
 import { getAllPaginated } from '$lib/utils/wave/getAllPaginated';
+import { getKycStatus } from '$lib/utils/wave/kyc.js';
 
 export const load = async ({ fetch }) => {
-  const ownRepos = await getAllPaginated((page, limit) => getOwnRepos(fetch, { page, limit }));
+  const [ownRepos, kycStatus] = await Promise.all([
+    getAllPaginated((page, limit) => getOwnRepos(fetch, { page, limit })),
+    getKycStatus(fetch),
+  ]);
+
+  const isKycVerified =
+    kycStatus.status === 'applicantReviewed' && kycStatus.reviewAnswer === 'GREEN';
 
   return {
     ownRepos,
+    isKycVerified,
   };
 };


### PR DESCRIPTION
## What

Gate the repo-apply form behind a verified (GREEN) KYC, mirroring the established issue-application KYC pattern. Backend enforcement is in drips-network/wave#649.

## Changes

- **Repo-apply form** (`maintainer-onboarding/apply-to-wave-program/[waveProgramId]/form/`):
  - `+page.ts` now fetches `getKycStatus` and exposes `isKycVerified`.
  - `+page.svelte` shows an inline error `AnnotationBox` with a "Verify identity" link (`/wave/kyc?backTo=…`) when KYC isn't verified.
  - All form controls are disabled until KYC is GREEN. `disabled={!isKycVerified}` is passed directly to each control (TextAreas, supporting-link input, Add link/Remove buttons) — not just the `FormField` wrapper — so the gate can't be bypassed via keyboard navigation. The `ListSelect` uses `blockInteraction` for the same reason. The submit button is also disabled with helper text.
- **Post-login `kyc-required` reminder** copy now mentions both "applying to issues" and "applying repos to a Wave Program".
- **KYC success page** copy tidied to point users to Profile settings.

## UX note

This is inline gating (not a hard redirect): KYC isn't instant, so after submitting Sumsub the user lands on the success page with status `applicantPending`, and the form stays gated until KYC turns GREEN — same real-world behavior as issue applications.

## Related

Implements drips-network/wave#647 (tracking issue lives in the `wave` repo). Pairs with drips-network/wave#649 for the backend gate. Note: this does not auto-close anything in this repo — `#647` here is an unrelated issue.