### PR TITLE
harden redis cache against stalled connections

### DIFF
--- a/src/lib/utils/cache/remote/cached.ts
+++ b/src/lib/utils/cache/remote/cached.ts
@@ -3,6 +3,12 @@ import type { RedisClientType } from '../../../../routes/api/redis';
 
 const ENABLE_CACHE_LOGS = true;
 
+// A cache read should take single-digit milliseconds. If it takes longer the
+// connection is likely degraded (e.g. a half-open socket after an idle drop), so
+// we give up and serve fresh data rather than block the request. A stalled read
+// once hung explore + project SSR for over a minute and took a deployment down.
+const READ_TIMEOUT_MS = 1000;
+
 function log(...content: unknown[]) {
   if (ENABLE_CACHE_LOGS) {
     // eslint-disable-next-line no-console
@@ -10,8 +16,29 @@ function log(...content: unknown[]) {
   }
 }
 
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`redis read timed out after ${ms}ms`)), ms);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err);
+      },
+    );
+  });
+}
+
 /**
  * Caches the result of a fetcher function using Redis.
+ *
+ * The cache read is bounded by a short timeout and never throws: if Redis is
+ * slow or unreachable the fetcher runs instead, so a degraded cache slows
+ * requests down rather than breaking them.
+ *
  * @param redis - The Redis instance. If undefined, caching is disabled.
  * @param key - The cache key.
  * @param EX - The expiration time in seconds.
@@ -27,7 +54,15 @@ export default async function cached<T extends Record<string, any>>(
 ) {
   const keyWithNetwork = `${network.name}-${key}`;
 
-  const cachedResponse = redis && (await redis.get(keyWithNetwork));
+  let cachedResponse: string | null = null;
+  if (redis) {
+    try {
+      cachedResponse = await withTimeout(redis.get(keyWithNetwork), READ_TIMEOUT_MS);
+    } catch (err) {
+      // Degraded cache — fall through to the fetcher rather than blocking.
+      log('CACHE READ FAILED', { keyWithNetwork, error: (err as Error).message });
+    }
+  }
 
   if (cachedResponse) {
     log('CACHE HIT', { keyWithNetwork });
@@ -38,8 +73,8 @@ export default async function cached<T extends Record<string, any>>(
 
     const data = await fetcher();
 
-    redis?.set(keyWithNetwork, JSON.stringify(data), {
-      EX,
+    redis?.set(keyWithNetwork, JSON.stringify(data), { EX })?.catch((err) => {
+      log('CACHE WRITE FAILED', { keyWithNetwork, error: (err as Error).message });
     });
 
     return data;

--- a/src/routes/api/redis.ts
+++ b/src/routes/api/redis.ts
@@ -10,7 +10,17 @@ const connectionString = getOptionalEnvVar(
 );
 
 export const redis =
-  connectionString && !building ? redisSdk.createClient({ url: connectionString }) : undefined;
+  connectionString && !building
+    ? redisSdk.createClient({
+        url: connectionString,
+        // Proactively PING on an idle interval so a dropped or half-open socket
+        // is detected and reconnected. Railway closes idle internal TCP
+        // connections; without this, a low-traffic instance can keep sending
+        // commands into a dead socket that never replies, hanging every cache
+        // read for tens of seconds (the 2026-06-28 Filecoin app outage).
+        pingInterval: 10000,
+      })
+    : undefined;
 export type RedisClientType = typeof redis;
 
 redis?.on('error', (err) => {


### PR DESCRIPTION
Follow-up to today's Filecoin app incident.

The Filecoin app instance's Redis connection went half-open: Railway drops idle internal TCP connections, and a low-traffic deployment like Filecoin lets the socket sit idle long enough to get dropped. node-redis kept sending commands into the dead socket with no reply, so every cache read — explore page and project pages alike — hung for tens of seconds to minutes, blocking SSR and tripping the health check into 500s. Mainnet was unaffected because its constant traffic keeps the socket warm. Evicting the cache key didn't help (the value was never the problem); a restart fixed it by re-establishing the connection.

Two changes so a bad connection can't take a deployment down again:

- `redis.ts`: add `pingInterval: 10000` so the client PINGs on idle and detects/reconnects a dead socket instead of queueing commands into the void. This is the actual root-cause fix.
- `cached.ts`: bound the cache read with a 1s timeout and fall through to the fetcher on timeout/error, so a degraded cache makes pages a bit slower rather than hanging them. Also stops silently swallowing write failures.

Net effect: a stalled cache now means slightly slower uncached pages, not a downed app.

One thing left deliberately out of scope: a few endpoints (`api/tlv`, `api/projects`, fiat price, embed) still do direct `redis.get` reads outside `cached()`. `pingInterval` protects them from the indefinite-wedge failure mode too, but wrapping them in the same timeout helper would be a reasonable follow-up.
