### PR TITLE
inline styles, pre-rendered blog cover variants, hero image priority

### DIFF
--- a/src/lib/components/blog/post-card/post-card.svelte
+++ b/src/lib/components/blog/post-card/post-card.svelte
@@ -7,13 +7,13 @@
     type authorSchema,
     type BLOG_CATEGORIES,
   } from '../../../../routes/api/blog/posts/schema';
+  import { BLOG_COVER_IMAGE_VARIANTS, blogCoverImageUrl } from '$lib/utils/blog-cover-images';
 
   interface Props {
     title: string;
     excerpt: string;
     date: string;
     slug: string;
-    coverImage: string;
     coverImageAlt: string;
     categories?: (typeof BLOG_CATEGORIES)[number][] | undefined;
     imageUrl?: string | undefined;
@@ -31,7 +31,6 @@
     excerpt,
     date,
     slug,
-    coverImage,
     coverImageAlt,
     categories = undefined,
     imageUrl = undefined,
@@ -53,6 +52,8 @@
   );
 
   let authorNames = $derived(authors?.map((a) => a.name.split(' ')[0]).join(' & '));
+
+  let coverVariant = $derived(compact ? ('compact' as const) : ('card' as const));
 </script>
 
 <svelte:element
@@ -65,7 +66,15 @@
   href="/blog/posts/{slug}"
   target={newTab ? '_blank' : undefined}
 >
