### PR TITLE
feat(wave): add CAPTCHA to repo application form

### DIFF
--- a/src/lib/utils/wave/wavePrograms.ts
+++ b/src/lib/utils/wave/wavePrograms.ts
@@ -68,6 +68,7 @@ export async function batchApplyRepos(
   waveProgramId: string,
   orgRepoIds: string[],
   formData: BatchApplyFormData,
+  turnstileToken?: string,
 ) {
   return parseRes(
     batchApplyResponseSchema,
@@ -77,6 +78,7 @@ export async function batchApplyRepos(
         orgRepoIds,
         formData,
       }),
+      headers: turnstileToken ? { 'x-turnstile-token': turnstileToken } : {},
     }),
   );
 }

--- a/src/routes/(pages)/wave/(flows)/maintainer-onboarding/apply-to-wave-program/[waveProgramId]/form/+page.svelte
+++ b/src/routes/(pages)/wave/(flows)/maintainer-onboarding/apply-to-wave-program/[waveProgramId]/form/+page.svelte
@@ -14,6 +14,7 @@
   import Plus from '$lib/components/icons/Plus.svelte';
   import Trash from '$lib/components/icons/Trash.svelte';
   import { batchApplyRepos } from '$lib/utils/wave/wavePrograms';
+  import Turnstile from '$lib/components/turnstile/turnstile.svelte';
   import doWithErrorModal from '$lib/utils/do-with-error-modal';
   import FlowStepWrapper from '../../../../shared/flow-step-wrapper.svelte';
   import type { PreviousParticipation } from '$lib/utils/wave/types/waveProgram';
@@ -152,12 +153,15 @@
     return null;
   });
 
+  let turnstileToken = $state<string | undefined>(undefined);
+
   let formValid = $derived(
     plannedIssuesValid &&
       repoRelationshipValid &&
       upstreamRelationshipValid &&
       forkJustificationValid &&
-      !limitViolation,
+      !limitViolation &&
+      !!turnstileToken,
   );
 
   let previousParticipationItems: Items = {
@@ -206,13 +210,21 @@
 
     try {
       await doWithErrorModal(async () => {
-        await batchApplyRepos(undefined, data.waveProgram.id, repoIds, {
-          previousParticipation: previousParticipation as PreviousParticipation[],
-          plannedIssuesDescription,
-          ...(multipleReposSelected ? { repoRelationshipDescription } : {}),
-          ...(anySelectedRepoIsFork ? { upstreamRelationshipDescription, forkJustification } : {}),
-          supportingLinks: supportingLinks.length > 0 ? supportingLinks : undefined,
-        });
+        await batchApplyRepos(
+          undefined,
+          data.waveProgram.id,
+          repoIds,
+          {
+            previousParticipation: previousParticipation as PreviousParticipation[],
+            plannedIssuesDescription,
+            ...(multipleReposSelected ? { repoRelationshipDescription } : {}),
+            ...(anySelectedRepoIsFork
+              ? { upstreamRelationshipDescription, forkJustification }
+              : {}),
+            supportingLinks: supportingLinks.length > 0 ? supportingLinks : undefined,
+          },
+          turnstileToken,
+        );
       });
 
       submittedSuccessfully = true;
@@ -458,6 +470,19 @@ There's no wrong answer. We need this context to review forks accurately.`}
       Inaccurate information may result in your application being rejected and could lead to
       disqualification from the Drips Wave Program.
     </AnnotationBox>
+
+    <FormField
+      title="Verification*"
+      description="Confirm you're not a robot with a quick check."
+      type="div"
+      disabled={!data.isKycVerified}
+    >
+      {#if data.isKycVerified}
+        <div class="turnstile-wrapper">
+          <Turnstile ontoken={(t) => (turnstileToken = t)} />
+        </div>
+      {/if}
+    </FormField>
   {/if}
 
   {#snippet leftActions()}
@@ -535,5 +560,10 @@ There's no wrong answer. We need this context to review forks accurately.`}
     display: flex;
     gap: 0.5rem;
     align-items: flex-start;
+  }
+
+  .turnstile-wrapper {
+    display: flex;
+    justify-content: flex-start;
   }
 </style>


### PR DESCRIPTION
Adds the Cloudflare Turnstile (CAPTCHA) check to the **repo application form** — the maintainer-onboarding "apply repos to a wave program" flow — mirroring the pattern already used on the issue application page.

This is the frontend counterpart required by the backend PR https://github.com/drips-network/wave/pull/662, which adds `requireCaptcha` to `POST /api/wave-programs/:waveProgramId/repos/apply`. Without this, that endpoint would reject submissions in environments where Turnstile is configured.

## Changes
- **`src/lib/utils/wave/wavePrograms.ts`** — `batchApplyRepos` now accepts an optional `turnstileToken` and forwards it as the `x-turnstile-token` header (only when present), matching `applyToWorkOnIssue`.
- **`.../apply-to-wave-program/[waveProgramId]/form/+page.svelte`** (last step of the repo application form):
  - Renders the existing reusable `Turnstile` widget in a `Verification*` `FormField` (shown once KYC is verified), just before the submit button.
  - Adds `turnstileToken` state and folds `!!turnstileToken` into `formValid`, so "Apply selected repos" stays disabled until the challenge is solved.
  - Passes the token into the `batchApplyRepos` call.

Reuses all existing Turnstile infra (`Turnstile` component, `PUBLIC_TURNSTILE_SITE_KEY`, the Cloudflare script in `app.html`) — same approach as the issue application page.

## Notes
- The backend middleware skips verification when `TURNSTILE_SECRET_KEY` is unset, so this is a no-op locally without the key.

## Verification
- `svelte-check` passes with 0 errors.