### PR TITLE
fix(wave): gate issues empty state on returned rows, not pagination.total

### DIFF
--- a/src/lib/components/wave/issues-page/issues-page.svelte
+++ b/src/lib/components/wave/issues-page/issues-page.svelte
@@ -429,7 +429,13 @@
         <div class="spinner">
           <Spinner />
         </div>
-      {:else if issues.pagination.total === 0}
+        <!-- Gate the empty state on the actual returned rows, NOT pagination.total.
+           The total is cached server-side with a short TTL (decoupled from the
+           per-mutation list-cache invalidation), so during a wave it can briefly
+           read 0 while freshly-labeled issues already match the filter. Keying off
+           data.length keeps the empty state consistent with what we actually show;
+           total stays purely the "N matches" badge above. -->
+      {:else if issues.data.length === 0}
         <div style="padding: 1rem; ">
           <p style="padding: 1rem; text-align: center; color: var(--color-foreground-level-5);">
             No issues found matching the selected filters.


### PR DESCRIPTION
## What

The issue browse renders its **"No issues found"** empty state when `pagination.total === 0` (`issues-page.svelte`). This change gates it on `issues.data.length === 0` instead.

## Why

The wave backend is about to cache the `/api/issues` pagination total separately (short TTL, in a namespace **not** wiped by the per-mutation `cache:issues:*` invalidation) to keep that `count()` off the DB connection-pool hot path during a wave.

A cached total can briefly read **0 while issues already match the filter** — most likely **right at wave open**, as maintainers label issues in. Gated on `total`, the browse would then show "No issues found" while real, freshly-added issues exist, for up to the cache TTL.

Gating on `data.length` keeps the empty state consistent with the rows we actually render. `pagination.total` stays purely the "N matches" badge, where brief staleness is harmless.

This is also the **correct invariant regardless of caching**: `total` and `data` come from two separate queries and can already disagree under concurrent mutation (just over a much smaller window today).

## Scope

- Pagination *navigation* is unaffected — the list is cursor / load-more driven (`nextCursor` / `hasNextPage`), never `total`.
- One-line conditional change + comment. No behavior change when the total is accurate.

Companion to the backend count-cache change (wave repo).