### PR TITLE
feat(wave): repo rejection appeal flow

### DIFF
--- a/src/lib/utils/wave/types/waveProgram.ts
+++ b/src/lib/utils/wave/types/waveProgram.ts
@@ -109,6 +109,28 @@ export type Tag = z.infer<typeof tagSchema>;
 export const waveProgramRepoStatusSchema = z.enum(['pending', 'approved', 'rejected']);
 export type WaveProgramRepoStatus = z.infer<typeof waveProgramRepoStatusSchema>;
 
+export const repoRejectionAppealStatusSchema = z.enum(['pending', 'dismissed']);
+export type RepoRejectionAppealStatus = z.infer<typeof repoRejectionAppealStatusSchema>;
+
+export const repoRejectionAppealResolutionSchema = z.enum([
+  'admin_dismissed',
+  'auto_repo_approved',
+  'auto_repo_reapplied',
+]);
+export type RepoRejectionAppealResolution = z.infer<typeof repoRejectionAppealResolutionSchema>;
+
+// Appeal eligibility for a rejected repo application, surfaced on the maintainer
+// dashboard so it can render the "Appeal" button state without extra calls.
+export const repoAppealEligibilitySchema = z.object({
+  canAppeal: z.boolean(),
+  latestAppealStatus: repoRejectionAppealStatusSchema.nullable(),
+  latestAppealAt: z.coerce.date().nullable(),
+  nextAppealAllowedAt: z.coerce.date().nullable(),
+  appealCount: z.number().int(),
+  appealsRemaining: z.number().int(),
+});
+export type RepoAppealEligibility = z.infer<typeof repoAppealEligibilitySchema>;
+
 export const waveProgramRepoDtoSchema = z.object({
   id: z.uuid(),
   waveProgramId: z.uuid(),
@@ -127,6 +149,38 @@ export const rejectWaveProgramRepoDtoSchema = z.object({
   rejectionReason: z.string().min(1).max(5000).optional(),
 });
 export type RejectWaveProgramRepoDto = z.infer<typeof rejectWaveProgramRepoDtoSchema>;
+
+// Appeal questionnaire. Mirrors the backend's extensible jsonb form_data — add
+// fields here as the appeal form grows.
+export const appealWaveProgramRepoFormDataSchema = z.object({
+  developmentWorkSinceRejection: z.string().min(1).max(10000),
+});
+export type AppealWaveProgramRepoFormData = z.infer<typeof appealWaveProgramRepoFormDataSchema>;
+
+export const repoRejectionAppealDtoSchema = z.object({
+  id: z.uuid(),
+  waveProgramRepoId: z.uuid(),
+  formData: appealWaveProgramRepoFormDataSchema,
+  status: repoRejectionAppealStatusSchema,
+  resolution: repoRejectionAppealResolutionSchema.nullable(),
+  createdAt: z.coerce.date(),
+  resolvedAt: z.coerce.date().nullable(),
+});
+export type RepoRejectionAppealDto = z.infer<typeof repoRejectionAppealDtoSchema>;
+
+// Context for the standalone appeal flow's entrypoint (single application).
+export const repoAppealContextDtoSchema = z.object({
+  waveProgramId: z.uuid(),
+  orgRepoId: z.uuid(),
+  status: waveProgramRepoStatusSchema,
+  repo: z.object({
+    id: z.uuid(),
+    gitHubRepoFullName: z.string(),
+    gitHubRepoUrl: z.string(),
+  }),
+  appeal: repoAppealEligibilitySchema,
+});
+export type RepoAppealContextDto = z.infer<typeof repoAppealContextDtoSchema>;
 
 export const waveProgramRepoWithDetailsDtoSchema = z.object({
   id: z.uuid(),
@@ -168,6 +222,8 @@ export const waveProgramRepoWithDetailsDtoSchema = z.object({
     accountType: z.enum(['User', 'Organization']),
   }),
   appliedBy: waveUserDtoSchema,
+  // Present only on the maintainer's own repo listing (/api/wave-program-repos).
+  appeal: repoAppealEligibilitySchema.optional(),
 });
 export type WaveProgramRepoWithDetailsDto = z.infer<typeof waveProgramRepoWithDetailsDtoSchema>;
 

--- a/src/lib/utils/wave/wavePrograms.ts
+++ b/src/lib/utils/wave/wavePrograms.ts
@@ -7,6 +7,8 @@ import {
 } from './types/pagination';
 import {
   batchApplyResponseSchema,
+  repoAppealContextDtoSchema,
+  repoRejectionAppealDtoSchema,
   waveProgramApplicationLimitsDtoSchema,
   waveDtoSchema,
   waveFiltersSchema,
@@ -17,6 +19,7 @@ import {
   waveProgramOrgsFiltersSchema,
   waveProgramReposFiltersSchema,
   waveProgramRepoWithDetailsDtoSchema,
+  type AppealWaveProgramRepoFormData,
   type BatchApplyFormData,
   type Complexity,
   type WaveFilters,
@@ -174,6 +177,36 @@ export async function rejectWaveProgramRepo(
       body: JSON.stringify({
         rejectionReason,
       }),
+    }),
+  );
+}
+
+export async function getRepoAppealEligibility(
+  f = fetch,
+  waveProgramId: string,
+  orgRepoId: string,
+) {
+  return parseRes(
+    repoAppealContextDtoSchema,
+    await authenticatedCall(
+      f,
+      `/api/wave-programs/${waveProgramId}/repos/${orgRepoId}/appeal-eligibility`,
+    ),
+    { expect404: true },
+  );
+}
+
+export async function appealWaveProgramRepo(
+  f = fetch,
+  waveProgramId: string,
+  orgRepoId: string,
+  formData: AppealWaveProgramRepoFormData,
+) {
+  return parseRes(
+    repoRejectionAppealDtoSchema,
+    await authenticatedCall(f, `/api/wave-programs/${waveProgramId}/repos/${orgRepoId}/appeal`, {
+      method: 'POST',
+      body: JSON.stringify({ formData }),
     }),
   );
 }

--- a/src/routes/(pages)/wave/(base-layout)/maintainers/repos/+page.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/maintainers/repos/+page.svelte
@@ -12,8 +12,12 @@
   import MultiSelectFilter from '$lib/components/wave/repos-filter-bar/multi-select-filter.svelte';
   import Tooltip from '$lib/components/tooltip/tooltip.svelte';
   import InfoCircle from '$lib/components/icons/InfoCircle.svelte';
+  import ArrowReply from '$lib/components/icons/ArrowReply.svelte';
   import formatDate from '$lib/utils/format-date';
-  import type { WaveProgramRepoWithDetailsDto } from '$lib/utils/wave/types/waveProgram.js';
+  import type {
+    RepoAppealEligibility,
+    WaveProgramRepoWithDetailsDto,
+  } from '$lib/utils/wave/types/waveProgram.js';
   import { goto } from '$app/navigation';
 
   let { data } = $props();
@@ -105,6 +109,31 @@
     }
     goto(url.pathname + url.search, { replaceState: true });
   }
