### PR TITLE
lazy-load wallet stack, share flow and SIWE button

### DIFF
--- a/src/lib/components/large-empty-state/large-empty-state.svelte
+++ b/src/lib/components/large-empty-state/large-empty-state.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import Emoji from '$lib/components/emoji/emoji.svelte';
   import Button from '../button/button.svelte';
-  import RpgfSiweButton from '../rpgf-siwe-button/rpgf-siwe-button.svelte';
 
   interface Props {
     emoji: string;
@@ -47,7 +46,11 @@
           >{button.label}</Button
         >{/if}
       {#if showSiweButton}
-        <RpgfSiweButton on:signIn></RpgfSiweButton>
+        <!-- Imported lazily: the SIWE button pulls in the wallet stack, and this
+             component is part of the error page preloaded with every route. -->
+        {#await import('../rpgf-siwe-button/rpgf-siwe-button.svelte') then { default: RpgfSiweButton }}
+          <RpgfSiweButton />
+        {/await}
       {/if}
     </div>
   </div>

--- a/src/lib/components/section-skeleton/disconnected-state-actions.svelte
+++ b/src/lib/components/section-skeleton/disconnected-state-actions.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import wallet from '$lib/stores/wallet/wallet.store';
+  import Wallet from '$lib/components/icons/Wallet.svelte';
+  import Button from '../button/button.svelte';
+  import RpgfSiweButton from '../rpgf-siwe-button/rpgf-siwe-button.svelte';
+
+  interface Props {
+    requireRpgfSignIn?: boolean;
+  }
+
+  let { requireRpgfSignIn = false }: Props = $props();
+</script>
+
+{#if requireRpgfSignIn && $wallet.signer}
+  <RpgfSiweButton />
+{:else}
+  <Button icon={Wallet} variant="primary" onclick={() => wallet.connect()}>Connect wallet</Button>
+{/if}

--- a/src/lib/components/section-skeleton/disconnected-state.svelte
+++ b/src/lib/components/section-skeleton/disconnected-state.svelte
@@ -1,9 +1,5 @@
 <script lang="ts">
-  import wallet from '$lib/stores/wallet/wallet.store';
   import ActionableEmptyState from './actionable-empty-state.svelte';
-  import Wallet from '$lib/components/icons/Wallet.svelte';
-  import Button from '../button/button.svelte';
-  import RpgfSiweButton from '../rpgf-siwe-button/rpgf-siwe-button.svelte';
 
   interface Props {
     emoji?: string;
@@ -22,12 +18,10 @@
 
 <ActionableEmptyState {emoji} {headline} description={text}>
   {#snippet actions()}
-    {#if requireRpgfSignIn && $wallet.signer}
-      <RpgfSiweButton />
-    {:else}
-      <Button icon={Wallet} variant="primary" onclick={() => wallet.connect()}>
-        Connect wallet
-      </Button>
-    {/if}
+    <!-- Imported lazily: the actions need the wallet store, which must stay out
+         of the static import graph of every page that renders a Section. -->
+    {#await import('./disconnected-state-actions.svelte') then { default: Actions }}
+      <Actions {requireRpgfSignIn} />
+    {/await}
   {/snippet}
 </ActionableEmptyState>

--- a/src/lib/components/share-button/share-button.svelte
+++ b/src/lib/components/share-button/share-button.svelte
@@ -5,9 +5,11 @@
   import Button from '../button/button.svelte';
   import { type ComponentProps } from 'svelte';
   import modal from '$lib/stores/modal';
-  import shareSteps from '$lib/flows/share/share-steps';
-  import Stepper from '$lib/components/stepper/stepper.svelte';
   import { browser } from '$app/environment';
+
+  // The share flow transitively imports the stepper machinery and wallet stack,
+  // so it must only ever be imported lazily when the modal actually opens.
+  type ShareSteps = typeof import('$lib/flows/share/share-steps').default;
 
   interface Props {
     text?: string | undefined;
@@ -16,7 +18,7 @@
     downloadableImageUrl?: string;
     shareModalText?: string | undefined;
     buttonVariant?: ComponentProps<typeof Button>['variant'];
-    supportButtonOptions?: Parameters<typeof shareSteps>[0]['supportButtonOptions'] | undefined;
+    supportButtonOptions?: Parameters<ShareSteps>[0]['supportButtonOptions'] | undefined;
     shareLabel?: string;
   }
 
@@ -47,7 +49,12 @@
     browser && downloadableImageUrl && preloadImage(downloadableImageUrl);
   });
 
-  function handleClick() {
+  async function handleClick() {
+    const [{ default: Stepper }, { default: shareSteps }] = await Promise.all([
+      import('$lib/components/stepper/stepper.svelte'),
+      import('$lib/flows/share/share-steps'),
+    ]);
+
     modal.show(
       Stepper,
       undefined,

--- a/src/lib/stores/wallet/wallet.store.ts
+++ b/src/lib/stores/wallet/wallet.store.ts
@@ -73,7 +73,11 @@ function getOnboard(): Promise<OnboardAPI> {
 
     onboardInstance = onboard;
     return onboard;
-  })());
+  })().catch((e) => {
+    // Don't cache a failed load (e.g. flaky connection) — let the next call retry.
+    onboardPromise = undefined;
+    throw e;
+  }));
 }
 
 async function getSafeAppsSdk(): Promise<SafeAppsSDK> {
@@ -376,6 +380,16 @@ const walletStore = () => {
     });
   }
 
+  /**
+   * Best-effort prefetch of the lazily-loaded wallet libraries (web3-onboard etc.),
+   * so that a later `connect()` doesn't have to download them first. Intended to be
+   * called during browser idle time after hydration.
+   */
+  function warmUp(): void {
+    if (!browser || network.readOnlyMode || isRunningInSafe()) return;
+    getOnboard().catch(() => undefined);
+  }
+
   return {
     subscribe: state.subscribe,
     initialized: { subscribe: initialized.subscribe },
@@ -383,6 +397,7 @@ const walletStore = () => {
     initialize,
     connect,
     disconnect,
+    warmUp,
     setOnboardTheme: (theme: Theme) => {
       onboardTheme = theme;
       onboardInstance?.state.actions.updateTheme(theme);
@@ -460,6 +475,7 @@ const localTestnetWalletStore = () => {
     initialize,
     connect,
     disconnect,
+    warmUp: () => undefined,
     setOnboardTheme: () => undefined,
   };
 };

--- a/src/lib/stores/wallet/wallet.store.ts
+++ b/src/lib/stores/wallet/wallet.store.ts
@@ -1,14 +1,11 @@
 import { JsonRpcProvider, JsonRpcSigner } from 'ethers';
 import { get, writable } from 'svelte/store';
 import { browser } from '$app/environment';
-import Onboard, { type EIP1193Provider } from '@web3-onboard/core';
-import injectedWallets from '@web3-onboard/injected-wallets';
-import walletConnectModule from '@web3-onboard/walletconnect';
+import type { EIP1193Provider, OnboardAPI, Theme } from '@web3-onboard/core';
 
 import globalAdvisoryStore from '../global-advisory/global-advisory.store';
 
-import SafeAppsSDK from '@safe-global/safe-apps-sdk';
-import { SafeAppProvider } from '@safe-global/safe-apps-provider';
+import type SafeAppsSDK from '@safe-global/safe-apps-sdk';
 import isRunningInSafe from '$lib/utils/is-running-in-safe';
 import storedWritable from '@efstajas/svelte-stored-writable';
 import { z } from 'zod';
@@ -22,43 +19,67 @@ import assert from '$lib/utils/assert';
 import getOptionalEnvVar from '$lib/utils/get-optional-env-var/public';
 import { logOut } from '$lib/utils/rpgf/siwe';
 
-const appsSdk = new SafeAppsSDK();
-
 const DEFAULT_NETWORK: Network = network;
 
-const injected = injectedWallets();
+// web3-onboard, WalletConnect and the Safe SDKs together weigh several hundred KB,
+// and this store is imported by components all over the app just to read wallet
+// state. They must only ever be imported dynamically, on first actual use.
+let onboardInstance: OnboardAPI | undefined;
+let onboardPromise: Promise<OnboardAPI> | undefined;
+let onboardTheme: Theme | undefined;
 
-const onboard = Onboard({
-  wallets: [
-    injected,
-    walletConnectModule({
-      version: 2,
-      projectId: 'c09f5d8545d67c604ccf454219fd8f4d',
-      requiredChains: [network.chainId],
-      dappUrl: 'https://drips.network',
-    }),
-  ],
-  chains: [
-    {
-      id: network.id,
-      token: network.token,
-      label: network.label,
-      rpcUrl: network.rpcUrl,
-    },
-  ],
-  accountCenter: {
-    mobile: { enabled: false },
-    desktop: { enabled: false },
-  },
-  notify: {
-    enabled: false,
-  },
-  appMetadata: {
-    name: 'Drips',
-    description: 'Please select a wallet to connect to Drips',
-    icon: '<svg height="100%"><image href="/assets/onboard-logo.png" height="100%" /></svg>',
-  },
-});
+function getOnboard(): Promise<OnboardAPI> {
+  return (onboardPromise ??= (async () => {
+    const [{ default: Onboard }, { default: injectedWallets }, { default: walletConnectModule }] =
+      await Promise.all([
+        import('@web3-onboard/core'),
+        import('@web3-onboard/injected-wallets'),
+        import('@web3-onboard/walletconnect'),
+      ]);
+
+    const onboard = Onboard({
+      wallets: [
+        injectedWallets(),
+        walletConnectModule({
+          version: 2,
+          projectId: 'c09f5d8545d67c604ccf454219fd8f4d',
+          requiredChains: [network.chainId],
+          dappUrl: 'https://drips.network',
+        }),
+      ],
+      chains: [
+        {
+          id: network.id,
+          token: network.token,
+          label: network.label,
+          rpcUrl: network.rpcUrl,
+        },
+      ],
+      accountCenter: {
+        mobile: { enabled: false },
+        desktop: { enabled: false },
+      },
+      notify: {
+        enabled: false,
+      },
+      appMetadata: {
+        name: 'Drips',
+        description: 'Please select a wallet to connect to Drips',
+        icon: '<svg height="100%"><image href="/assets/onboard-logo.png" height="100%" /></svg>',
+      },
+    });
+
+    if (onboardTheme) onboard.state.actions.updateTheme(onboardTheme);
+
+    onboardInstance = onboard;
+    return onboard;
+  })());
+}
+
+async function getSafeAppsSdk(): Promise<SafeAppsSDK> {
+  const { default: SafeAppsSdkClass } = await import('@safe-global/safe-apps-sdk');
+  return new SafeAppsSdkClass();
+}
 
 const lastConnectedWallet = storedWritable<string | undefined>(
   'last-connected-wallet',
@@ -67,7 +88,7 @@ const lastConnectedWallet = storedWritable<string | undefined>(
   !browser,
 );
 
-type SafeInfo = Awaited<ReturnType<typeof appsSdk.safe.getInfo>>;
+type SafeInfo = Awaited<ReturnType<SafeAppsSDK['safe']['getInfo']>>;
 
 export interface ConnectedWalletStoreState {
   connected: true;
@@ -114,7 +135,7 @@ const walletStore = () => {
     if (isSafeApp) {
       await connect(true, isSafeApp);
     } else {
-      if (onboard.state.get().wallets.length > 0) return;
+      if (onboardInstance && onboardInstance.state.get().wallets.length > 0) return;
 
       const label = get(lastConnectedWallet);
       if (!label) {
@@ -139,7 +160,7 @@ const walletStore = () => {
   async function connect(
     initializing = false,
     isSafeApp = false,
-    onboardOptions?: Parameters<typeof onboard.connectWallet>[0],
+    onboardOptions?: Parameters<OnboardAPI['connectWallet']>[0],
   ): Promise<WalletStoreState | undefined> {
     if (!browser) throw new Error('Can only connect client-side');
 
@@ -170,9 +191,14 @@ const walletStore = () => {
     let safeInfo: SafeInfo | undefined;
 
     if (isSafeApp) {
+      const [appsSdk, { SafeAppProvider }] = await Promise.all([
+        getSafeAppsSdk(),
+        import('@safe-global/safe-apps-provider'),
+      ]);
       safeInfo = await appsSdk.safe.getInfo();
       provider = new BrowserProvider(new SafeAppProvider(safeInfo, appsSdk));
     } else {
+      const onboard = await getOnboard();
       waitingForOnboard.set(true);
       const wallets = await onboard.connectWallet(onboardOptions);
       waitingForOnboard.set(false);
@@ -202,7 +228,7 @@ const walletStore = () => {
         ]);
 
         // Recreate provider to avoid network change issue with MetaMask
-        const wallets = onboard.state.get().wallets;
+        const wallets = (await getOnboard()).state.get().wallets;
         const newProvider = new BrowserProvider(wallets[0].provider);
 
         // Network is already added, we can proceed.
@@ -272,8 +298,8 @@ const walletStore = () => {
    * Completely clear the store and drop any connected wallets.
    */
   function disconnect(): void {
-    onboard.state.get().wallets.forEach((w) => {
-      onboard.disconnectWallet({ label: w.label });
+    onboardInstance?.state.get().wallets.forEach((w) => {
+      onboardInstance?.disconnectWallet({ label: w.label });
     });
 
     if (browser) invalidateAll();
@@ -357,7 +383,10 @@ const walletStore = () => {
     initialize,
     connect,
     disconnect,
-    setOnboardTheme: onboard.state.actions.updateTheme,
+    setOnboardTheme: (theme: Theme) => {
+      onboardTheme = theme;
+      onboardInstance?.state.actions.updateTheme(theme);
+    },
   };
 };
 

--- a/src/routes/(pages)/app/+layout.svelte
+++ b/src/routes/(pages)/app/+layout.svelte
@@ -95,6 +95,14 @@
   onMount(async () => {
     await initializeStores();
 
+    // Prefetch the lazily-loaded wallet libraries during idle time, so the
+    // connect flow opens instantly when the user clicks "Connect".
+    if ('requestIdleCallback' in window) {
+      requestIdleCallback(() => wallet.warmUp());
+    } else {
+      setTimeout(() => wallet.warmUp(), 2000);
+    }
+
     wallet.subscribe((s) => {
       if ($initializing) return;
 


### PR DESCRIPTION
Turns out the wave landing page (and via the error page, actually every page) was preloading ~1.2MB of compressed JS it never runs, most of it the web3 stack (ethers, web3-onboard, walletconnect, safe SDKs) plus the entire uniswap default token list. Three innocent static imports were responsible:

- `share-button` statically imported the share flow + stepper, which drags in transact-step, fiat estimates and the token list
- `large-empty-state` (part of the error page, so preloaded with every route) statically imported the RPGF SIWE button, which imports the wallet store
- `disconnected-state` in the section skeleton did the same

All three now load their heavy parts lazily on demand. On top of that, `wallet.store` no longer initializes web3-onboard at module scope — the onboard instance (and the safe SDKs) are created lazily on first connect, so simply importing the store to read wallet state is cheap now. Public API of the store is unchanged; `setOnboardTheme` caches the theme and applies it when onboard is eventually created.

Measured from a prod build manifest, the preload set for `/wave` drops from 1,226KB to 403KB gzipped (-67%). Since the wallet chunk also leaves the error page's graph, every route on the site sheds the 623KB chunk. Context: our TTFP is dominated by users on slow connections, where this preload directly competes with the CSS/HTML needed for first paint.

So that connecting still feels instant on `/app` routes, the layout now calls a new `wallet.warmUp()` during browser idle time after hydration, which prefetches the wallet libs without competing with first paint. Users with a cached connection load them during session restore as before (just as a dynamic chunk now). A failed prefetch isn't cached, so `connect()` retries the import.

One small cleanup: dropped the `on:signIn` forward in `large-empty-state` — `RpgfSiweButton` has no dispatcher, so it never fired and nothing listens for it.

Note on behavior: the connect/SIWE buttons in empty states render after hydration rather than in SSR HTML (they need JS to work anyway).