### PR TITLE
feat(wave): nest error pages under wave layout, fix 500 on non-existent user profile

### DIFF
--- a/src/lib/components/wave/wave-error/wave-error.svelte
+++ b/src/lib/components/wave/wave-error/wave-error.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import { goto } from '$app/navigation';
+  import { page } from '$app/state';
+  import LargeEmptyState from '$lib/components/large-empty-state/large-empty-state.svelte';
+  import Card from '$lib/components/wave/card/card.svelte';
+
+  let { showHomeButton = false }: { showHomeButton?: boolean } = $props();
+
+  let description = $derived.by(() => {
+    switch (page.status) {
+      case 404: {
+        return "We weren't able to find this.";
+      }
+      case 500: {
+        return 'Something went wrong on our end.';
+      }
+      default: {
+        return page.error?.message || 'Something went wrong.';
+      }
+    }
+  });
+</script>
+
+<Card>
+  <LargeEmptyState
+    emoji="💀"
+    headline="Error {page.status}"
+    {description}
+    button={showHomeButton ? { label: 'Explore Waves', handler: () => goto('/wave') } : undefined}
+  />
+</Card>

--- a/src/routes/(pages)/wave/(base-layout)/+error.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/+error.svelte
@@ -2,4 +2,4 @@
   import WaveError from '$lib/components/wave/wave-error/wave-error.svelte';
 </script>
 
-<WaveError />
+<WaveError showHomeButton />

--- a/src/routes/(pages)/wave/(base-layout)/users/[userId]/+page.ts
+++ b/src/routes/(pages)/wave/(base-layout)/users/[userId]/+page.ts
@@ -3,7 +3,7 @@ import { getPointsBalanceForUser } from '$lib/utils/wave/points.js';
 import { getUser, getUserOrgs } from '$lib/utils/wave/users.js';
 import { error } from '@sveltejs/kit';
 
-export const load = async ({ params }) => {
+export const load = async ({ params, fetch }) => {
   const { userId } = params;
 
   // Fetch the user first and 404 early. Restricted / banned users are hidden by

--- a/src/routes/(pages)/wave/(base-layout)/users/[userId]/+page.ts
+++ b/src/routes/(pages)/wave/(base-layout)/users/[userId]/+page.ts
@@ -6,13 +6,20 @@ import { error } from '@sveltejs/kit';
 export const load = async ({ params }) => {
   const { userId } = params;
 
-  const [profileUserData, pointsBalance, resolvedIssues, orgs] = await Promise.all([
-    getUser(fetch, userId),
+  // Fetch the user first and 404 early. Restricted / banned users are hidden by
+  // the backend returning 404 here, so we must not surface data from the sibling
+  // endpoints (points, issues, orgs) for them.
+  const profileUserData = await getUser(fetch, userId);
+  if (!profileUserData) {
+    throw error(404, 'User not found');
+  }
+
+  const [pointsBalance, resolvedIssues, orgs] = await Promise.all([
     getPointsBalanceForUser(fetch, userId),
     getIssues(fetch, { limit: 50 }, { assignedToUser: userId, state: 'closed' }),
     getUserOrgs(fetch, userId),
   ]);
-  if (!profileUserData || !pointsBalance) {
+  if (!pointsBalance) {
     throw error(404, 'User not found');
   }
 


### PR DESCRIPTION
Implements the frontend part of drips-network/wave#665.

Backend counterpart: drips-network/wave#697

## What
- **Fix 500 on 404 user profile** The profile loader now fetches the user first and 404s early. Non-existent users return 404, so we must not surface points, issues, or org data from the sibling endpoints for them (previously those ran in a `Promise.all` and could reject first, yielding a 500 instead of a clean 404).
- **Error pages nested under the wave main layout.** Added a `(base-layout)` error boundary so errors thrown anywhere under the wave shell render *inside* the wave header/nav chrome, instead of bubbling to the bare app-wide error page.
- Added a shared `wave-error` component and refactored the near-identical existing `single-issue-error` page to reuse it.

## Verification
- `eslint` clean on all changed files.
- `svelte-check` clean on all changed files (repo-wide errors are pre-existing `$env/static/public` env-var issues, unrelated to this change).
