### PR TITLE
lazy-load repo filter options on the wave issues pages

### DIFF
--- a/src/lib/components/wave/issues-page/components/filter-config/components/dropdown-filter-item.svelte
+++ b/src/lib/components/wave/issues-page/components/filter-config/components/dropdown-filter-item.svelte
@@ -15,7 +15,19 @@
   }
 
   let { config, onchange, selectedOption = $bindable(undefined) }: Props = $props();
-  let { optionsPromise } = $derived(config);
+
+  // Options are loaded lazily: the fetch only fires once the user opens the
+  // dropdown, or immediately when a value is already selected and its label
+  // needs resolving. This keeps heavy option fetches off every page view.
+  let optionsPromise = $state<Promise<OT> | undefined>(undefined);
+
+  function ensureOptionsLoaded() {
+    optionsPromise ??= config.getOptions();
+  }
+
+  $effect(() => {
+    if (selectedOption) ensureOptionsLoaded();
+  });
 
   let triggerEl: HTMLButtonElement;
   let popoverEl: HTMLDivElement;
@@ -54,6 +66,7 @@
 
   function handlePopoverOpen() {
     popoverOpen = true;
+    ensureOptionsLoaded();
     positionPopover();
 
     scrollStore.lock();
@@ -87,7 +100,7 @@
   <span class="name">
     {#if !selectedOption}
       Any
-    {:else}
+    {:else if optionsPromise}
       {#await optionsPromise}
         Loading...
       {:then options}
@@ -98,6 +111,8 @@
           Unknown
         {/if}
       {/await}
+    {:else}
+      Loading...
     {/if}
   </span>
 
@@ -116,40 +131,50 @@
   }}
   popover
 >
-  {#await optionsPromise}
+  {#if !optionsPromise}
     <div class="spinner">
       <Spinner />
     </div>
-  {:then options}
-    <div class="dropdown-options">
-      <div class="search-bar">
-        <input bind:value={searchTerm} type="text" placeholder="Search..." />
-        {#if searchTerm}
-          <button aria-label="Clear search" onclick={() => (searchTerm = '')}>
-            <CrossCircle />
-          </button>
-        {/if}
+  {:else}
+    {#await optionsPromise}
+      <div class="spinner">
+        <Spinner />
       </div>
+    {:then options}
+      <div class="dropdown-options">
+        <div class="search-bar">
+          <input bind:value={searchTerm} type="text" placeholder="Search..." />
+          {#if searchTerm}
+            <button aria-label="Clear search" onclick={() => (searchTerm = '')}>
+              <CrossCircle />
+            </button>
+          {/if}
+        </div>
 
-      <div class="options-list">
-        <button class="option" class:selected={!selectedOption} onclick={() => handleSelect(null)}>
-          Any
-        </button>
-
-        {#each options.filter((option) => option.label
-            .toLowerCase()
-            .includes(searchTerm.toLowerCase())) as { label, value } (value)}
+        <div class="options-list">
           <button
             class="option"
-            class:selected={selectedOption === value}
-            onclick={() => handleSelect(value)}
+            class:selected={!selectedOption}
+            onclick={() => handleSelect(null)}
           >
-            {label}
+            Any
           </button>
-        {/each}
+
+          {#each options.filter((option) => option.label
+              .toLowerCase()
+              .includes(searchTerm.toLowerCase())) as { label, value } (value)}
+            <button
+              class="option"
+              class:selected={selectedOption === value}
+              onclick={() => handleSelect(value)}
+            >
+              {label}
+            </button>
+          {/each}
+        </div>
       </div>
-    </div>
-  {/await}
+    {/await}
+  {/if}
 </div>
 
 <style>

--- a/src/lib/components/wave/issues-page/components/filter-config/components/dropdown-filter-item.svelte
+++ b/src/lib/components/wave/issues-page/components/filter-config/components/dropdown-filter-item.svelte
@@ -110,6 +110,8 @@
         {:else}
           Unknown
         {/if}
+      {:catch}
+        Failed to load
       {/await}
     {:else}
       Loading...
@@ -173,6 +175,8 @@
           {/each}
         </div>
       </div>
+    {:catch}
+      <div class="load-error typo-text-small">Failed to load options. Please try again.</div>
     {/await}
   {/if}
 </div>
@@ -211,6 +215,12 @@
     padding: 1rem;
     display: flex;
     justify-content: center;
+  }
+
+  .load-error {
+    padding: 1rem;
+    text-align: center;
+    color: var(--color-foreground-level-5);
   }
 
   .dropdown-content {

--- a/src/lib/components/wave/issues-page/components/filter-config/filter-config.svelte
+++ b/src/lib/components/wave/issues-page/components/filter-config/filter-config.svelte
@@ -26,12 +26,13 @@
             assignment: {
               type: 'dropdown',
               label: 'Assignment',
-              optionsPromise: Promise.resolve([
-                { label: 'Assigned to me or unassigned', value: 'mine-or-unassigned' },
-                { label: 'Assigned to me', value: 'mine' },
-                { label: 'Unassigned', value: 'unassigned' },
-                { label: 'Assigned to someone else', value: 'assigned-to-others' },
-              ]),
+              getOptions: () =>
+                Promise.resolve([
+                  { label: 'Assigned to me or unassigned', value: 'mine-or-unassigned' },
+                  { label: 'Assigned to me', value: 'mine' },
+                  { label: 'Unassigned', value: 'unassigned' },
+                  { label: 'Assigned to someone else', value: 'assigned-to-others' },
+                ]),
             },
           }
         : {}),
@@ -101,7 +102,7 @@
                       href: `/wave/${currentWaveProgram?.slug}/repos`,
                     }
                   : undefined,
-              optionsPromise: (async () => {
+              getOptions: async () => {
                 if (mode === 'wave') {
                   if (!currentWaveProgram) {
                     throw new Error('currentWaveProgram is required for wave mode');
@@ -125,7 +126,7 @@
                     value: waveProgramRepo.repo.id,
                   }));
                 }
-              })(),
+              },
             },
           }
         : {}),

