### PR TITLE
feat(wave): block externally-assigned issues and list per-issue add errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -127,6 +127,12 @@ RUN npm run gql:generate-schema
 # This relies on schema.graphql file being present in the root dir.
 RUN npm run gql:build-types
 
+# The build spawns headless Chromium (Puppeteer). Fresh Chromium builds try to
+# connect to a dbus session bus that doesn't exist in the Docker build
+# environment, which crashes the launch. Point it at /dev/null so Chromium skips
+# the session bus instead of failing.
+ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
+
 # While building the app, we set dummy values for GQL_URL so that the build passes. When running the image these need to be set in env
 RUN npm run build:app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -127,12 +127,6 @@ RUN npm run gql:generate-schema
 # This relies on schema.graphql file being present in the root dir.
 RUN npm run gql:build-types
 
-# The build spawns headless Chromium (Puppeteer). Fresh Chromium builds try to
-# connect to a dbus session bus that doesn't exist in the Docker build
-# environment, which crashes the launch. Point it at /dev/null so Chromium skips
-# the session bus instead of failing.
-ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
-
 # While building the app, we set dummy values for GQL_URL so that the build passes. When running the image these need to be set in env
 RUN npm run build:app
 

--- a/src/lib/components/stepper/components/await-error-step.svelte
+++ b/src/lib/components/stepper/components/await-error-step.svelte
@@ -46,7 +46,12 @@
     max-width: 32rem;
     background-color: var(--color-foreground-level-2);
     text-align: left;
-    overflow: scroll;
+    overflow: auto;
+    /* Preserve line breaks so multi-line messages (e.g. a per-item failure list)
+       render as a list rather than collapsing onto one line, while still wrapping
+       long lines instead of overflowing horizontally. */
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
   }
 
   p {

--- a/src/lib/components/wave/issues-page/single-issue-page.svelte
+++ b/src/lib/components/wave/issues-page/single-issue-page.svelte
@@ -163,7 +163,10 @@
       reviewDeadlineMs !== null &&
       Date.now() <= reviewDeadlineMs,
   );
