### PR TITLE
feat(wave): report client-side load/render errors to Faro

### DIFF
--- a/src/hooks.client.ts
+++ b/src/hooks.client.ts
@@ -1,0 +1,26 @@
+import type { HandleClientError } from '@sveltejs/kit';
+import { pushError } from '$lib/utils/faro/faro-manager';
+
+/**
+ * SvelteKit only invokes `handleError` for *unexpected* errors — anything thrown
+ * via `error(...)` (e.g. expected 404s) is handled by SvelteKit directly and
+ * never reaches here. So every error that arrives is a genuine client-side
+ * crash (a throw in a `load` function or during rendering) that surfaces to the
+ * user as a full-page 500.
+ *
+ * These errors are caught by SvelteKit and therefore never reach
+ * `window.onerror` / `unhandledrejection`, which is all Faro's default
+ * instrumentation observes — so without this hook they're invisible in
+ * monitoring. Forward them to Faro explicitly.
+ */
+export const handleError: HandleClientError = ({ error, event, status, message }) => {
+  const reported = error instanceof Error ? error : new Error(message);
+
+  pushError(reported, {
+    route: event.route.id ?? 'unknown',
+    url: event.url.pathname,
+    status: String(status),
+  });
+
+  // Don't alter what the user sees — keep SvelteKit's default message.
+};

--- a/src/lib/utils/faro/faro-manager.ts
+++ b/src/lib/utils/faro/faro-manager.ts
@@ -1,13 +1,15 @@
-import { getWebInstrumentations, initializeFaro } from '@grafana/faro-web-sdk';
+import { getWebInstrumentations, initializeFaro, type Faro } from '@grafana/faro-web-sdk';
 import { TracingInstrumentation } from '@grafana/faro-web-tracing';
 import getOptionalEnvVar from '../get-optional-env-var/public';
+
+let faro: Faro | null = null;
 
 export const init = () => {
   const FARO_ENABLED = getOptionalEnvVar('PUBLIC_FARO_ENABLED', false, null);
   const FARO_ENVIRONMENT = getOptionalEnvVar('PUBLIC_FARO_ENVIRONMENT', false, null);
 
   if (FARO_ENABLED === 'true' && FARO_ENVIRONMENT) {
-    initializeFaro({
+    faro = initializeFaro({
       url: 'https://faro-collector-prod-eu-west-2.grafana.net/collect/0a4519657ebc92ca47d9271be5503b63',
       app: {
         name: 'app',
@@ -24,4 +26,18 @@ export const init = () => {
       ],
     });
   }
+};
+
+/**
+ * Forwards an error to Faro, if monitoring is active. No-ops when Faro isn't
+ * initialized (e.g. the user hasn't consented to monitoring, or
+ * `PUBLIC_FARO_ENABLED` is off), so it's always safe to call.
+ *
+ * Faro's default web instrumentation only captures errors that reach
+ * `window.onerror` / `unhandledrejection`. SvelteKit catches errors thrown in
+ * `load`/rendering itself, so those never surface to Faro unless we report them
+ * explicitly from the client `handleError` hook.
+ */
+export const pushError = (error: Error, context?: Record<string, string>) => {
+  faro?.api.pushError(error, context ? { context } : undefined);
 };


### PR DESCRIPTION
## Problem

Users have reported seeing a full-page **Error 500** ("Something went wrong on our end" 💀) when viewing an issue on the contributor dashboard — the screen `SingleIssueError` renders when `page.status === 500`.

That status comes from an unexpected error thrown in a client-side `load` function (e.g. a zod `schema.parse` failure in `parseRes` when a wave API response doesn't match its DTO — the backend returns a clean `200`, so there's nothing in the backend logs). The frontend ships Grafana Faro, but **none of these 500s show up in it**: SvelteKit catches errors thrown in `load`/rendering, so they never reach `window.onerror` / `unhandledrejection`, which is all Faro's default web instrumentation observes. The result is a client-side observability blind spot — exactly the crashes users hit are the ones we can't see.

## Fix

- Add `src/hooks.client.ts` with a `handleError` hook. SvelteKit only calls this for *unexpected* errors (expected `error(...)` throws like 404s are handled directly and never reach it), so everything that arrives is a genuine crash worth reporting. Each is forwarded to Faro tagged with `route`, `url`, and `status`.
- Capture the Faro instance in `faro-manager.ts` and expose a guarded `pushError(error, context)` helper. It no-ops when Faro isn't initialized (user hasn't consented to monitoring, or `PUBLIC_FARO_ENABLED` is off), so it's always safe to call.

## Notes

This only adds reporting — it doesn't change anything users see (SvelteKit's default error message is preserved). It doesn't fix the underlying issue-view 500; it makes that error (and any future client-side `load`/render crash) visible in monitoring with its stack and route so the root cause can be diagnosed. Errors land in Loki as `service_name="app"`, `kind="exception"`.

## Testing

- `npm run check` — 0 errors.
- prettier + eslint clean on changed files.