### PR TITLE
prefer cursor pagination when draining wave listing endpoints

### DIFF
--- a/src/lib/utils/wave/getAllPaginated.ts
+++ b/src/lib/utils/wave/getAllPaginated.ts
@@ -5,15 +5,21 @@ import type { PaginatedResponse } from './types/pagination';
  *
  * Prefers keyset/cursor pagination when the endpoint returns a `nextCursor`
  * (O(limit) and exempt from the deep-offset 400 clamp), falling back to
- * page-number pagination otherwise. The `cursor` arg is only populated once the
- * first response mints one, so cursor-aware callers should forward it.
- * @param fetchPage - A function that fetches a single page given a page number,
- *   limit, and (for cursor-aware endpoints) the previous page's `nextCursor`
+ * page-number pagination otherwise. Once a cursor is in play `page` is passed as
+ * `undefined` so callers send only `{ cursor, limit }`, mirroring the issues
+ * page; endpoints that never return a cursor keep paging by number.
+ * @param fetchPage - A function that fetches a single page given the page number
+ *   (undefined once a cursor drives paging), limit, and the previous page's
+ *   `nextCursor` (for cursor-aware endpoints)
  * @param limit - The number of items per page (default: 100)
  * @returns All items from all pages combined
  */
 export async function getAllPaginated<T>(
-  fetchPage: (page: number, limit: number, cursor?: string) => Promise<PaginatedResponse<T>>,
+  fetchPage: (
+    page: number | undefined,
+    limit: number,
+    cursor?: string,
+  ) => Promise<PaginatedResponse<T>>,
   limit = 100,
 ): Promise<T[]> {
   const allItems: T[] = [];
@@ -22,13 +28,12 @@ export async function getAllPaginated<T>(
   let hasNextPage = true;
 
   while (hasNextPage) {
-    const response = await fetchPage(page, limit, cursor);
+    // Once the endpoint mints a cursor, drop `page` and page by cursor only.
+    const response = await fetchPage(cursor ? undefined : page, limit, cursor);
     allItems.push(...response.data);
     hasNextPage = response.pagination.hasNextPage;
-    // Prefer the keyset cursor when the endpoint provides one; it's O(limit) and
-    // exempt from the deep-offset 400 clamp. Falls back to page++ otherwise.
     cursor = response.pagination.nextCursor ?? undefined;
-    page++;
+    if (!cursor) page++;
   }
 
   return allItems;

--- a/src/lib/utils/wave/getAllPaginated.ts
+++ b/src/lib/utils/wave/getAllPaginated.ts
@@ -2,22 +2,32 @@ import type { PaginatedResponse } from './types/pagination';
 
 /**
  * Fetches all pages of a paginated API endpoint and returns the combined data.
- * @param fetchPage - A function that fetches a single page given a page number
+ *
+ * Prefers keyset/cursor pagination when the endpoint returns a `nextCursor`
+ * (O(limit) and exempt from the deep-offset 400 clamp), falling back to
+ * page-number pagination otherwise. The `cursor` arg is only populated once the
+ * first response mints one, so cursor-aware callers should forward it.
+ * @param fetchPage - A function that fetches a single page given a page number,
+ *   limit, and (for cursor-aware endpoints) the previous page's `nextCursor`
  * @param limit - The number of items per page (default: 100)
  * @returns All items from all pages combined
  */
 export async function getAllPaginated<T>(
-  fetchPage: (page: number, limit: number) => Promise<PaginatedResponse<T>>,
+  fetchPage: (page: number, limit: number, cursor?: string) => Promise<PaginatedResponse<T>>,
   limit = 100,
 ): Promise<T[]> {
   const allItems: T[] = [];
   let page = 1;
+  let cursor: string | undefined;
   let hasNextPage = true;
 
   while (hasNextPage) {
-    const response = await fetchPage(page, limit);
+    const response = await fetchPage(page, limit, cursor);
     allItems.push(...response.data);
     hasNextPage = response.pagination.hasNextPage;
+    // Prefer the keyset cursor when the endpoint provides one; it's O(limit) and
+    // exempt from the deep-offset 400 clamp. Falls back to page++ otherwise.
+    cursor = response.pagination.nextCursor ?? undefined;
     page++;
   }
 

--- a/src/lib/utils/wave/getAllPaginated.unit.test.ts
+++ b/src/lib/utils/wave/getAllPaginated.unit.test.ts
@@ -33,7 +33,13 @@ describe('getAllPaginated', () => {
 
   it('falls back to page-number pagination when no nextCursor is returned', async () => {
     const fetchPage = vi
-      .fn<(page: number, limit: number, cursor?: string) => Promise<PaginatedResponse<number>>>()
+      .fn<
+        (
+          page: number | undefined,
+          limit: number,
+          cursor?: string,
+        ) => Promise<PaginatedResponse<number>>
+      >()
       .mockResolvedValueOnce(response([1, 2], { hasNextPage: true, page: 1 }))
       .mockResolvedValueOnce(response([3, 4], { hasNextPage: true, page: 2 }))
       .mockResolvedValueOnce(response([5], { hasNextPage: false, page: 3 }));
@@ -50,7 +56,13 @@ describe('getAllPaginated', () => {
 
   it('prefers the keyset cursor once the endpoint mints one', async () => {
     const fetchPage = vi
-      .fn<(page: number, limit: number, cursor?: string) => Promise<PaginatedResponse<number>>>()
+      .fn<
+        (
+          page: number | undefined,
+          limit: number,
+          cursor?: string,
+        ) => Promise<PaginatedResponse<number>>
+      >()
       // First request has no cursor (offset mode) but mints one.
       .mockResolvedValueOnce(response([1, 2], { hasNextPage: true, nextCursor: 'cursor-1' }))
       .mockResolvedValueOnce(response([3, 4], { hasNextPage: true, nextCursor: 'cursor-2' }))
@@ -60,11 +72,12 @@ describe('getAllPaginated', () => {
     const all = await getAllPaginated(fetchPage);
 
     expect(all).toEqual([1, 2, 3, 4, 5]);
-    // The prior response's nextCursor is forwarded as the cursor arg each time.
+    // First request pages by number; once a cursor is minted it drives paging
+    // and `page` is dropped (undefined), so only `{ cursor, limit }` is sent.
     expect(fetchPage.mock.calls).toEqual([
       [1, 100, undefined],
-      [2, 100, 'cursor-1'],
-      [3, 100, 'cursor-2'],
+      [undefined, 100, 'cursor-1'],
+      [undefined, 100, 'cursor-2'],
     ]);
   });
 

--- a/src/lib/utils/wave/getAllPaginated.unit.test.ts
+++ b/src/lib/utils/wave/getAllPaginated.unit.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getAllPaginated } from './getAllPaginated';
+import type { PaginatedResponse } from './types/pagination';
+
+function response<T>(
+  data: T[],
+  pagination: { hasNextPage: boolean; page?: number; nextCursor?: string | null },
+): PaginatedResponse<T> {
+  return {
+    data,
+    pagination: {
+      total: 0,
+      page: pagination.page ?? 1,
+      limit: 100,
+      totalPages: 0,
+      hasNextPage: pagination.hasNextPage,
+      hasPreviousPage: false,
+      ...(pagination.nextCursor !== undefined ? { nextCursor: pagination.nextCursor } : {}),
+    },
+  };
+}
+
+describe('getAllPaginated', () => {
+  it('returns the single page when there is no next page', async () => {
+    const fetchPage = vi.fn(async () => response([1, 2], { hasNextPage: false }));
+
+    const all = await getAllPaginated(fetchPage);
+
+    expect(all).toEqual([1, 2]);
+    expect(fetchPage).toHaveBeenCalledTimes(1);
+    expect(fetchPage).toHaveBeenCalledWith(1, 100, undefined);
+  });
+
+  it('falls back to page-number pagination when no nextCursor is returned', async () => {
+    const fetchPage = vi
+      .fn<(page: number, limit: number, cursor?: string) => Promise<PaginatedResponse<number>>>()
+      .mockResolvedValueOnce(response([1, 2], { hasNextPage: true, page: 1 }))
+      .mockResolvedValueOnce(response([3, 4], { hasNextPage: true, page: 2 }))
+      .mockResolvedValueOnce(response([5], { hasNextPage: false, page: 3 }));
+
+    const all = await getAllPaginated(fetchPage);
+
+    expect(all).toEqual([1, 2, 3, 4, 5]);
+    expect(fetchPage.mock.calls).toEqual([
+      [1, 100, undefined],
+      [2, 100, undefined],
+      [3, 100, undefined],
+    ]);
+  });
+
+  it('prefers the keyset cursor once the endpoint mints one', async () => {
+    const fetchPage = vi
+      .fn<(page: number, limit: number, cursor?: string) => Promise<PaginatedResponse<number>>>()
+      // First request has no cursor (offset mode) but mints one.
+      .mockResolvedValueOnce(response([1, 2], { hasNextPage: true, nextCursor: 'cursor-1' }))
+      .mockResolvedValueOnce(response([3, 4], { hasNextPage: true, nextCursor: 'cursor-2' }))
+      // Last page: nextCursor null → hasNextPage false.
+      .mockResolvedValueOnce(response([5], { hasNextPage: false, nextCursor: null }));
+
+    const all = await getAllPaginated(fetchPage);
+
+    expect(all).toEqual([1, 2, 3, 4, 5]);
+    // The prior response's nextCursor is forwarded as the cursor arg each time.
+    expect(fetchPage.mock.calls).toEqual([
+      [1, 100, undefined],
+      [2, 100, 'cursor-1'],
+      [3, 100, 'cursor-2'],
+    ]);
+  });
+
+  it('honors a custom limit', async () => {
+    const fetchPage = vi.fn(async () => response([1], { hasNextPage: false }));
+
+    await getAllPaginated(fetchPage, 25);
+
+    expect(fetchPage).toHaveBeenCalledWith(1, 25, undefined);
+  });
+});

--- a/src/routes/(pages)/wave/(base-layout)/admin/adjust-points/+page.ts
+++ b/src/routes/(pages)/wave/(base-layout)/admin/adjust-points/+page.ts
@@ -11,8 +11,8 @@ export const load = async ({ parent, fetch, depends }) => {
     throw redirect(302, '/wave/admin');
   }
 
-  const wavePrograms = await getAllPaginated((page, limit) =>
-    getWavePrograms(fetch, { page, limit }),
+  const wavePrograms = await getAllPaginated((page, limit, cursor) =>
+    getWavePrograms(fetch, { page, limit, cursor }),
   );
 
   const wavesByProgram: Record<string, Awaited<ReturnType<typeof getWaves>>['data']> = {};

--- a/src/routes/(pages)/wave/(base-layout)/admin/waves/+page.ts
+++ b/src/routes/(pages)/wave/(base-layout)/admin/waves/+page.ts
@@ -11,8 +11,8 @@ export const load = async ({ parent, fetch, depends }) => {
     throw redirect(302, '/wave/admin');
   }
 
-  const wavePrograms = await getAllPaginated((page, limit) =>
-    getWavePrograms(fetch, { page, limit }),
+  const wavePrograms = await getAllPaginated((page, limit, cursor) =>
+    getWavePrograms(fetch, { page, limit, cursor }),
   );
 
   return {

--- a/src/routes/(pages)/wave/(base-layout)/orgs/[orgId]/+page.ts
+++ b/src/routes/(pages)/wave/(base-layout)/orgs/[orgId]/+page.ts
@@ -9,7 +9,7 @@ export const load = async ({ params, fetch }) => {
   const [org, members, wavePrograms] = await Promise.all([
     getPublicOrg(fetch, orgId),
     getOrgMembers(fetch, orgId),
-    getAllPaginated((page, limit) => getWavePrograms(fetch, { page, limit })),
+    getAllPaginated((page, limit, cursor) => getWavePrograms(fetch, { page, limit, cursor })),
   ]);
 
   if (!org) {

--- a/src/routes/(pages)/wave/(flows)/maintainer-onboarding/apply-to-wave-program/[waveProgramId]/form/+page.ts
+++ b/src/routes/(pages)/wave/(flows)/maintainer-onboarding/apply-to-wave-program/[waveProgramId]/form/+page.ts
@@ -4,7 +4,7 @@ import { getKycStatus } from '$lib/utils/wave/kyc.js';
 
 export const load = async ({ fetch }) => {
   const [ownRepos, kycStatus] = await Promise.all([
-    getAllPaginated((page, limit) => getOwnRepos(fetch, { page, limit })),
+    getAllPaginated((page, limit, cursor) => getOwnRepos(fetch, { page, limit, cursor })),
     getKycStatus(fetch),
   ]);
 

--- a/src/routes/(pages)/wave/(flows)/maintainer-onboarding/apply-to-wave-program/[waveProgramId]/select/+page.ts
+++ b/src/routes/(pages)/wave/(flows)/maintainer-onboarding/apply-to-wave-program/[waveProgramId]/select/+page.ts
@@ -7,7 +7,7 @@ export const load = async ({ fetch, depends }) => {
   depends('wave:maintainer-onboarding-apply-to-wave');
 
   const [ownRepos, ownOrgs, ownWaveProgramRepos] = await Promise.all([
-    getAllPaginated((page, limit) => getOwnRepos(fetch, { page, limit })),
+    getAllPaginated((page, limit, cursor) => getOwnRepos(fetch, { page, limit, cursor })),
     getOrgs(fetch, { limit: 100 }),
     getOwnWaveProgramRepos(fetch, { limit: 100 }),
   ]);


### PR DESCRIPTION
wave [#675](https://github.com/drips-network/wave/pull/675) rolls keyset/cursor pagination out to the remaining public listing endpoints and adds a deep-offset 400 clamp (offset > 10k gets rejected). this is the app-side adoption so those endpoints get driven by cursors before offset walking past the clamp starts 400ing.

the only frontend code that actually walks multiple pages of a now-cursor-enabled endpoint is `getAllPaginated` wrapping `getWavePrograms` / `getOwnRepos`. so:

- `getAllPaginated` now prefers `pagination.nextCursor` when the endpoint returns one (O(limit), exempt from the clamp) and falls back to `page++` otherwise. the callback got an optional `cursor` third arg, so offset-only call sites are untouched and keep paging by number.
- the 5 drain sites for wave-programs / own-repos forward the cursor.
- added a unit test for `getAllPaginated` (offset fallback + cursor preference).

everything else on cursor-enabled endpoints only fetches a single page (grants, points history — never hit the clamp), and all the other grids/drains hit endpoints #675 deliberately keeps on offset, so they're left alone.

since offset still works, merging #675 won't break the app on its own — but this should land first so the wave-programs/repos drains use cursors before the clamp goes live. dropping offset entirely is a later gated follow-up.