### PR TITLE
feat(wave): nest error pages under wave layout, fix 500 on non-existent user profile

### DIFF
--- a/src/lib/components/wave/wave-error/wave-error.svelte
+++ b/src/lib/components/wave/wave-error/wave-error.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import { goto } from '$app/navigation';
+  import { page } from '$app/state';
+  import LargeEmptyState from '$lib/components/large-empty-state/large-empty-state.svelte';
+  import Card from '$lib/components/wave/card/card.svelte';
+
+  let { showHomeButton = false }: { showHomeButton?: boolean } = $props();
+
+  let description = $derived.by(() => {
+    switch (page.status) {
+      case 404: {
+        return "We weren't able to find this.";
+      }
+      case 500: {
+        return 'Something went wrong on our end.';
+      }
+      default: {
+        return page.error?.message || 'Something went wrong.';
+      }
+    }
+  });
+</script>
+
+<Card>
+  <LargeEmptyState
+    emoji="💀"
+    headline="Error {page.status}"
+    {description}
+    button={showHomeButton ? { label: 'Explore Waves', handler: () => goto('/wave') } : undefined}
+  />
+</Card>

--- a/src/routes/(pages)/wave/(base-layout)/+error.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/+error.svelte
@@ -2,4 +2,4 @@
   import WaveError from '$lib/components/wave/wave-error/wave-error.svelte';
 </script>
 
-<WaveError />
+<WaveError showHomeButton />

--- a/src/routes/(pages)/wave/(base-layout)/users/[userId]/+page.ts
+++ b/src/routes/(pages)/wave/(base-layout)/users/[userId]/+page.ts
@@ -1,30 +1,47 @@
 import { getIssues } from '$lib/utils/wave/issues.js';
 import { getPointsBalanceForUser } from '$lib/utils/wave/points.js';
 import { getUser, getUserOrgs } from '$lib/utils/wave/users.js';