-  let canBeAddedToAWave = $derived(isMaintainer && issue.state === 'open');
+  // Issues already assigned to someone on GitHub outside of Wave are rejected by
+  // the backend, so block adding them up-front straight from the issue payload.
+  let isExternallyAssigned = $derived(!issue.waveProgramId && issue.assignees.length > 0);
+  let canBeAddedToAWave = $derived(isMaintainer && issue.state === 'open' && !isExternallyAssigned);
   let canUpdateComplexity = $derived(
     Boolean(
       partOfWaveProgram && allowAddingOrRemovingWave && isMaintainer && issue.state === 'open',
@@ -690,6 +693,12 @@
               >
                 Add to Wave Program
               </SidebarButton>
+              {#if isExternallyAssigned && issue.state === 'open' && isMaintainer}
+                <p class="typo-text-small" style:color="var(--color-foreground-level-5)">
+                  This issue is already assigned to someone outside the Wave. Unassign them on
+                  GitHub first to add it.
+                </p>
+              {/if}
             {/if}
           {/if}
         </div>

--- a/src/lib/flows/wave/add-issues-to-wave-program/configure-details.svelte
+++ b/src/lib/flows/wave/add-issues-to-wave-program/configure-details.svelte
@@ -277,8 +277,10 @@
   ): string {
     const header =
       failures.length === total
-        ? `None of the ${total} issue${total > 1 ? 's' : ''} could be added to the Wave Program:`
-        : `${failures.length} of ${total} issues couldn't be added to the Wave Program:`;
+        ? total === 1
+          ? "The issue couldn't be added to the Wave Program:"
+          : `None of the ${total} issues could be added to the Wave Program:`
+        : `${failures.length} of ${total} ${total === 1 ? 'issue' : 'issues'} couldn't be added to the Wave Program:`;
 
     const lines = failures.map(
       ({ issue, reason }) =>

--- a/src/lib/flows/wave/add-issues-to-wave-program/configure-details.svelte
+++ b/src/lib/flows/wave/add-issues-to-wave-program/configure-details.svelte
@@ -591,6 +591,7 @@
   .issue-list {
     margin: 0.5rem 0 0;
     padding-left: 1.25rem;
+    list-style: disc;
   }
 
   .issue-list li {

--- a/src/lib/flows/wave/add-issues-to-wave-program/configure-details.svelte
+++ b/src/lib/flows/wave/add-issues-to-wave-program/configure-details.svelte
@@ -20,6 +20,7 @@
   import AnnotationBox from '$lib/components/annotation-box/annotation-box.svelte';
   import { getIssue } from '$lib/utils/wave/issues';
   import { getPointsForComplexity } from '$lib/utils/wave/get-points-for-complexity';
+  import extractApiErrorMessage from '$lib/utils/wave/utils/extract-api-error-message';
   import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 
   const dispatch = createEventDispatcher<StepComponentEvents>();
@@ -38,9 +39,23 @@
 
   const pluralS = issues.length > 1 ? 's' : '';
 
+  // Open issues that aren't in a Wave yet but are already assigned to someone on
+  // GitHub outside of Wave. The backend rejects these (see
+  // `addIssueToWaveProgram` in wave-program-issue.service.ts), so we block them
+  // up-front from the issue payload and surface a clear reason instead of firing
+  // a request that's guaranteed to fail. (An in-Wave assignee is the
+  // Wave-assigned contributor, so we scope this to issues not yet in a Wave.)
+  let externallyAssignedIssues = $derived(
+    issues.filter(
+      (issue) => !issue.waveProgramId && issue.state === 'open' && issue.assignees.length > 0,
+    ),
+  );
+
   let eligibleIssues = $derived(
     issues
-      .filter((issue) => !issue.waveProgramId && issue.state === 'open')
+      .filter(
+        (issue) => !issue.waveProgramId && issue.state === 'open' && issue.assignees.length === 0,
+      )
       .filter((issue) => {
         const matchingWaveProgramRepo = waveProgramRepos.find(
           (waveProgramRepo) =>
@@ -49,7 +64,11 @@
         return Boolean(matchingWaveProgramRepo);
       }),
   );
-  let hasIneligibleIssues = $derived(eligibleIssues.length < issues.length);
+  // Issues that can't be added because they're already in a Wave or not open.
+  // Externally-assigned issues get their own dedicated message below.
+  let hasIneligibleIssues = $derived(
+    issues.some((issue) => issue.waveProgramId || issue.state !== 'open'),
+  );
 
   let activeComplexity: 'small' | 'medium' | 'large' = $state('small');
 
@@ -250,31 +269,63 @@
 
   let allBlocked = $derived(submittableIssues.length === 0 && eligibleIssues.length > 0);
 
+  // Builds a readable, per-issue breakdown of which adds failed and why. Rendered
+  // as-is on the stepper's error screen (newlines preserved), so keep it plain.
+  function formatAddIssueFailures(
+    failures: { issue: IssueDetailsDto; reason: unknown }[],
+    total: number,
+  ): string {
+    const header =
+      failures.length === total
+        ? `None of the ${total} issue${total > 1 ? 's' : ''} could be added to the Wave Program:`
+        : `${failures.length} of ${total} issues couldn't be added to the Wave Program:`;
+
+    const lines = failures.map(
+      ({ issue, reason }) =>
+        `• ${issue.repo.gitHubRepoFullName}#${issue.gitHubIssueNumber}: ${extractApiErrorMessage(
+          reason,
+        )}`,
+    );
+
+    return [header, '', ...lines].join('\n');
+  }
+
   async function handleSubmit() {
     dispatch('await', {
       message: `Adding issue${pluralS} to Wave Program…`,
       promise: async () => {
         const selectedWaveId = selectedWaveIds[0];
+        const issuesToAdd = submittableIssues;
 
         const results = await Promise.allSettled(
-          submittableIssues.map((issue) =>
+          issuesToAdd.map((issue) =>
             addIssueToWaveProgram(undefined, selectedWaveId, issue.id, activeComplexity),
           ),
         );
 
-        const failedResults = results.filter((result) => result.status === 'rejected');
+        // Refresh every issue that was added successfully — even on partial
+        // failure — so the list reflects reality regardless of the outcome.
+        const succeededIssues = issuesToAdd.filter((_, i) => results[i].status === 'fulfilled');
+        if (succeededIssues.length > 0) {
+          const updatedIssues = (
+            await Promise.all(succeededIssues.map((issue) => getIssue(undefined, issue.id)))
+          ).filter((issue): issue is IssueDetailsDto => issue !== null);
 
-        if (failedResults.length > 0) {
-          // todo(wave): Make this error nicer and list out which issues failed
-          throw new Error('Some issues could not be added to the Wave. Please try again.');
+          notifyIssuesUpdated(updatedIssues);
+          await invalidate('wave:issues');
         }
 
-        const updatedIssues = (
-          await Promise.all(submittableIssues.map((issue) => getIssue(undefined, issue.id)))
-        ).filter((issue): issue is IssueDetailsDto => issue !== null);
+        const failures = issuesToAdd
+          .map((issue, i) => ({ issue, result: results[i] }))
+          .filter(
+            (entry): entry is { issue: IssueDetailsDto; result: PromiseRejectedResult } =>
+              entry.result.status === 'rejected',
+          )
+          .map(({ issue, result }) => ({ issue, reason: result.reason }));
 
-        notifyIssuesUpdated(updatedIssues);
-        await invalidate('wave:issues');
+        if (failures.length > 0) {
+          throw new Error(formatAddIssueFailures(failures, issuesToAdd.length));
+        }
 
         onsuccess?.();
       },
@@ -298,7 +349,7 @@
     ),
   );
 
-  let valid = $derived(selectedWaveIds.length > 0 && !allBlocked);
+  let valid = $derived(selectedWaveIds.length > 0 && submittableIssues.length > 0);
 </script>
 
 <StandaloneFlowStepLayout
@@ -353,6 +404,25 @@
     <AnnotationBox>
       Some selected issues are already part of a Wave, or are not currently open. To add an issue to
       a different Wave, please remove it from its current Wave first.
+    </AnnotationBox>
+  {/if}
+
+  {#if externallyAssignedIssues.length > 0}
+    <AnnotationBox type="warning">
+      {externallyAssignedIssues.length} issue{externallyAssignedIssues.length > 1 ? 's' : ''} will be
+      skipped because {externallyAssignedIssues.length > 1 ? 'they are' : "it's"} already assigned to
+      someone outside the Wave. Unassign them on GitHub first, then try adding {externallyAssignedIssues.length >
+      1
+        ? 'them'
+        : 'it'} again.
+      <ul class="issue-list">
+        {#each externallyAssignedIssues as issue (issue.id)}
+          <li>
+            <strong>{issue.repo.gitHubRepoFullName}#{issue.gitHubIssueNumber}</strong>
+            {issue.title}
+          </li>
+        {/each}
+      </ul>
     </AnnotationBox>
   {/if}
 
@@ -513,6 +583,19 @@
   }
 
   .budget-warning-row:last-child {
+    margin-bottom: 0;
+  }
+
+  .issue-list {
+    margin: 0.5rem 0 0;
+    padding-left: 1.25rem;
+  }
+
+  .issue-list li {
+    margin-bottom: 0.25rem;
+  }
+
+  .issue-list li:last-child {
     margin-bottom: 0;
   }
 </style>

--- a/src/lib/utils/wave/utils/extract-api-error-message.ts
+++ b/src/lib/utils/wave/utils/extract-api-error-message.ts
@@ -1,0 +1,29 @@
+/**
+ * Unwraps the human-readable message from an error thrown by `authenticatedCall`
+ * (see `../call.ts`). Those errors carry the raw response body appended to the
+ * status line, e.g.:
+ *
+ *   API call failed: 400 Bad Request - {"error":"This issue is already assigned…"}
+ *
+ * The Wave API serialises failures as `{ error: string }`, so we split off the
+ * body after the first " - " separator and pull `error` out of it. Falls back to
+ * the body (or the whole message when there's no separator, e.g. network errors
+ * or `AccountSuspendedError`/`AccountRestrictedError`, which carry plain messages).
+ */
+export default function extractApiErrorMessage(error: unknown): string {
+  const raw = error instanceof Error ? error.message : String(error);
+
+  const separatorIndex = raw.indexOf(' - ');
+  const body = separatorIndex === -1 ? raw : raw.slice(separatorIndex + 3);
+
+  try {
+    const parsed = JSON.parse(body);
+    if (parsed && typeof parsed === 'object' && typeof parsed.error === 'string') {
+      return parsed.error;
+    }
+  } catch {
+    // Body wasn't JSON — fall through to the raw body.
+  }
+
+  return body;
+}

--- a/src/lib/utils/wave/utils/extract-api-error-message.unit.test.ts
+++ b/src/lib/utils/wave/utils/extract-api-error-message.unit.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import extractApiErrorMessage from './extract-api-error-message';
+
+describe('extractApiErrorMessage', () => {
+  it('unwraps the Wave API error body from an authenticatedCall error', () => {
+    const error = new Error(
+      'API call failed: 400 Bad Request - {"error":"This issue is already assigned to someone outside the Wave, please unassign them first."}',
+    );
+
+    expect(extractApiErrorMessage(error)).toBe(
+      'This issue is already assigned to someone outside the Wave, please unassign them first.',
+    );
+  });
+
+  it('handles a body whose message itself contains " - "', () => {
+    const error = new Error(
+      'API call failed: 400 Bad Request - {"error":"Used: 900/1000 - over budget"}',
+    );
+
+    expect(extractApiErrorMessage(error)).toBe('Used: 900/1000 - over budget');
+  });
+
+  it('falls back to the raw message when the body is not JSON', () => {
+    const error = new Error('API call failed: 500 Internal Server Error - Something exploded');
+
+    expect(extractApiErrorMessage(error)).toBe('Something exploded');
+  });
+
+  it('falls back to the raw message when there is no body separator', () => {
+    const error = new Error('Account suspended');
+
+    expect(extractApiErrorMessage(error)).toBe('Account suspended');
+  });
+
+  it('falls back when the JSON body has no string error field', () => {
+    const error = new Error('API call failed: 400 Bad Request - {"message":"nope"}');
+
+    expect(extractApiErrorMessage(error)).toBe('{"message":"nope"}');
+  });
+
+  it('handles non-Error values', () => {
+    expect(extractApiErrorMessage('plain string')).toBe('plain string');
+  });
+});


### PR DESCRIPTION
Addresses PR feedback:
1. Preemptively block adding issues assigned to someone else — the FE now tells this straight from the issue payload (`assignees`).
2. Improve add-issue error handling by laying out individual failures in a list.

## Preemptively block externally-assigned issues
The backend already rejects issues already assigned to someone outside of Wave. This now happens up-front on the FE, from the issue payload, so users don't fire requests guaranteed to fail:

- **Bulk add flow** (`configure-details.svelte`): open issues (not yet in a Wave) with `assignees.length > 0` are pulled out of `eligibleIssues` into a dedicated warning that **lists each skipped issue**. `hasIneligibleIssues` was split so assigned issues no longer get the misleading "already part of a Wave / not open" copy, and `valid` now requires at least one submittable issue (no more no-op submits).
- **Single-issue view** (`single-issue-page.svelte`): the "Add to Wave Program" button is disabled for externally-assigned open issues, with a short hint explaining why.

Payload reliability: `assignees` is a `NOT NULL DEFAULT []` jsonb column (`{ id, login }`), kept fresh by the GitHub `assigned`/`unassigned` webhooks, and included in the same DTO for both the list and single-issue endpoints — so `assignees.length > 0` is safe without an extra fetch.

## Nicer per-issue add errors
- New `extract-api-error-message` util (+ unit tests) unwraps the backend `{ error }` message out of the `authenticatedCall` error string.
- `handleSubmit` collects each failed issue, still refreshes the ones that succeeded (partial-success safe), and throws a formatted per-issue list, e.g.:
  ```
  2 of 3 issues couldn't be added to the Wave Program:

  • acme/repo#123: This issue is already assigned to someone outside the Wave, please unassign them first.
  • acme/repo#456: Adding this issue would exceed the per-repo points budget. Used: 900/1000, this issue: 130 points.
  ```
- One-line CSS tweak in the shared `await-error-step.svelte` (`white-space: pre-wrap`) so that list renders as a list instead of collapsing onto one line.

## Testing
- `prettier`, `eslint`, `svelte-check` clean (no new errors/warnings).
- New unit tests for `extract-api-error-message` pass.