### PR TITLE
feat(app): global incident banner driven by status.drips.network

### DIFF
--- a/src/lib/components/header/header.svelte
+++ b/src/lib/components/header/header.svelte
@@ -248,7 +248,7 @@
 
   .search-bar {
     position: fixed;
-    top: 0.5rem;
+    top: calc(0.5rem + var(--incident-banner-offset, 0px));
     left: 50%;
     transform: translateX(-50%);
     width: 100%;

--- a/src/lib/components/incident-banner/incident-banner.svelte
+++ b/src/lib/components/incident-banner/incident-banner.svelte
@@ -1,0 +1,169 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { z } from 'zod';
+  import ExclamationCircle from '$lib/components/icons/ExclamationCircle.svelte';
+  import CrossSmall from '$lib/components/icons/CrossSmall.svelte';
+  import dismissablesStore from '$lib/stores/dismissables/dismissables.store';
+
+  const STATUS_URL = 'https://status.drips.network/status.json';
+
+  const incidentSchema = z.object({
+    id: z.string().nullable().optional(),
+    title: z.string(),
+    severity: z.string().optional(),
+    status: z.string().optional(),
+    startedAt: z.string().optional(),
+  });
+
+  const statusSchema = z.object({
+    incidents: z
+      .object({
+        active: z.array(incidentSchema).optional(),
+      })
+      .optional(),
+  });
+
+  type Incident = z.infer<typeof incidentSchema>;
+
+  let active = $state<Incident[]>([]);
+
+  // A stable per-incident key so dismissing one incident doesn't dismiss future
+  // ones. Falls back to title + start time when the incident has no id.
+  function dismissId(incident: Incident): string {
+    return `incident-banner-${incident.id ?? `${incident.title}-${incident.startedAt ?? ''}`}`;
+  }
+
+  // Show a single banner at a time so its height stays predictable (sub-app
+  // headers offset themselves by a fixed --incident-banner-height).
+  let current = $derived(
+    active.filter((i) => !$dismissablesStore.includes(dismissId(i)))[0] ?? null,
+  );
+
+  // Toggle a root class so headers/content can offset below the fixed banner.
+  $effect(() => {
+    document.documentElement.classList.toggle('incident-banner-visible', Boolean(current));
+    return () => document.documentElement.classList.remove('incident-banner-visible');
+  });
+
+  function dismiss(incident: Incident) {
+    dismissablesStore.dismiss(dismissId(incident));
+  }
+
+  onMount(async () => {
+    try {
+      const res = await fetch(STATUS_URL, { cache: 'no-store' });
+      if (!res.ok) return;
+      const parsed = statusSchema.safeParse(await res.json());
+      if (!parsed.success) return;
+      active = parsed.data.incidents?.active ?? [];
+    } catch {
+      // Status page unreachable — fail silent; a banner is best-effort.
+    }
+  });
+</script>
+
+{#if current}
+  {@const incident = current}
+  <div class="incident-banner typo-text-small" role="alert">
+    <div class="content">
+      <div class="message">
+        <ExclamationCircle style="height: 1rem; width: 1rem; fill: currentColor; flex-shrink: 0;" />
+        <span class="title">{incident.title}</span>
+      </div>
+      <a
+        class="status-link"
+        href="https://status.drips.network"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        View status
+      </a>
+    </div>
+    <button class="dismiss" aria-label="Dismiss" onclick={() => dismiss(incident)}>
+      <CrossSmall style="height: 1rem; width: 1rem; fill: currentColor;" />
+    </button>
+  </div>
+{/if}
+
+<style>
+  .incident-banner {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: var(--incident-banner-height);
+    z-index: 100;
+    background-color: var(--color-negative-level-1);
+    color: var(--color-negative-level-6);
+    padding: 0 1rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    overflow: hidden;
+    view-transition-name: incident-banner;
+  }
+
+  /* Fills the space left of the dismiss button and centres its children. */
+  .content {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.75rem;
+  }
+
+  /* Icon + title; the title is the only part allowed to shrink/ellipsise. */
+  .message {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  .title {
+    min-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  /* Never shrinks or wraps, so "View status" is never cut off. */
+  .status-link {
+    flex-shrink: 0;
+    white-space: nowrap;
+    color: inherit;
+    font-weight: bold;
+    text-decoration: underline;
+  }
+
+  .status-link:hover {
+    opacity: 0.8;
+  }
+
+  .dismiss {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.25rem;
+    border: none;
+    background: none;
+    color: inherit;
+    cursor: pointer;
+    border-radius: 0.25rem;
+  }
+
+  .dismiss:hover {
+    background-color: var(--color-negative-level-2);
+  }
+
+  /* Two lines on mobile: message on top, "View status" below. */
+  @media (max-width: 768px) {
+    .content {
+      flex-direction: column;
+      gap: 0.125rem;
+    }
+  }
+</style>

--- a/src/lib/components/lp-header/lp-header.svelte
+++ b/src/lib/components/lp-header/lp-header.svelte
@@ -319,7 +319,7 @@
       box-shadow 0.3s,
       border-radius 0.3s;
     overflow: hidden;
-    top: 1rem;
+    top: calc(1rem + var(--incident-banner-offset, 0px));
     view-transition-name: header;
   }
 

--- a/src/lib/components/wave/issues-page/components/applications-filter-bar.svelte
+++ b/src/lib/components/wave/issues-page/components/applications-filter-bar.svelte
@@ -75,15 +75,17 @@
     sortBy = { key: preset.key, direction: preset.direction };
   }
 
-  const STICKY_TOP_PX = 6.5 * 16; // 6.5rem in px
-
   let wrapperEl = $state<HTMLDivElement>();
   let isSticky = $state(false);
 
   function checkSticky() {
     if (!wrapperEl) return;
+    // Read the resolved sticky `top` (CSS: calc(6.5rem + --incident-banner-offset))
+    // rather than hardcoding 6.5rem, so the threshold stays correct when the
+    // global incident banner pushes everything down.
+    const stickyTopPx = parseFloat(getComputedStyle(wrapperEl).top) || 0;
     const rect = wrapperEl.getBoundingClientRect();
-    isSticky = rect.top <= STICKY_TOP_PX + 1;
+    isSticky = rect.top <= stickyTopPx + 1;
   }
 
   $effect(() => {
@@ -123,7 +125,7 @@
 <style>
   .sticky-wrapper {
     position: sticky;
-    top: 6.5rem;
+    top: calc(6.5rem + var(--incident-banner-offset, 0px));
     z-index: 1;
   }
 

--- a/src/lib/components/wave/issues-page/issues-page.svelte
+++ b/src/lib/components/wave/issues-page/issues-page.svelte
@@ -493,9 +493,9 @@
     flex: 1;
     display: flex;
     flex-direction: column;
-    height: calc(100dvh - 5.5rem);
+    height: calc(100dvh - 5.5rem - var(--incident-banner-offset, 0px));
     position: sticky;
-    top: 4.5rem;
+    top: calc(4.5rem + var(--incident-banner-offset, 0px));
   }
 
   .issue-list-configuration {

--- a/src/lib/components/wave/issues-page/single-issue-page.svelte
+++ b/src/lib/components/wave/issues-page/single-issue-page.svelte
@@ -850,9 +850,9 @@
 
   .sidebar-wrapper {
     position: sticky;
-    top: 6.5rem;
+    top: calc(6.5rem + var(--incident-banner-offset, 0px));
     align-self: start;
-    max-height: calc(100dvh - 5.5rem);
+    max-height: calc(100dvh - 5.5rem - var(--incident-banner-offset, 0px));
     --fade-size: 1.5rem;
     mask-image: linear-gradient(
       to bottom,
@@ -883,7 +883,7 @@
 
   .sidebar {
     overflow-y: auto;
-    max-height: calc(100dvh - 7.5rem);
+    max-height: calc(100dvh - 7.5rem - var(--incident-banner-offset, 0px));
     display: flex;
     flex-direction: column;
     gap: 1rem;

--- a/src/routes/(pages)/(lp)/blog/+layout.svelte
+++ b/src/routes/(pages)/(lp)/blog/+layout.svelte
@@ -20,7 +20,7 @@
     width: 100vw;
     margin: 0 auto;
     padding: 1rem;
-    padding-top: 6rem;
+    padding-top: calc(6rem + var(--incident-banner-offset, 0px));
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -34,7 +34,7 @@
 
   @media (max-width: 577px) {
     .wrapper {
-      padding-top: 5rem;
+      padding-top: calc(5rem + var(--incident-banner-offset, 0px));
     }
   }
 </style>

--- a/src/routes/(pages)/(lp)/legal/+layout.svelte
+++ b/src/routes/(pages)/(lp)/legal/+layout.svelte
@@ -22,7 +22,7 @@
     width: 100vw;
     margin: 0 auto;
     padding: 1rem;
-    padding-top: 6rem;
+    padding-top: calc(6rem + var(--incident-banner-offset, 0px));
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/src/routes/(pages)/(lp)/solutions/+layout.svelte
+++ b/src/routes/(pages)/(lp)/solutions/+layout.svelte
@@ -19,7 +19,7 @@
 <style>
   .wrapper {
     background-color: var(--color-foreground-level-1);
-    padding-top: 6rem;
+    padding-top: calc(6rem + var(--incident-banner-offset, 0px));
     padding-bottom: 2rem;
     width: 100vw;
     min-height: 100svh;

--- a/src/routes/(pages)/+layout.svelte
+++ b/src/routes/(pages)/+layout.svelte
@@ -3,6 +3,7 @@
 
   import '$lib/stores/theme/theme.store';
   import animationsStore from '$lib/stores/animations/animations.store';
+  import IncidentBanner from '$lib/components/incident-banner/incident-banner.svelte';
 
   import { onMount } from 'svelte';
   import { get } from 'svelte/store';
@@ -49,6 +50,7 @@
 </script>
 
 <div class="main" data-uifont="inter">
+  <IncidentBanner />
   <main class="page">
     {@render children?.()}
   </main>

--- a/src/routes/(pages)/app/(app)/+layout.svelte
+++ b/src/routes/(pages)/app/(app)/+layout.svelte
@@ -165,18 +165,18 @@
 
   .header {
     position: fixed;
-    top: 0;
+    top: var(--incident-banner-offset, 0px);
     left: 0;
     width: 100%;
     z-index: 1;
   }
 
   .has-read-only-banner .sidenav {
-    padding-top: 8rem;
+    padding-top: calc(8rem + var(--incident-banner-offset, 0px));
   }
 
   .has-read-only-banner .page {
-    padding-top: 8rem;
+    padding-top: calc(8rem + var(--incident-banner-offset, 0px));
   }
 
   .page {
@@ -184,6 +184,7 @@
     min-height: 100vh;
     width: 100vw;
     padding: 6rem 2.5rem 1rem 2.5rem;
+    padding-top: calc(6rem + var(--incident-banner-offset, 0px));
     margin: 0 auto 0 16rem;
   }
 
@@ -214,7 +215,7 @@
     height: 100%;
     width: 16rem;
     padding: 1rem;
-    padding-top: 6rem;
+    padding-top: calc(6rem + var(--incident-banner-offset, 0px));
     z-index: 2;
   }
 
@@ -259,12 +260,13 @@
     .page,
     .sidenav-forced-collapsed .page {
       padding: 6rem 1rem 6rem 1rem;
+      padding-top: calc(6rem + var(--incident-banner-offset, 0px));
       margin-left: 0;
     }
 
     .has-read-only-banner .page,
     .has-read-only-banner.sidenav-forced-collapsed .page {
-      padding-top: 8rem;
+      padding-top: calc(8rem + var(--incident-banner-offset, 0px));
     }
 
     .bottom-nav {

--- a/src/routes/(pages)/app/(app)/components/latest-news-section.svelte
+++ b/src/routes/(pages)/app/(app)/components/latest-news-section.svelte
@@ -68,7 +68,10 @@
   }
 
   .posts-grid.compact {
-    grid-template-columns: repeat(auto-fill, minmax(24rem, 1fr));
+    /* min(24rem, 100%) so a column never forces a track wider than its
+       container — otherwise narrow viewports overflow horizontally (the
+       max-width: 767px rule below can't override this due to specificity). */
+    grid-template-columns: repeat(auto-fill, minmax(min(24rem, 100%), 1fr));
   }
 
   @media (max-width: 767px) {

--- a/src/routes/(pages)/wave/(base-layout)/+layout.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/+layout.svelte
@@ -173,7 +173,7 @@
 <style>
   .header-container {
     position: fixed;
-    top: 0;
+    top: var(--incident-banner-offset, 0px);
     left: 0;
     width: 100%;
     z-index: 5;
@@ -186,7 +186,7 @@
     width: 100%;
     margin: 0 auto;
     padding: 0.5rem 1rem 1rem 0;
-    min-height: calc(100dvh - 4rem);
+    min-height: calc(100dvh - 4rem - var(--incident-banner-offset, 0px));
     display: flex;
     height: fit-content;
     flex-direction: column;
@@ -213,14 +213,14 @@
   }
 
   .layout-container {
-    margin-top: 4rem;
+    margin-top: calc(4rem + var(--incident-banner-offset, 0px));
     display: grid;
     max-width: 100vw;
     grid-template-columns: 3rem 1fr;
     grid-template-areas: 'nav content';
     gap: 2rem;
     padding: 0rem 1rem 0 0;
-    min-height: calc(100dvh - 4rem);
+    min-height: calc(100dvh - 4rem - var(--incident-banner-offset, 0px));
   }
 
   .nav-wrapper {
@@ -228,9 +228,9 @@
     view-transition-name: sidenav;
     view-transition-class: element-handover;
     position: sticky;
-    top: 4.5rem;
+    top: calc(4.5rem + var(--incident-banner-offset, 0px));
     height: 100%;
-    max-height: calc(100vh - 4.5rem);
+    max-height: calc(100vh - 4.5rem - var(--incident-banner-offset, 0px));
   }
 
   :root::view-transition-group(sidenav) {

--- a/src/routes/(pages)/wave/(base-layout)/admin/repos/+layout.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/admin/repos/+layout.svelte
@@ -42,7 +42,7 @@
 
   .tabs {
     position: sticky;
-    top: 2.5rem;
+    top: calc(2.5rem + var(--incident-banner-offset, 0px));
     width: 100%;
     background-color: var(--color-background);
     z-index: 2;

--- a/src/routes/(pages)/wave/(base-layout)/orgs/[orgId]/+page.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/orgs/[orgId]/+page.svelte
@@ -312,7 +312,7 @@
   .org-info {
     grid-area: org-info;
     position: sticky;
-    top: 5rem;
+    top: calc(5rem + var(--incident-banner-offset, 0px));
     align-self: start;
   }
 

--- a/src/routes/(pages)/wave/(base-layout)/settings/+layout.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/settings/+layout.svelte
@@ -67,7 +67,7 @@
 
   .tabs {
     position: sticky;
-    top: 3.5rem;
+    top: calc(3.5rem + var(--incident-banner-offset, 0px));
     width: 100%;
     background-color: var(--color-background);
     z-index: 2;
@@ -75,7 +75,7 @@
 
   @media (max-width: 1024px) {
     .tabs {
-      top: 2.5rem;
+      top: calc(2.5rem + var(--incident-banner-offset, 0px));
     }
   }
 </style>

--- a/src/routes/(pages)/wave/(base-layout)/users/[userId]/+page.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/users/[userId]/+page.svelte
@@ -196,7 +196,7 @@
   .profile-info {
     grid-area: profile-info;
     position: sticky;
-    top: 4.5rem;
+    top: calc(4.5rem + var(--incident-banner-offset, 0px));
     align-self: start;
   }
 

--- a/src/routes/(pages)/wave/(flows)/+layout.svelte
+++ b/src/routes/(pages)/wave/(flows)/+layout.svelte
@@ -67,6 +67,7 @@
     width: 100%;
     height: 100%;
     gap: 2rem;
+    padding-top: var(--incident-banner-offset, 0px);
     min-height: 100vh;
     max-width: 100vw;
   }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -5,6 +5,22 @@
 @import 'elevation.css';
 @import 'typography.css';
 
+/* Global incident banner (status.drips.network). The banner is fixed at the very
+   top with a static height so each sub-app's header can offset itself below it
+   via --incident-banner-offset. Height: one line on desktop, two on mobile. */
+:root {
+  --incident-banner-height: 2.5rem;
+  --incident-banner-offset: 0px;
+}
+@media (max-width: 768px) {
+  :root {
+    --incident-banner-height: 3.75rem;
+  }
+}
+html.incident-banner-visible {
+  --incident-banner-offset: var(--incident-banner-height);
+}
+
 html.smoothscroll {
   scroll-behavior: smooth;
 }


### PR DESCRIPTION
## What

Adds a global, dismissable incident banner shown at the top of **every view** of the app. On mount it fetches `status.drips.network/status.json`, reads `incidents.active`, and renders the current active incident (single banner) in red, with a "View status" link. If the status page is unreachable or there's no active incident, nothing renders.

- **Dismissal** persists via the existing `dismissables` store, keyed per-incident, so dismissing one incident won't suppress a future one.
- **Fixed height** (1 line desktop / 2 lines mobile) so layouts know exactly how much to offset by.
- The **title** ellipsises; the **"View status"** link never shrinks/truncates.
- View-transition-named so it doesn't flicker across navigations.

## Layout offsets

A shared `--incident-banner-offset` CSS var (set on `<html>` only while an incident is showing, otherwise `0px`) lets each sub-app's header/content shift below the banner. Nothing moves in the normal (no-incident) case.

- **Landing pages** — floating-pill header `top`, and blog/solutions/legal content top-padding.
- **/app** — fixed header `top`, page & sidenav clearances (including the read-only-banner combinations), and the fixed search bar.
- **/wave** — base shell header + content/nav heights, sticky sub-headers (settings/admin tabs, org & user profile cards), the flows layout, and the issues view (list/sidebar heights + applications filter bar). The filter bar's JS stickiness threshold now reads the element's resolved `top` instead of a hardcoded `6.5rem`, so the "hide content above" logic stays correct with the banner up.

## Drive-by fix

Fixes a pre-existing horizontal overflow in `LatestNewsSection`'s compact grid on narrow viewports (`minmax(min(24rem, 100%), 1fr)`), which also affected the `/app` explore page.

## Notes

`svelte-check`, ESLint, and Prettier all pass. The banner is best-effort and fails silently if the status endpoint is down.