-  <img class="cover-image" src={coverImage} alt={coverImageAlt} />
+  <img
+    class="cover-image"
+    src={blogCoverImageUrl(slug, coverVariant)}
+    alt={coverImageAlt}
+    width={BLOG_COVER_IMAGE_VARIANTS[coverVariant].width}
+    height={BLOG_COVER_IMAGE_VARIANTS[coverVariant].height}
+    loading={first ? undefined : 'lazy'}
+    fetchpriority={first ? 'high' : undefined}
+  />
   <div class="content">
     <div>
       {#if first}
@@ -88,7 +97,14 @@
         {#if authors?.length}
           <span class="author-pile">
             {#each authors as author (author.name)}
-              <img class="author-avatar" src={author.avatarUrl} alt={author.name} />
+              <img
+                class="author-avatar"
+                src={author.avatarUrl}
+                alt={author.name}
+                width="24"
+                height="24"
+                loading="lazy"
+              />
             {/each}
           </span>
           <span>{authorNames}</span>

--- a/src/lib/components/blog/post-card/post-card.svelte
+++ b/src/lib/components/blog/post-card/post-card.svelte
@@ -74,6 +74,7 @@
     height={BLOG_COVER_IMAGE_VARIANTS[coverVariant].height}
     loading={first ? undefined : 'lazy'}
     fetchpriority={first ? 'high' : undefined}
+    style:view-transition-name="blog-cover-{slug}"
   />
   <div class="content">
     <div>

--- a/src/lib/utils/blog-cover-images.ts
+++ b/src/lib/utils/blog-cover-images.ts
@@ -1,0 +1,18 @@
+/**
+ * Pre-rendered blog cover image variants, served by `/api/blog-images/[variant]/[slug].jpg`.
+ * All variants for all posts are statically generated at build time, so adding a variant
+ * here is all that's needed to make it available.
+ *
+ * Aspect ratio matches the ~2.34:1 of our cover image sources, so the `first` post card
+ * (which displays the image at its intrinsic aspect) looks the same as before.
+ */
+export const BLOG_COVER_IMAGE_VARIANTS = {
+  card: { width: 1200, height: 512 },
+  compact: { width: 720, height: 308 },
+} as const;
+
+export type BlogCoverImageVariant = keyof typeof BLOG_COVER_IMAGE_VARIANTS;
+
+export function blogCoverImageUrl(slug: string, variant: BlogCoverImageVariant): string {
+  return `/api/blog-images/${variant}/${slug}.jpg`;
+}

--- a/src/lib/utils/blog-cover-images.ts
+++ b/src/lib/utils/blog-cover-images.ts
@@ -3,12 +3,11 @@
  * All variants for all posts are statically generated at build time, so adding a variant
  * here is all that's needed to make it available.
  *
- * Aspect ratio matches the ~2.34:1 of our cover image sources, so the `first` post card
- * (which displays the image at its intrinsic aspect) looks the same as before.
+ * Variants are center-cropped from the (wider) source images to a 10:7 aspect.
  */
 export const BLOG_COVER_IMAGE_VARIANTS = {
-  card: { width: 1200, height: 512 },
-  compact: { width: 720, height: 308 },
+  card: { width: 1200, height: 840 },
+  compact: { width: 720, height: 504 },
 } as const;
 
 export type BlogCoverImageVariant = keyof typeof BLOG_COVER_IMAGE_VARIANTS;

--- a/src/routes/(pages)/(lp)/components/case-study-card.svelte
+++ b/src/routes/(pages)/(lp)/components/case-study-card.svelte
@@ -8,6 +8,7 @@
   import fiatEstimates from '$lib/utils/fiat-estimates/fiat-estimates';
   import CoinAnimation from '$lib/components/coin-animation/coin-animation.svelte';
   import type { SupportedChain } from '$lib/graphql/__generated__/base-types';
+  import { BLOG_COVER_IMAGE_VARIANTS, blogCoverImageUrl } from '$lib/utils/blog-cover-images';
 
   interface Props {
     blogPost:
@@ -50,7 +51,13 @@
     {#if blogPost}
       <a class="typo-text-small" href={`/blog/posts/${blogPost.slug}`} target="_blank">
         <div>
-          <img src={blogPost.coverImage} alt={blogPost.coverImageAlt} loading="lazy" />
+          <img
+            src={blogCoverImageUrl(blogPost.slug, 'compact')}
+            alt={blogPost.coverImageAlt}
+            width={BLOG_COVER_IMAGE_VARIANTS.compact.width}
+            height={BLOG_COVER_IMAGE_VARIANTS.compact.height}
+            loading="lazy"
+          />
           {blogPost.title}
         </div>
         <ChevronRight style="fill: var(--color-foreground)" />

--- a/src/routes/(pages)/app/(app)/components/default-explore-page.svelte
+++ b/src/routes/(pages)/app/(app)/components/default-explore-page.svelte
@@ -83,7 +83,11 @@
 </script>
 
 <div class="explore">
-  <FeatureCard imageUrl="/assets/wave/wave-hp.png">
+  <FeatureCard
+    imageUrl="/assets/wave/wave-hp.png"
+    priorityImage
+    imageDimensions={{ width: 1560, height: 760 }}
+  >
     <div class="highlight-badge typo-header-5">
       <PulsatingCircle pulseColor="rgba(255,255,255,0.5)" />
       NEW

--- a/src/routes/(pages)/app/(app)/components/feature-card.svelte
+++ b/src/routes/(pages)/app/(app)/components/feature-card.svelte
@@ -1,11 +1,14 @@
 <script lang="ts">
   interface Props {
     imageUrl?: string;
+    /** Set for above-the-fold usage so the browser fetches the image with high priority. */
+    priorityImage?: boolean;
+    imageDimensions?: { width: number; height: number };
     children?: import('svelte').Snippet;
     actions?: import('svelte').Snippet;
   }
 
-  let { imageUrl, children, actions }: Props = $props();
+  let { imageUrl, priorityImage = false, imageDimensions, children, actions }: Props = $props();
 
   let imageEl: HTMLImageElement | undefined = $state();
   let imageLoaded = $state(false);
@@ -23,6 +26,9 @@
       bind:this={imageEl}
       class:loaded={imageLoaded}
       src={imageUrl}
+      fetchpriority={priorityImage ? 'high' : undefined}
+      width={imageDimensions?.width}
+      height={imageDimensions?.height}
       onload={() => {
         imageLoaded = true;
       }}

--- a/src/routes/(pages)/wave/(base-layout)/+page.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/+page.svelte
@@ -24,7 +24,11 @@
 <HeadMeta title="Explore Wave Programs | Wave" canonical="https://www.drips.network/wave" />
 
 <div class="page">
-  <FeatureCard imageUrl="/assets/wave/wave-hp.png">
+  <FeatureCard
+    imageUrl="/assets/wave/wave-hp.png"
+    priorityImage
+    imageDimensions={{ width: 1560, height: 760 }}
+  >
     <div>
       <h2 style:margin-bottom="0.25rem">Introducing Drips Wave</h2>
       <p>

--- a/src/routes/api/blog-images/[variant]/[slug].jpg/+server.ts
+++ b/src/routes/api/blog-images/[variant]/[slug].jpg/+server.ts
@@ -1,0 +1,47 @@
+import { error } from '@sveltejs/kit';
+import { z } from 'zod';
+import type { EntryGenerator } from './$types.js';
+import Jimp from 'jimp';
+import { getSlug } from '$lib/utils/blog-posts.js';
+import { BLOG_COVER_IMAGE_VARIANTS } from '$lib/utils/blog-cover-images';
+
+export const GET = async ({ params }) => {
+  const { slug, variant } = params;
+
+  const dimensions =
+    BLOG_COVER_IMAGE_VARIANTS[variant as keyof typeof BLOG_COVER_IMAGE_VARIANTS] ?? undefined;
+  if (!dimensions) error(400, 'Unknown variant');
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let post: any;
+  try {
+    post = await import(`../../../../../blog-posts/${slug}.md`);
+  } catch {
+    error(404, 'Post not found');
+  }
+
+  const { coverImage } = z.object({ coverImage: z.string() }).parse(post.metadata);
+
+  const jimp = (await Jimp.read(`static${coverImage}`))
+    .cover(dimensions.width, dimensions.height)
+    .quality(80);
+
+  return new Response((await jimp.getBufferAsync(Jimp.MIME_JPEG)) as BodyInit, {
+    headers: {
+      'content-type': 'image/jpeg',
+    },
+  });
+};
+
+export const prerender = true;
+
+// Tell SvelteKit to prerender every variant of every post's cover image
+export const entries: EntryGenerator = async () => {
+  const allPosts = import.meta.glob('/src/blog-posts/*.md', { as: 'raw' });
+
+  const slugs = Object.keys(allPosts).map(getSlug);
+
+  return slugs.flatMap((slug) =>
+    Object.keys(BLOG_COVER_IMAGE_VARIANTS).map((variant) => ({ slug, variant })),
+  );
+};

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -35,6 +35,10 @@ const config = {
 
   kit: {
     adapter: adapter(),
+    // Inline all stylesheets into the SSR'd HTML (largest is currently ~32KB).
+    // Serving them as separate files means 40+ render-blocking requests per page,
+    // which dominates first paint for users on high-latency connections.
+    inlineStyleThreshold: 48 * 1024,
     prerender: {
       origin: process.env.PUBLIC_BASE_URL,
     },


### PR DESCRIPTION
Follow-up to #1939, knocking out the rest of what Lighthouse flags on /wave (and most other pages).

**Inline all stylesheets** (`inlineStyleThreshold`): pages were making 40+ render-blocking CSS requests — on /wave that was 41 files for only 23KB compressed total, and the LCP hero sat fully loaded for ~1s waiting on them. All page CSS now ships inline in the SSR'd HTML (verified in the prerendered output: zero active stylesheet links, only SvelteKit's disabled placeholders). Adds roughly 10-15KB gzipped to each HTML response in exchange for eliminating the entire request cascade, which is the right trade for our mostly-cold, high-latency traffic. Client-side navigations are unaffected (CSS keeps loading via JS modules).

**Pre-rendered blog cover variants**: new `/api/blog-images/[variant]/[slug].jpg` endpoint (same Jimp + `prerender` + `entries()` pattern as the share-image endpoint) that crops covers to fixed dimensions — `card` (1200x840) and `compact` (720x504), 10:7 aspect, defined in `blog-cover-images.ts`. All 56 variants are generated at build time and served as static files, so they get edge-cached like any asset. `post-card` and `case-study-card` now render these instead of the raw originals (which were up to 190KB at 1536-1640px wide for ~360px slots), with baked-in `width`/`height` attributes and `loading=lazy` below the fold. Card variants average 80KB, compact 40KB.

**Hero image priority**: the wave/explore hero (`feature-card`) now supports `priorityImage` + `imageDimensions`, and both usages pass `fetchpriority=high` with intrinsic dimensions, so the LCP image no longer waits for layout to be prioritized.

Checked: build passes, all variants generated correctly (spot-checked crops), svelte-check clean, blog post og/twitter meta images untouched.
