### PR TITLE
Remove issue-application-received notification toggle

### DIFF
--- a/src/lib/utils/wave/notifications.ts
+++ b/src/lib/utils/wave/notifications.ts
@@ -7,7 +7,6 @@ export enum WORKFLOW_ID {
   REPO_APPLIED_TO_WAVE = 'repo-applied-to-wave-program',
   REPO_APPLICATION_APPROVED = 'repo-approved-for-wave-program',
   REPO_APPLICATION_REJECTED = 'repo-declined-for-wave-program',
-  ISSUE_APPLICATION_RECEIVED = 'issue-application-received',
   ISSUE_APPLICATION_APPROVED = 'issue-application-approved',
   COMPLIMENT_RECEIVED = 'compliment-received',
   CONTRIBUTOR_UNASSIGNED = 'contributor-unassigned',

--- a/src/routes/(pages)/wave/(base-layout)/settings/notifications/+page.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/settings/notifications/+page.svelte
@@ -22,11 +22,6 @@
   } = {
     //contributor
 
-    [WORKFLOW_ID.ISSUE_APPLICATION_RECEIVED]: {
-      title: 'Issue application received',
-      description: 'You successfully applied to work on an issue in a Wave.',
-      category: 'contributor',
-    },
     [WORKFLOW_ID.ISSUE_APPLICATION_APPROVED]: {
       title: 'Issue application approved',
       description:


### PR DESCRIPTION
## What

Removes the **"Issue application received"** notification preference from the Wave notification settings page.

## Why

The corresponding Novu workflow — fired for the applicant when they submit an issue application — is being removed on the backend (see drips-network/wave#689). It accounted for a large share (~40%) of total notification volume while providing little value: the applicant already gets immediate in-app confirmation and a GitHub comment when they apply. With the workflow gone, this toggle no longer controls anything.

## Changes

- Remove the `ISSUE_APPLICATION_RECEIVED` member from the `WORKFLOW_ID` enum (`notifications.ts`)
- Remove its entry from `NOTIFICATION_FRIENDLY_MAP` in the notification settings page

The maintainer-facing "Issue application received" toggle (`ORG_ISSUE_APPLICATION_RECEIVED`) is **unaffected**.

## Deploy ordering

The backend stops returning this workflow in the preferences list. The settings page throws if it renders a toggle with no matching backend preference, so this frontend change should ship together with (or after) drips-network/wave#689 — never before it.

## Testing

- `npm run check` passes (0 errors)