### PR TITLE
fix(wave): prevent issue page 500 on relative markdown links

### DIFF
--- a/src/lib/utils/build-external-url.test.ts
+++ b/src/lib/utils/build-external-url.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import buildExternalUrl from './build-external-url';
+
+describe('buildExternalUrl', () => {
+  it('wraps a valid absolute URL in the /external/ route', () => {
+    expect(buildExternalUrl('https://example.com/x')).toBe(
+      `/external/${encodeURIComponent('https://example.com/x')}`,
+    );
+  });
+
+  it('returns a non-absolute href unchanged instead of throwing', () => {
+    // Relative links reach this fn via user-authored markdown (e.g. issue bodies).
+    // `new URL()` would throw TypeError: Invalid URL and crash SSR.
+    expect(() => buildExternalUrl('README.md')).not.toThrow();
+    expect(buildExternalUrl('README.md')).toBe('README.md');
+    expect(buildExternalUrl('/contributing')).toBe('/contributing');
+  });
+});

--- a/src/lib/utils/build-external-url.ts
+++ b/src/lib/utils/build-external-url.ts
@@ -3,10 +3,19 @@
  * warns the user before sending them off to the external page.
  * @param href The href to build the link to.
  * @returns A link to `/external/` route, warning the user before
- * sending them off to the external page.
+ * sending them off to the external page. If `href` is not a valid
+ * absolute URL (e.g. a relative link coming from user-authored markdown
+ * such as a GitHub issue body), it is returned unchanged — there is no
+ * external destination to guard, and `new URL()` would otherwise throw
+ * `TypeError: Invalid URL` and crash server-side rendering.
  */
 export default function (href: string) {
-  const url = new URL(href);
+  let url: URL;
+  try {
+    url = new URL(href);
+  } catch {
+    return href;
+  }
   const encoded = encodeURIComponent(url.href);
 
   return `/external/${encoded}`;


### PR DESCRIPTION
## Problem
Opening a wave issue whose **body** contains a relative markdown link (e.g. ``[README.md](README.md)``, ``[lib.rs](contracts/escrow/src/lib.rs)``) returns a **500**. These bodies are common in the Stellar wave (AI-generated issues link to repo files).

SSR stack trace (captured on staging):
```
[500] GET /wave/contributors/issues/…
TypeError: Invalid URL
    at new URL (node:internal/url)
    at buildExternalUrl (build-external-url…)
    at _Renderer.link (markdown…)
    at marked (marked.esm.js)
```

`markdown.svelte` renders the body via `marked` and routes every link through `buildExternalUrl()`, which called `new URL(href)` **unguarded**. A non-absolute href makes `new URL` throw `TypeError: Invalid URL`.

It's **SSR-only**: client-side, `isDripsDomain()` resolves the relative URL against the page origin (so `buildExternalUrl` is skipped), but during SSR there's no origin, so the call runs and throws — crashing the whole page. That's why an in-app click renders fine while a hard load / refresh / shared link 500s, and why it was mistaken for an "assigned issues" problem (people opened their assigned issues directly).

## Fix
`buildExternalUrl` now returns the href unchanged when it isn't a valid absolute URL, instead of throwing. This also hardens the other ~12 call sites.

## Test
- `src/lib/utils/build-external-url.test.ts`: absolute URL is externalized; a non-absolute href returns unchanged and does not throw.

## How to verify
1. Set an issue body to ``[x](README.md)`` (e.g. edit the GitHub issue, or set `org_repo_issues.body` on staging).
2. **Hard-load** the issue detail page (address bar + Enter, or Cmd+Shift+R) — before: 500, after: 200 with the link rendered.