--- a/src/lib/components/wave/issues-page/components/filter-config/types.ts
+++ b/src/lib/components/wave/issues-page/components/filter-config/types.ts
@@ -14,7 +14,12 @@ export type DropdownConfig<OT extends { label: string; value: string }[]> = {
   type: 'dropdown';
   label: string;
   link?: LinkConfig;
-  optionsPromise: Promise<OT>;
+  /**
+   * Lazily loads the dropdown options. Only invoked once the user opens the
+   * dropdown (or when a value is already selected and its label needs
+   * resolving), so heavy option fetches don't run on every page view.
+   */
+  getOptions: () => Promise<OT>;
 };
 
 export type MultiSelectConfig<OT extends { label: string; value: string }[]> = {

--- a/src/lib/components/wave/issues-page/load-fns/issues-page-layout-load.ts
+++ b/src/lib/components/wave/issues-page/load-fns/issues-page-layout-load.ts
@@ -113,8 +113,10 @@ export const issuesPageLayoutLoad = async (
 
   const [issues, waveProgramRepos, wavePrograms] = await Promise.all([
     getIssues(fetch, { limit: 10 }, filters, sortBy),
+    // Only needed for the "add to wave program" flow, which is gated behind
+    // `allowAddToWaveProgram` (maintainer view only). Skip the fetch elsewhere.
     // todo(wave): pagination
-    user ? (await getOwnWaveProgramRepos(fetch, { limit: 100 })).data : [],
+    user && allowAddToWaveProgram ? (await getOwnWaveProgramRepos(fetch, { limit: 100 })).data : [],
     // todo(wave): Only fetch wave programs included in the issues list
     (await getWavePrograms(fetch, { limit: 100 })).data,
   ]);

--- a/src/lib/components/wave/issues-page/load-fns/issues-page-layout-load.ts
+++ b/src/lib/components/wave/issues-page/load-fns/issues-page-layout-load.ts
@@ -111,15 +111,18 @@ export const issuesPageLayoutLoad = async (
 
   // fetch data
 
-  const [issues, waveProgramRepos, wavePrograms] = await Promise.all([
+  const [issues, ownWaveProgramReposResult, waveProgramsResult] = await Promise.all([
     getIssues(fetch, { limit: 10 }, filters, sortBy),
     // Only needed for the "add to wave program" flow, which is gated behind
     // `allowAddToWaveProgram` (maintainer view only). Skip the fetch elsewhere.
     // todo(wave): pagination
-    user && allowAddToWaveProgram ? (await getOwnWaveProgramRepos(fetch, { limit: 100 })).data : [],
+    user && allowAddToWaveProgram ? getOwnWaveProgramRepos(fetch, { limit: 100 }) : undefined,
     // todo(wave): Only fetch wave programs included in the issues list
-    (await getWavePrograms(fetch, { limit: 100 })).data,
+    getWavePrograms(fetch, { limit: 100 }),
   ]);
+
+  const waveProgramRepos = ownWaveProgramReposResult?.data ?? [];
+  const wavePrograms = waveProgramsResult.data;
 
   return {
     issues,

--- a/src/lib/components/wave/repos-filter-bar/multi-select-filter.svelte
+++ b/src/lib/components/wave/repos-filter-bar/multi-select-filter.svelte
@@ -81,13 +81,18 @@
   });
 
   let resolvedOptions = $state<OT | undefined>(undefined);
+  let optionsError = $state(false);
   $effect(() => {
-    optionsPromise.then((opts) => (resolvedOptions = opts));
+    optionsPromise.then(
+      (opts) => (resolvedOptions = opts),
+      () => (optionsError = true),
+    );
   });
 
   let displayText = $derived.by(() => {
     if (selectedValues.length === 0) return placeholder;
     if (selectedValues.length === 1) {
+      if (optionsError) return selectedValues[0];
       const match = resolvedOptions?.find((o) => o.value === selectedValues[0]);
       return match?.label ?? (resolvedOptions ? selectedValues[0] : 'Loading...');
     }
@@ -155,6 +160,8 @@
         {/each}
       </div>
     </div>
+  {:catch}
+    <div class="load-error typo-text-small">Failed to load options. Please try again.</div>
   {/await}
 </div>
 
@@ -193,6 +200,12 @@
     padding: 1rem;
     display: flex;
     justify-content: center;
+  }
+
+  .load-error {
+    padding: 1rem;
+    text-align: center;
+    color: var(--color-foreground-level-5);
   }
 
   .dropdown-content {


### PR DESCRIPTION
the wave issue-listing pages were pulling down a lot of repo detail on every page view that they didn't need. two separate spots:

**repo filter dropdown.** it built its options via an eagerly-invoked async fn inside `AVAILABLE_FILTERS`, which runs on mount of `FilterConfig`. that component renders on every page view (even while the filter panel is collapsed), so we fetched the full repo list — 250kb+ of detailed repo DTOs — every time, only to pull each repo's `id` and full name out of it. this makes the dropdown options a lazy loader (`getOptions`) instead of a pre-created promise, so the fetch only fires when the user actually opens the repo dropdown, or immediately when a repo filter is already selected (so the trigger label can resolve). same treatment applies to the contributor-mode assignment dropdown, though that one was already cheap static data.

**shared layout load.** `issuesPageLayoutLoad` fetched up to 100 full repo-detail DTOs via `getOwnWaveProgramRepos` whenever logged in, but that data only feeds the "add to wave program" flow — which is gated behind `allowAddToWaveProgram`, set only on the maintainer issues view. so the wave + contributor views were fetching a payload they throw away entirely. gated the fetch on the same flag.