### PR TITLE
preconnect to wave api, defer status check to idle time

### DIFF
--- a/src/lib/components/incident-banner/incident-banner.svelte
+++ b/src/lib/components/incident-banner/incident-banner.svelte
@@ -83,7 +83,7 @@
     dismissablesStore.dismiss(dismissId(incident));
   }
 
-  onMount(async () => {
+  async function checkStatus() {
     try {
       const res = await fetch(STATUS_URL, { cache: 'no-store' });
       if (!res.ok) return;
@@ -98,6 +98,17 @@
       active = parsed.data.incidents?.active ?? [];
     } catch {
       // Status page unreachable — fail silent; a banner is best-effort.
+    }
+  }
+
+  onMount(() => {
+    // Deferred to idle time so the status request doesn't compete with
+    // render-critical work during page load. The banner is position: fixed,
+    // so appearing late causes no layout shift.
+    if ('requestIdleCallback' in window) {
+      requestIdleCallback(() => void checkStatus());
+    } else {
+      setTimeout(() => void checkStatus(), 2000);
     }
   });
 </script>

--- a/src/lib/utils/wave/call.ts
+++ b/src/lib/utils/wave/call.ts
@@ -50,7 +50,7 @@ async function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-const PUBLIC_WAVE_API_URL = getOptionalEnvVarPublic(
+export const PUBLIC_WAVE_API_URL = getOptionalEnvVarPublic(
   'PUBLIC_WAVE_API_URL',
   true,
   'Wave functionality will not work.',

--- a/src/routes/(pages)/wave/+layout.svelte
+++ b/src/routes/(pages)/wave/+layout.svelte
@@ -2,10 +2,19 @@
   import NavProgressBar from '$lib/components/nav-progress-bar/nav-progress-bar.svelte';
   import CookieConsentBanner from '$lib/components/wave/cookie-consent-banner/cookie-consent-banner.svelte';
   import FaroInitializer from '$lib/utils/faro/faro-initializer.svelte';
+  import { PUBLIC_WAVE_API_URL } from '$lib/utils/wave/call';
   import type { Snippet } from 'svelte';
 
   let { children }: { children?: Snippet } = $props();
 </script>
+
+<svelte:head>
+  {#if PUBLIC_WAVE_API_URL}
+    <!-- No `crossorigin`: Wave API requests are credentialed, and browsers only
+         reuse a preconnected socket for them if the hint omits `crossorigin`. -->
+    <link rel="preconnect" href={PUBLIC_WAVE_API_URL} />
+  {/if}
+</svelte:head>
 
 <div class="nav-progress-bar">
   <NavProgressBar color="var(--color-primary)" />


### PR DESCRIPTION
Two small loading-phase tweaks from the latest Lighthouse pass:

- Preconnect to the Wave API from the wave layout, so the TCP+TLS handshake (~430ms at our Nigerian p75 RTT) overlaps with HTML parsing instead of starting when the first client-side call fires after hydration. Deliberately no `crossorigin` attribute: our Wave API fetches are credentialed, and browsers only reuse a preconnected socket for credentialed requests when the hint omits it.

- The incident banner's status.drips.network fetch now runs in `requestIdleCallback` (2s timeout fallback) instead of immediately on mount. It was competing with render-critical requests on every page load — Lighthouse attributed ~300ms of LCP to it. The banner is `position: fixed`, so appearing a moment later causes no layout shift, and an incident banner doesn't need sub-second delivery. This also means we don't need a second preconnect for the status origin at all.