+
+  // Whole days from now until `date`, rounded up (never negative).
+  function daysUntil(date: Date): number {
+    const ms = date.getTime() - Date.now();
+    return Math.max(0, Math.ceil(ms / (1000 * 60 * 60 * 24)));
+  }
+
+  // Explanation shown in the Appeal button's tooltip when it's disabled. Returns
+  // null when the user can appeal (button enabled, no tooltip needed).
+  function appealDisabledReason(appeal: RepoAppealEligibility): string | null {
+    if (appeal.canAppeal) return null;
+    if (appeal.latestAppealStatus === 'pending') {
+      return 'Your appeal is currently pending review.';
+    }
+    if (appeal.appealsRemaining <= 0) {
+      return 'You’ve used all appeals available for this repository.';
+    }
+    if (appeal.nextAppealAllowedAt) {
+      const days = daysUntil(appeal.nextAppealAllowedAt);
+      if (days > 0) {
+        return `You can submit an appeal in ${days} day${days === 1 ? '' : 's'}.`;
+      }
+    }
+    return 'You can’t appeal this rejection right now.';
+  }
 </script>
 
 {#snippet waveProgramRepo(d: WaveProgramRepoWithDetailsDto)}
@@ -146,9 +175,34 @@
             Approved
           </span>
         {:else if d.status === 'rejected'}
-          <span class="typo-text-small-bold" style:color="var(--color-negative-level-6)">
-            Rejected
-          </span>
+          {#if d.appeal?.latestAppealStatus === 'pending'}
+            <span class="typo-text-small-bold" style:color="var(--color-caution-level-6)">
+              Appeal pending
+            </span>
+          {:else}
+            <span class="typo-text-small-bold" style:color="var(--color-negative-level-6)">
+              Rejected
+            </span>
+          {/if}
+          {#if d.appeal}
+            {@const disabledReason = appealDisabledReason(d.appeal)}
+            <Tooltip disabled={!disabledReason}>
+              <Button
+                variant="normal"
+                size="small"
+                icon={ArrowReply}
+                disabled={!d.appeal.canAppeal}
+                href={d.appeal.canAppeal
+                  ? `/wave/appeal/${d.waveProgramId}/${d.repo.id}`
+                  : undefined}
+              >
+                Appeal
+              </Button>
+              {#snippet tooltip_content()}
+                <span class="typo-text-small">{disabledReason}</span>
+              {/snippet}
+            </Tooltip>
+          {/if}
         {/if}
       </div>
     </div>
@@ -460,7 +514,7 @@
   }
 
   .header-status {
-    width: 6rem;
+    width: 9rem;
     text-align: right;
   }
 
@@ -486,7 +540,12 @@
   }
 
   .status {
-    width: 6rem;
+    width: 9rem;
+    flex-shrink: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.5rem;
     text-align: right;
     white-space: nowrap;
   }

--- a/src/routes/(pages)/wave/(flows)/appeal/[waveProgramId]/[orgRepoId]/+page.svelte
+++ b/src/routes/(pages)/wave/(flows)/appeal/[waveProgramId]/[orgRepoId]/+page.svelte
@@ -1,0 +1,159 @@
+<script lang="ts">
+  import { beforeNavigate, goto } from '$app/navigation';
+  import AnnotationBox from '$lib/components/annotation-box/annotation-box.svelte';
+  import Button from '$lib/components/button/button.svelte';
+  import ArrowLeft from '$lib/components/icons/ArrowLeft.svelte';
+  import ArrowReply from '$lib/components/icons/ArrowReply.svelte';
+  import FormField from '$lib/components/form-field/form-field.svelte';
+  import TextArea from '$lib/components/text-area/text-area.svelte';
+  import doWithErrorModal from '$lib/utils/do-with-error-modal';
+  import { appealWaveProgramRepo } from '$lib/utils/wave/wavePrograms';
+  import FlowStepWrapper from '../../../shared/flow-step-wrapper.svelte';
+
+  let { data } = $props();
+
+  let context = $derived(data.context);
+  let appeal = $derived(context.appeal);
+
+  const DASHBOARD_HREF = '/wave/maintainers/repos?status=rejected';
+
+  // Whole days from now until `date`, rounded up (never negative).
+  function daysUntil(date: Date): number {
+    const ms = date.getTime() - Date.now();
+    return Math.max(0, Math.ceil(ms / (1000 * 60 * 60 * 24)));
+  }
+
+  // Why an appeal can't be submitted right now, or null when it can.
+  let ineligibleReason = $derived.by<string | null>(() => {
+    if (context.status !== 'rejected') {
+      return 'This application isn’t rejected, so there’s nothing to appeal.';
+    }
+    if (appeal.canAppeal) return null;
+    if (appeal.latestAppealStatus === 'pending') {
+      return 'Your appeal is currently pending review. You’ll be able to appeal again only if it’s dismissed.';
+    }
+    if (appeal.appealsRemaining <= 0) {
+      return 'You’ve used all appeals available for this repository.';
+    }
+    if (appeal.nextAppealAllowedAt) {
+      const days = daysUntil(appeal.nextAppealAllowedAt);
+      if (days > 0) {
+        return `You can submit an appeal in ${days} day${days === 1 ? '' : 's'}.`;
+      }
+    }
+    return 'You can’t appeal this rejection right now.';
+  });
+
+  let developmentWork = $state('');
+  let developmentWorkFocussed = $state(false);
+
+  const MIN_LENGTH = 20;
+  const MAX_LENGTH = 10000;
+
+  let tooShort = $derived(developmentWork.trim().length < MIN_LENGTH);
+  let tooLong = $derived(developmentWork.length > MAX_LENGTH);
+  let valid = $derived(!tooShort && !tooLong);
+
+  let submitting = $state(false);
+  let submittedSuccessfully = $state(false);
+
+  let hasUnsavedChanges = $derived(developmentWork.length > 0);
+
+  beforeNavigate((navigation) => {
+    if (hasUnsavedChanges && !submittedSuccessfully) {
+      if (!confirm('You have unsaved changes. Are you sure you want to leave?')) {
+        navigation.cancel();
+      }
+    }
+  });
+
+  async function handleSubmit() {
+    submitting = true;
+    try {
+      await doWithErrorModal(async () => {
+        await appealWaveProgramRepo(undefined, context.waveProgramId, context.orgRepoId, {
+          developmentWorkSinceRejection: developmentWork.trim(),
+        });
+      });
+      submittedSuccessfully = true;
+      goto(`/wave/appeal/${context.waveProgramId}/${context.orgRepoId}/success`);
+    } finally {
+      submitting = false;
+    }
+  }
+</script>
+
+<FlowStepWrapper
+  headline="Appeal rejection"
+  description="Appeal the rejection of {context.repo
+    .gitHubRepoFullName}. Our team will review your appeal and get back to you."
+>
+  {#if data.user?.restricted}
+    <AnnotationBox type="error">
+      Sorry, but your Drips Wave account has been restricted from submitting appeals. You can reach
+      out to support@drips.network for more details.
+      {#snippet actions()}
+        <Button href="mailto:support@drips.network">Contact support</Button>
+      {/snippet}
+    </AnnotationBox>
+  {:else if ineligibleReason}
+    <AnnotationBox type="info">
+      {ineligibleReason}
+    </AnnotationBox>
+  {:else}
+    <FormField
+      title="What development work / improvements have you made since the repo was initially rejected?*"
+      type="div"
+      validationState={valid
+        ? { type: 'valid' }
+        : developmentWorkFocussed
+          ? {
+              type: 'invalid',
+              message: tooShort
+                ? `Please provide at least ${MIN_LENGTH} characters.`
+                : `Please keep this under ${MAX_LENGTH.toLocaleString()} characters.`,
+            }
+          : { type: 'valid' }}
+    >
+      <TextArea
+        bind:value={developmentWork}
+        placeholder="Describe the changes and improvements you've made to address the reasons for the rejection…"
+        onblur={() => (developmentWorkFocussed = true)}
+      />
+      <div class="char-count">
+        <span class:too-long={tooLong} class="tnum"
+          >{developmentWork.length.toLocaleString()} / {MAX_LENGTH.toLocaleString()}</span
+        >
+      </div>
+    </FormField>
+  {/if}
+
+  {#snippet leftActions()}
+    <Button icon={ArrowLeft} href={DASHBOARD_HREF}>Back to dashboard</Button>
+  {/snippet}
+
+  {#snippet actions()}
+    {#if !data.user?.restricted && !ineligibleReason}
+      <Button
+        variant="primary"
+        icon={ArrowReply}
+        disabled={!valid}
+        loading={submitting}
+        onclick={handleSubmit}>Submit appeal</Button
+      >
+    {/if}
+  {/snippet}
+</FlowStepWrapper>
+
+<style>
+  .char-count {
+    font-size: 0.875rem;
+    color: var(--color-foreground-level-6);
+    text-align: right;
+    margin-top: 0.25rem;
+  }
+
+  .char-count .too-long {
+    color: var(--color-negative);
+  }
+</style>

--- a/src/routes/(pages)/wave/(flows)/appeal/[waveProgramId]/[orgRepoId]/+page.svelte
+++ b/src/routes/(pages)/wave/(flows)/appeal/[waveProgramId]/[orgRepoId]/+page.svelte
@@ -107,6 +107,12 @@
       review. If nothing material has changed, the decision won't change, and you'll use up one of
       your limited appeals.
     </AnnotationBox>
+    <AnnotationBox type="info">
+      You have <strong
+        >{appeal.appealsRemaining} appeal{appeal.appealsRemaining === 1 ? '' : 's'} remaining</strong
+      > for this repository. If this appeal is dismissed, you'll need to wait 1 month before you can
+      appeal again.
+    </AnnotationBox>
     <FormField
       title="What development work / improvements have you made since the repo was initially rejected?*"
       type="div"

--- a/src/routes/(pages)/wave/(flows)/appeal/[waveProgramId]/[orgRepoId]/+page.svelte
+++ b/src/routes/(pages)/wave/(flows)/appeal/[waveProgramId]/[orgRepoId]/+page.svelte
@@ -101,6 +101,12 @@
       {ineligibleReason}
     </AnnotationBox>
   {:else}
+    <AnnotationBox type="warning">
+      Appeals are only reconsidered when there's been substantive work since the rejection —
+      meaningful improvements to the code, project quality, activity, or the concerns raised in the
+      review. If nothing material has changed, the decision won't change, and you'll use up one of
+      your limited appeals.
+    </AnnotationBox>
     <FormField
       title="What development work / improvements have you made since the repo was initially rejected?*"
       type="div"

--- a/src/routes/(pages)/wave/(flows)/appeal/[waveProgramId]/[orgRepoId]/+page.ts
+++ b/src/routes/(pages)/wave/(flows)/appeal/[waveProgramId]/[orgRepoId]/+page.ts
@@ -1,0 +1,12 @@
+import { getRepoAppealEligibility } from '$lib/utils/wave/wavePrograms';
+import { error } from '@sveltejs/kit';
+
+export const load = async ({ fetch, params }) => {
+  const context = await getRepoAppealEligibility(fetch, params.waveProgramId, params.orgRepoId);
+
+  if (!context) {
+    throw error(404, 'Repo application not found');
+  }
+
+  return { context };
+};

--- a/src/routes/(pages)/wave/(flows)/appeal/[waveProgramId]/[orgRepoId]/+page.ts
+++ b/src/routes/(pages)/wave/(flows)/appeal/[waveProgramId]/[orgRepoId]/+page.ts
@@ -1,7 +1,17 @@
 import { getRepoAppealEligibility } from '$lib/utils/wave/wavePrograms';
-import { error } from '@sveltejs/kit';
+import { error, redirect } from '@sveltejs/kit';
 
-export const load = async ({ fetch, params }) => {
+export const load = async ({ fetch, params, parent, url }) => {
+  const { user } = await parent();
+
+  // Not logged in: bounce through login and return to this flow afterwards.
+  if (!user) {
+    throw redirect(
+      302,
+      `/wave/login?backTo=${encodeURIComponent(url.pathname + url.search)}&skipWelcome=true`,
+    );
+  }
+
   const context = await getRepoAppealEligibility(fetch, params.waveProgramId, params.orgRepoId);
 
   if (!context) {

--- a/src/routes/(pages)/wave/(flows)/appeal/[waveProgramId]/[orgRepoId]/success/+page.svelte
+++ b/src/routes/(pages)/wave/(flows)/appeal/[waveProgramId]/[orgRepoId]/success/+page.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import AnnotationBox from '$lib/components/annotation-box/annotation-box.svelte';
+  import Button from '$lib/components/button/button.svelte';
+  import ArrowRight from '$lib/components/icons/ArrowRight.svelte';
+  import Emoji from '$lib/components/emoji/emoji.svelte';
+  import FlowStepWrapper from '../../../../shared/flow-step-wrapper.svelte';
+</script>
+
+<FlowStepWrapper
+  headline="Appeal submitted"
+  description="Thank you — your appeal is now pending review."
+>
+  <div class="circle">
+    <Emoji size="huge" emoji="📨" />
+  </div>
+
+  <AnnotationBox type="info">
+    We'll email you when we have any updates. You can track its status anytime on your maintainer
+    dashboard.
+  </AnnotationBox>
+
+  {#snippet actions()}
+    <Button variant="primary" icon={ArrowRight} href="/wave/maintainers/repos?status=rejected"
+      >View maintainer dashboard</Button
+    >
+  {/snippet}
+</FlowStepWrapper>
+
+<style>
+  .circle {
+    padding: 1rem;
+    border-radius: 50%;
+    border: 2px solid var(--color-primary-level-2);
+    align-self: center;
+  }
+</style>


### PR DESCRIPTION
## Summary

Frontend for the repo-application rejection appeal feature. Adds a deep-linkable, full-page flow for appealing a **rejected** repo application, plus "Appeal" affordances on the Orgs & Repos maintainer dashboard.

> Depends on the backend: drips-network/wave#663 (adds the appeal submit/eligibility endpoints and the `appeal` object on `/api/wave-program-repos`).

## What's included

- **New flow** `(flows)/appeal/[waveProgramId]/[orgRepoId]` (+ `success` step), using the shared `FlowStepWrapper` chrome like the apply flow. It's a proper route (deep-linkable / shareable), not a modal.
  - The `+page.ts` loader fetches appeal eligibility for the single application (`GET .../appeal-eligibility`).
  - The entrypoint explicitly handles every state: **restricted account**, **not rejected**, **within the initial cooldown / post-dismissal cooldown** ("You can submit an appeal in X days"), **lifetime cap reached**, **an appeal already pending** — otherwise it renders the questionnaire.
  - Questionnaire asks the single free-form question ("What development work / improvements have you made since the repo was initially rejected?"), submits, and advances to a success step.
- **Dashboard** (`maintainers/repos`):
  - "Appeal" button on rejected rows — a link to the flow when appealable, otherwise disabled with a tooltip explaining why.
  - Status shows **"Appeal pending"** while an appeal is in review.
  - Status column widened so the longer labels don't shift the other columns.
- **API + types**: `getRepoAppealEligibility` / `appealWaveProgramRepo`, and the appeal eligibility / context / form-data Zod schemas.

## Notes

- The rejection reason is intentionally **not** surfaced anywhere in the appeal UI.
- `svelte-check` passes with no new errors/warnings.