-import { error } from '@sveltejs/kit';
+import { error, redirect } from '@sveltejs/kit';
+import z from 'zod';
 
 export const load = async ({ params, fetch }) => {
   const { userId } = params;
 
-  // Fetch everything in parallel. When the backend won't expose a user it 404s
-  // the user-scoped endpoints, so we keep the orgs lookup from rejecting the
-  // whole batch and let the user lookup decide the outcome below: no user -> 404
-  // (a genuine failure for an existing user still surfaces as an error).
-  const [profileUserData, pointsBalance, resolvedIssues, orgs] = await Promise.all([
+  // The backend resolves GitHub usernames on /api/users/:id, but the sibling
+  // endpoints (points, issues, orgs) are UUID-only and would 400/404 for an
+  // existing user. Canonicalize username URLs onto the UUID route first.
+  if (!z.uuid().safeParse(userId).success) {
+    const user = await getUser(fetch, userId);
+    if (!user) throw error(404, 'User not found');
+    redirect(307, `/wave/users/${user.id}`);
+  }
+
+  // Fetch everything in parallel, deferring failures so the user lookup alone
+  // decides the outcome: no user -> 404, anything else -> genuine error.
+  const [userRes, pointsRes, issuesRes, orgsRes] = await Promise.allSettled([
     getUser(fetch, userId),
     getPointsBalanceForUser(fetch, userId),
     getIssues(fetch, { limit: 50 }, { assignedToUser: userId, state: 'closed' }),
-    getUserOrgs(fetch, userId).catch(() => []),
+    getUserOrgs(fetch, userId),
   ]);
 
-  if (!profileUserData || !pointsBalance) {
-    throw error(404, 'User not found');
-  }
+  // The user lookup itself failing (network, 5xx) is an error, not a 404.
+  if (userRes.status === 'rejected') throw userRes.reason;
+  if (!userRes.value) throw error(404, 'User not found');
+
+  // The user exists, so a sibling failure is a genuine error and must surface.
+  if (pointsRes.status === 'rejected') throw pointsRes.reason;
+  if (issuesRes.status === 'rejected') throw issuesRes.reason;
+  if (orgsRes.status === 'rejected') throw orgsRes.reason;
+
+  // Balance only 404s (-> null) when the user doesn't exist, so reaching this
+  // with null means the user vanished mid-request; treat it as not found.
+  if (!pointsRes.value) throw error(404, 'User not found');
 
   return {
-    profileUserData,
-    pointsBalance,
-    resolvedIssues,
-    orgs,
+    profileUserData: userRes.value,
+    pointsBalance: pointsRes.value,
+    resolvedIssues: issuesRes.value,
+    orgs: orgsRes.value,
   };
 };

--- a/src/routes/(pages)/wave/(base-layout)/users/[userId]/+page.ts
+++ b/src/routes/(pages)/wave/(base-layout)/users/[userId]/+page.ts
@@ -6,20 +6,18 @@ import { error } from '@sveltejs/kit';
 export const load = async ({ params, fetch }) => {
   const { userId } = params;
 
-  // Fetch the user first and 404 early. When the user isn't available the
-  // backend returns 404 here, so we must not surface data from the sibling
-  // endpoints (points, issues, orgs) for them.
-  const profileUserData = await getUser(fetch, userId);
-  if (!profileUserData) {
-    throw error(404, 'User not found');
-  }
-
-  const [pointsBalance, resolvedIssues, orgs] = await Promise.all([
+  // Fetch everything in parallel. When the backend won't expose a user it 404s
+  // the user-scoped endpoints, so we keep the orgs lookup from rejecting the
+  // whole batch and let the user lookup decide the outcome below: no user -> 404
+  // (a genuine failure for an existing user still surfaces as an error).
+  const [profileUserData, pointsBalance, resolvedIssues, orgs] = await Promise.all([
+    getUser(fetch, userId),
     getPointsBalanceForUser(fetch, userId),
     getIssues(fetch, { limit: 50 }, { assignedToUser: userId, state: 'closed' }),
-    getUserOrgs(fetch, userId),
+    getUserOrgs(fetch, userId).catch(() => []),
   ]);
-  if (!pointsBalance) {
+
+  if (!profileUserData || !pointsBalance) {
     throw error(404, 'User not found');
   }
 

--- a/src/routes/(pages)/wave/(base-layout)/users/[userId]/+page.ts
+++ b/src/routes/(pages)/wave/(base-layout)/users/[userId]/+page.ts
@@ -3,7 +3,7 @@ import { getPointsBalanceForUser } from '$lib/utils/wave/points.js';
 import { getUser, getUserOrgs } from '$lib/utils/wave/users.js';
 import { error } from '@sveltejs/kit';
 
-export const load = async ({ params }) => {
+export const load = async ({ params, fetch }) => {
   const { userId } = params;
 
   // Fetch the user first and 404 early. When the user isn't available the

--- a/src/routes/(pages)/wave/(base-layout)/users/[userId]/+page.ts
+++ b/src/routes/(pages)/wave/(base-layout)/users/[userId]/+page.ts
@@ -6,13 +6,20 @@ import { error } from '@sveltejs/kit';
 export const load = async ({ params }) => {
   const { userId } = params;
 
-  const [profileUserData, pointsBalance, resolvedIssues, orgs] = await Promise.all([
-    getUser(fetch, userId),
+  // Fetch the user first and 404 early. When the user isn't available the
+  // backend returns 404 here, so we must not surface data from the sibling
+  // endpoints (points, issues, orgs) for them.
+  const profileUserData = await getUser(fetch, userId);
+  if (!profileUserData) {
+    throw error(404, 'User not found');
+  }
+
+  const [pointsBalance, resolvedIssues, orgs] = await Promise.all([
     getPointsBalanceForUser(fetch, userId),
     getIssues(fetch, { limit: 50 }, { assignedToUser: userId, state: 'closed' }),
     getUserOrgs(fetch, userId),
   ]);
-  if (!profileUserData || !pointsBalance) {
+  if (!pointsBalance) {
     throw error(404, 'User not found');
   }
 


### PR DESCRIPTION
Implements the frontend part of drips-network/wave#665.

Backend counterpart: drips-network/wave#697

## What
- **Fix 500 on 404 user profile** The profile loader now fetches the user first and 404s early. Non-existent users return 404, so we must not surface points, issues, or org data from the sibling endpoints for them (previously those ran in a `Promise.all` and could reject first, yielding a 500 instead of a clean 404).
- **Error pages nested under the wave main layout.** Added a `(base-layout)` error boundary so errors thrown anywhere under the wave shell render *inside* the wave header/nav chrome, instead of bubbling to the bare app-wide error page.
- Added a shared `wave-error` component and refactored the near-identical existing `single-issue-error` page to reuse it.

## Verification
- `eslint` clean on all changed files.
- `svelte-check` clean on all changed files (repo-wide errors are pre-existing `$env/static/public` env-var issues, unrelated to this change).
