### PR TITLE
remove view transition on blog cover images

### DIFF
--- a/src/lib/components/blog/post-card/post-card.svelte
+++ b/src/lib/components/blog/post-card/post-card.svelte
@@ -74,7 +74,6 @@
     height={BLOG_COVER_IMAGE_VARIANTS[coverVariant].height}
     loading={first ? undefined : 'lazy'}
     fetchpriority={first ? 'high' : undefined}
-    style:view-transition-name="blog-cover-{slug}"
   />
   <div class="content">
     <div>


### PR DESCRIPTION
Reverts the `view-transition-name` on post card cover images that unintentionally rode along in the #1940 squash merge (the removal was sitting uncommitted in the working tree). Per-card transition names are glitchy: every card gets its own snapshot group, and duplicate names (same post rendered twice, e.g. listing + latest-news) make the browser abort the transition entirely.