### PR TITLE
feat(wave): contributor dashboard assignment filter

### DIFF
--- a/src/lib/components/wave/issues-page/components/filter-config/filter-config.svelte
+++ b/src/lib/components/wave/issues-page/components/filter-config/filter-config.svelte
@@ -21,17 +21,17 @@
         ],
       },
 
-      ...(ownUserId && mode === 'contributor'
+      ...(mode === 'contributor'
         ? {
-            assignedToUser: {
-              type: 'single-select',
+            assignment: {
+              type: 'dropdown',
               label: 'Assignment',
-              options: [
-                {
-                  label: 'Assigned to me',
-                  value: ownUserId,
-                },
-              ],
+              optionsPromise: Promise.resolve([
+                { label: 'Assigned to me or unassigned', value: 'mine-or-unassigned' },
+                { label: 'Assigned to me', value: 'mine' },
+                { label: 'Unassigned', value: 'unassigned' },
+                { label: 'Assigned to someone else', value: 'assigned-to-others' },
+              ]),
             },
           }
         : {}),

--- a/src/lib/components/wave/issues-page/components/filter-config/filter-config.svelte
+++ b/src/lib/components/wave/issues-page/components/filter-config/filter-config.svelte
@@ -191,7 +191,10 @@
     currentWaveProgram?: Pick<WaveProgramDto, 'id' | 'slug'>;
   } = $props();
 
-  let filters = $state<IssueFilters>(appliedFilters);
+  // Clone props into local state: `filters` is mutated in place by
+  // handleSelectFilter, so referencing `appliedFilters`/`defaultFilters`
+  // directly would write through and corrupt the props.
+  let filters = $state<IssueFilters>({ ...appliedFilters });
 
   function handleSelectFilter<K extends keyof IssueFilters>(
     filterKey: K,
@@ -212,13 +215,13 @@
 
   function handleClear() {
     filterItems.forEach((item) => item.clear());
-    filters = defaultFilters;
+    filters = { ...defaultFilters };
 
     onapply(filters);
   }
 
   export function reset() {
-    filters = appliedFilters;
+    filters = { ...appliedFilters };
   }
 
   let availableFilters = $state<ReturnType<typeof AVAILABLE_FILTERS>>({});

--- a/src/lib/utils/wave/types/issue.ts
+++ b/src/lib/utils/wave/types/issue.ts
@@ -23,6 +23,9 @@ export const issueFilters = filterSchema(
     applicantAssigned: booleanString.optional(),
     isInWaveProgram: booleanString.optional(),
     assignedToUser: z.uuid().optional(),
+    assignment: z
+      .enum(['mine-or-unassigned', 'mine', 'unassigned', 'assigned-to-others'])
+      .optional(),
     appliedToByUser: z.uuid().optional(),
     appliedToByUserCurrentWave: booleanString.optional(),
     resolvedByUserId: z.uuid().optional(),

--- a/src/routes/(pages)/wave/(base-layout)/contributors/issues/+layout.ts
+++ b/src/routes/(pages)/wave/(base-layout)/contributors/issues/+layout.ts
@@ -21,7 +21,7 @@ export const load = async (context) => {
       appliedToByUser: user?.id,
       appliedToByUserCurrentWave: true,
     },
-    defaultFilters: {},
+    defaultFilters: { state: 'open', assignment: 'mine-or-unassigned' },
     pathPrefix: '/wave/contributors/issues/',
     filtersMode: 'contributor',
     breadcrumbs: [{ label: 'Contributor Dashboard' }, { label: 'Issues' }],


### PR DESCRIPTION
## What

On the contributor dashboard (`/wave/contributors/issues`), replaces the single "Assigned to me" option with a 4-way single-select dropdown under **Assignment**:

- **Assigned to me or unassigned**
- **Assigned to me**
- **Unassigned**
- **Assigned to someone else**

And changes the view's default filters to **Open + "Assigned to me or unassigned"**.

## Why

Accepting one applicant doesn't reject the others, so an issue you applied to that was assigned to someone else still shows in your list, with no way to filter it out. "Assigned to me or unassigned" surfaces everything still relevant to you (hiding issues that went to someone else), and is now the default so the dashboard opens to the most useful view. Users can still freely change or reset the filters.

## How

- Adds the `assignment` enum to the issue filters schema; `toFilterParams` serializes it as `assignment=<value>` automatically.
- Renders the filter via the existing `DropdownFilterItem` with statically-resolved options; the value is an enum (no longer the user's UUID), and the backend resolves "me" from the already-preapplied `appliedToByUser`.
- Sets `defaultFilters: { state: 'open', assignment: 'mine-or-unassigned' }` on the contributor layout. Defaults apply only when the URL has no filters, and "Reset to default" restores them.

Requires the backend `assignment` param: drips-network/wave#661.

## Verification

`npm run check` passes (0 errors).