### PR TITLE
feat(wave): warn about unsynced private repos in maintainer onboarding

### DIFF
--- a/src/lib/utils/wave/orgs.ts
+++ b/src/lib/utils/wave/orgs.ts
@@ -6,7 +6,7 @@ import {
   orgRepoDtoSchema,
   publicOrgDtoSchema,
   publicOrgsFiltersSchema,
-  untrackedReposResponseSchema,
+  untrackedReposFlagsResponseSchema,
   userOrgDtoSchema,
   type OrgFilters,
   type PublicOrgsFilters,
@@ -35,13 +35,14 @@ export async function getOwnRepos(f = fetch, pagination?: PaginationInput) {
 }
 
 /**
- * Private repos the user's installations can access but Wave doesn't sync
- * (Wave only tracks public repos). Fetched live from GitHub by the backend.
+ * Per-org flags for whether the installation can access private repos that
+ * Wave doesn't sync (Wave only tracks public repos). Served live from
+ * GitHub by the backend.
  */
-export async function getUntrackedRepos(f = fetch) {
-  const res = await authenticatedCall(f, '/api/repos/untracked');
+export async function getUntrackedRepoFlags(f = fetch) {
+  const res = await authenticatedCall(f, '/api/orgs/untracked-repo-flags');
 
-  return parseRes(untrackedReposResponseSchema, res);
+  return parseRes(untrackedReposFlagsResponseSchema, res);
 }
 
 export async function getPublicOrg(f = fetch, orgId: string) {

--- a/src/lib/utils/wave/orgs.ts
+++ b/src/lib/utils/wave/orgs.ts
@@ -6,6 +6,7 @@ import {
   orgRepoDtoSchema,
   publicOrgDtoSchema,
   publicOrgsFiltersSchema,
+  untrackedReposResponseSchema,
   userOrgDtoSchema,
   type OrgFilters,
   type PublicOrgsFilters,
@@ -31,6 +32,16 @@ export async function getOwnRepos(f = fetch, pagination?: PaginationInput) {
   const res = await authenticatedCall(f, `/api/repos?${toPaginationParams(pagination)}`);
 
   return parseRes(paginatedResponseSchema(orgRepoDtoSchema), res);
+}
+
+/**
+ * Private repos the user's installations can access but Wave doesn't sync
+ * (Wave only tracks public repos). Fetched live from GitHub by the backend.
+ */
+export async function getUntrackedRepos(f = fetch) {
+  const res = await authenticatedCall(f, '/api/repos/untracked');
+
+  return parseRes(untrackedReposResponseSchema, res);
 }
 
 export async function getPublicOrg(f = fetch, orgId: string) {

--- a/src/lib/utils/wave/types/org.ts
+++ b/src/lib/utils/wave/types/org.ts
@@ -66,6 +66,19 @@ export const orgMemberDtoSchema = z.object({
 });
 export type OrgMemberDto = z.infer<typeof orgMemberDtoSchema>;
 
+export const untrackedRepoDtoSchema = z.object({
+  orgId: z.uuid(),
+  gitHubRepoId: z.number(),
+  gitHubRepoName: z.string(),
+  gitHubRepoFullName: z.string(),
+  gitHubRepoUrl: z.string(),
+});
+export type UntrackedRepoDto = z.infer<typeof untrackedRepoDtoSchema>;
+
+export const untrackedReposResponseSchema = z.object({
+  data: z.array(untrackedRepoDtoSchema),
+});
+
 export const orgRepoDtoSchema = z.object({
   id: z.uuid(),
   orgId: z.uuid(),

--- a/src/lib/utils/wave/types/org.ts
+++ b/src/lib/utils/wave/types/org.ts
@@ -66,17 +66,14 @@ export const orgMemberDtoSchema = z.object({
 });
 export type OrgMemberDto = z.infer<typeof orgMemberDtoSchema>;
 
-export const untrackedRepoDtoSchema = z.object({
+export const orgUntrackedReposFlagDtoSchema = z.object({
   orgId: z.uuid(),
-  gitHubRepoId: z.number(),
-  gitHubRepoName: z.string(),
-  gitHubRepoFullName: z.string(),
-  gitHubRepoUrl: z.string(),
+  hasUntrackedPrivateRepos: z.boolean(),
 });
-export type UntrackedRepoDto = z.infer<typeof untrackedRepoDtoSchema>;
+export type OrgUntrackedReposFlagDto = z.infer<typeof orgUntrackedReposFlagDtoSchema>;
 
-export const untrackedReposResponseSchema = z.object({
-  data: z.array(untrackedRepoDtoSchema),
+export const untrackedReposFlagsResponseSchema = z.object({
+  data: z.array(orgUntrackedReposFlagDtoSchema),
 });
 
 export const orgRepoDtoSchema = z.object({

--- a/src/routes/(pages)/wave/(flows)/maintainer-onboarding/review-repos/+page.svelte
+++ b/src/routes/(pages)/wave/(flows)/maintainer-onboarding/review-repos/+page.svelte
@@ -61,12 +61,12 @@
             {#if org.repos.length > 0 || org.privateRepos.length > 0}
               <ul>
                 {#each org.repos as repo (repo.id)}
-                  <div class="repo">
+                  <li class="repo">
                     <RepoBadge repo={{ ...repo }} />
-                  </div>
+                  </li>
                 {/each}
                 {#each org.privateRepos as repo (repo.gitHubRepoId)}
-                  <div class="repo private">
+                  <li class="repo private">
                     <div class="dimmed">
                       <RepoBadge repo={{ ...repo }} />
                     </div>
@@ -74,7 +74,7 @@
                       <Lock style="height: 1rem; width: 1rem; fill: currentColor" />
                       Private · won’t sync
                     </div>
-                  </div>
+                  </li>
                 {/each}
               </ul>
             {:else}

--- a/src/routes/(pages)/wave/(flows)/maintainer-onboarding/review-repos/+page.svelte
+++ b/src/routes/(pages)/wave/(flows)/maintainer-onboarding/review-repos/+page.svelte
@@ -69,11 +69,15 @@
               <p>No accessible repositories found for this organization.</p>
             {/if}
             {#if org.hasUntrackedPrivateRepos}
-              <AnnotationBox type="warning" size="small">
-                Some repos selected for this installation are private, so they won’t be synced —
-                Drips Wave only supports public repositories. Make a repo public on GitHub and it’ll
-                appear here automatically.
-              </AnnotationBox>
+              <div style:margin-top="0.5rem">
+                <AnnotationBox type="warning" size="small">
+                  <span class="typo-text-small-bold"
+                    >Some repos selected for this installation are private.</span
+                  >
+                  Drips Wave only supports public repositories. Make a repo public on GitHub and it’ll
+                  appear here automatically.
+                </AnnotationBox>
+              </div>
             {/if}
           </div>
         {/each}

--- a/src/routes/(pages)/wave/(flows)/maintainer-onboarding/review-repos/+page.svelte
+++ b/src/routes/(pages)/wave/(flows)/maintainer-onboarding/review-repos/+page.svelte
@@ -4,7 +4,6 @@
   import Button from '$lib/components/button/button.svelte';
   import ArrowBoxUpRight from '$lib/components/icons/ArrowBoxUpRight.svelte';
   import ArrowRight from '$lib/components/icons/ArrowRight.svelte';
-  import Lock from '$lib/components/icons/Lock.svelte';
   import Refresh from '$lib/components/icons/Refresh.svelte';
   import PaddedHorizontalScroll from '$lib/components/padded-horizontal-scroll/padded-horizontal-scroll.svelte';
   import Card from '$lib/components/wave/card/card.svelte';
@@ -23,18 +22,18 @@
   }
 
   let orgsAndRepos = $derived.by(() => {
-    const { userOrgs, ownRepos, untrackedRepos } = data;
+    const { userOrgs, ownRepos, untrackedRepoFlags } = data;
 
     return userOrgs.data.map((org) => {
       return {
         ...org,
         repos: ownRepos.data.filter((repo) => repo.orgId === org.orgId),
-        privateRepos: untrackedRepos.data.filter((repo) => repo.orgId === org.orgId),
+        hasUntrackedPrivateRepos:
+          untrackedRepoFlags.data.find((flag) => flag.orgId === org.orgId)
+            ?.hasUntrackedPrivateRepos ?? false,
       };
     });
   });
-
-  let hasPrivateRepos = $derived(data.untrackedRepos.data.length > 0);
 </script>
 
 <FlowStepWrapper
@@ -58,41 +57,29 @@
                 size="small">Edit settings</Button
               >
             </div>
-            {#if org.repos.length > 0 || org.privateRepos.length > 0}
+            {#if org.repos.length > 0}
               <ul>
                 {#each org.repos as repo (repo.id)}
                   <li class="repo">
                     <RepoBadge repo={{ ...repo }} />
                   </li>
                 {/each}
-                {#each org.privateRepos as repo (repo.gitHubRepoId)}
-                  <li class="repo private">
-                    <div class="dimmed">
-                      <RepoBadge repo={{ ...repo }} />
-                    </div>
-                    <div class="private-tag typo-text-small">
-                      <Lock style="height: 1rem; width: 1rem; fill: currentColor" />
-                      Private · won’t sync
-                    </div>
-                  </li>
-                {/each}
               </ul>
             {:else}
               <p>No accessible repositories found for this organization.</p>
+            {/if}
+            {#if org.hasUntrackedPrivateRepos}
+              <AnnotationBox type="warning" size="small">
+                Some repos selected for this installation are private, so they won’t be synced —
+                Drips Wave only supports public repositories. Make a repo public on GitHub and it’ll
+                appear here automatically.
+              </AnnotationBox>
             {/if}
           </div>
         {/each}
       </div>
     </Card>
   </PaddedHorizontalScroll>
-
-  {#if hasPrivateRepos}
-    <AnnotationBox type="warning">
-      Repos marked “Private” are selected in your GitHub App settings, but Drips Wave only supports
-      public repositories, so they won’t be synced. Make a repo public on GitHub and it’ll appear
-      here automatically.
-    </AnnotationBox>
-  {/if}
 
   <div class="notice">
     Don’t see your organization or repository?
@@ -116,30 +103,6 @@
 <style>
   .repo {
     margin-left: 1rem;
-  }
-
-  .repo.private {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    flex-wrap: wrap;
-    min-width: 0;
-  }
-
-  .repo.private .dimmed {
-    opacity: 0.5;
-    min-width: 0;
-  }
-
-  .private-tag {
-    display: flex;
-    align-items: center;
-    gap: 0.25rem;
-    color: var(--color-caution-level-6);
-    background-color: var(--color-caution-level-1);
-    border-radius: 1rem 0 1rem 1rem;
-    padding: 0.125rem 0.5rem;
-    white-space: nowrap;
   }
 
   .org-line {

--- a/src/routes/(pages)/wave/(flows)/maintainer-onboarding/review-repos/+page.svelte
+++ b/src/routes/(pages)/wave/(flows)/maintainer-onboarding/review-repos/+page.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
   import { invalidate } from '$app/navigation';
+  import AnnotationBox from '$lib/components/annotation-box/annotation-box.svelte';
   import Button from '$lib/components/button/button.svelte';
   import ArrowBoxUpRight from '$lib/components/icons/ArrowBoxUpRight.svelte';
   import ArrowRight from '$lib/components/icons/ArrowRight.svelte';
+  import Lock from '$lib/components/icons/Lock.svelte';
   import Refresh from '$lib/components/icons/Refresh.svelte';
   import PaddedHorizontalScroll from '$lib/components/padded-horizontal-scroll/padded-horizontal-scroll.svelte';
   import Card from '$lib/components/wave/card/card.svelte';
@@ -21,15 +23,18 @@
   }
 
   let orgsAndRepos = $derived.by(() => {
-    const { userOrgs, ownRepos } = data;
+    const { userOrgs, ownRepos, untrackedRepos } = data;
 
     return userOrgs.data.map((org) => {
       return {
         ...org,
         repos: ownRepos.data.filter((repo) => repo.orgId === org.orgId),
+        privateRepos: untrackedRepos.data.filter((repo) => repo.orgId === org.orgId),
       };
     });
   });
+
+  let hasPrivateRepos = $derived(data.untrackedRepos.data.length > 0);
 </script>
 
 <FlowStepWrapper
@@ -53,11 +58,22 @@
                 size="small">Edit settings</Button
               >
             </div>
-            {#if org.repos.length > 0}
+            {#if org.repos.length > 0 || org.privateRepos.length > 0}
               <ul>
                 {#each org.repos as repo (repo.id)}
                   <div class="repo">
                     <RepoBadge repo={{ ...repo }} />
+                  </div>
+                {/each}
+                {#each org.privateRepos as repo (repo.gitHubRepoId)}
+                  <div class="repo private">
+                    <div class="dimmed">
+                      <RepoBadge repo={{ ...repo }} />
+                    </div>
+                    <div class="private-tag typo-text-small">
+                      <Lock style="height: 1rem; width: 1rem; fill: currentColor" />
+                      Private · won’t sync
+                    </div>
                   </div>
                 {/each}
               </ul>
@@ -69,6 +85,14 @@
       </div>
     </Card>
   </PaddedHorizontalScroll>
+
+  {#if hasPrivateRepos}
+    <AnnotationBox type="warning">
+      Repos marked “Private” are selected in your GitHub App settings, but Drips Wave only supports
+      public repositories, so they won’t be synced. Make a repo public on GitHub and it’ll appear
+      here automatically.
+    </AnnotationBox>
+  {/if}
 
   <div class="notice">
     Don’t see your organization or repository?
@@ -92,6 +116,30 @@
 <style>
   .repo {
     margin-left: 1rem;
+  }
+
+  .repo.private {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    min-width: 0;
+  }
+
+  .repo.private .dimmed {
+    opacity: 0.5;
+    min-width: 0;
+  }
+
+  .private-tag {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    color: var(--color-caution-level-6);
+    background-color: var(--color-caution-level-1);
+    border-radius: 1rem 0 1rem 1rem;
+    padding: 0.125rem 0.5rem;
+    white-space: nowrap;
   }
 
   .org-line {

--- a/src/routes/(pages)/wave/(flows)/maintainer-onboarding/review-repos/+page.ts
+++ b/src/routes/(pages)/wave/(flows)/maintainer-onboarding/review-repos/+page.ts
@@ -1,4 +1,4 @@
-import { getOrgs, getOwnRepos } from '$lib/utils/wave/orgs.js';
+import { getOrgs, getOwnRepos, getUntrackedRepos } from '$lib/utils/wave/orgs.js';
 import { redirect } from '@sveltejs/kit';
 
 export const load = async ({ parent, fetch, depends }) => {
@@ -10,9 +10,12 @@ export const load = async ({ parent, fetch, depends }) => {
     throw redirect(302, '/wave/login?backTo=/wave/maintainer-onboarding/review-repos');
   }
 
-  const [userOrgs, ownRepos] = await Promise.all([
+  const [userOrgs, ownRepos, untrackedRepos] = await Promise.all([
     getOrgs(fetch, { limit: 100 }),
     getOwnRepos(fetch, { limit: 100 }),
+    // Best-effort: this is served live from GitHub by the backend, so a
+    // failure should degrade to "no warnings" rather than break the page.
+    getUntrackedRepos(fetch).catch(() => ({ data: [] })),
   ]);
 
   if (!userOrgs || userOrgs.data.length === 0) {
@@ -22,5 +25,6 @@ export const load = async ({ parent, fetch, depends }) => {
   return {
     userOrgs,
     ownRepos,
+    untrackedRepos,
   };
 };

--- a/src/routes/(pages)/wave/(flows)/maintainer-onboarding/review-repos/+page.ts
+++ b/src/routes/(pages)/wave/(flows)/maintainer-onboarding/review-repos/+page.ts
@@ -1,4 +1,4 @@
-import { getOrgs, getOwnRepos, getUntrackedRepos } from '$lib/utils/wave/orgs.js';
+import { getOrgs, getOwnRepos, getUntrackedRepoFlags } from '$lib/utils/wave/orgs.js';
 import { redirect } from '@sveltejs/kit';
 
 export const load = async ({ parent, fetch, depends }) => {
@@ -10,12 +10,12 @@ export const load = async ({ parent, fetch, depends }) => {
     throw redirect(302, '/wave/login?backTo=/wave/maintainer-onboarding/review-repos');
   }
 
-  const [userOrgs, ownRepos, untrackedRepos] = await Promise.all([
+  const [userOrgs, ownRepos, untrackedRepoFlags] = await Promise.all([
     getOrgs(fetch, { limit: 100 }),
     getOwnRepos(fetch, { limit: 100 }),
     // Best-effort: this is served live from GitHub by the backend, so a
     // failure should degrade to "no warnings" rather than break the page.
-    getUntrackedRepos(fetch).catch(() => ({ data: [] })),
+    getUntrackedRepoFlags(fetch).catch(() => ({ data: [] })),
   ]);
 
   if (!userOrgs || userOrgs.data.length === 0) {
@@ -25,6 +25,6 @@ export const load = async ({ parent, fetch, depends }) => {
   return {
     userOrgs,
     ownRepos,
-    untrackedRepos,
+    untrackedRepoFlags,
   };
 };


### PR DESCRIPTION
## Problem

Drips Wave only syncs public repositories. When a maintainer selects a private repo during GitHub App installation, it silently never appears in the review-repos step — no error, no explanation. This has been generating support reports (one org reinstalled the app 11 times trying to make a private repo show up).

## Change

The review-repos step now fetches the new `GET /api/orgs/untracked-repo-flags` wave endpoint (drips-network/wave#708) alongside the existing org/repo queries, and shows an inline warning AnnotationBox under an org's repo list when that org's installation includes private repos: they won't sync, Wave only supports public repositories, and making a repo public will sync it automatically.

The backend deliberately returns only a per-org boolean — no private repo names or URLs ever reach the frontend.

The flags fetch is best-effort: since the backend serves it live from GitHub, a failure degrades to "no warnings" instead of breaking the page. The existing Refresh button re-runs it via the same `depends` key.

## Notes

- Depends on drips-network/wave#708 being deployed; until then the endpoint 404s and the page renders as before (catch → empty list). Safe to merge in either order.
- `svelte-check`, eslint, and prettier pass.

## Testing

Type-checked and linted; not exercised against a live backend (needs the wave PR deployed plus an installation with a private repo selected — happy to demo once wave#708 ships).
