### PR TITLE
throttle bulk wave issue adds

### DIFF
--- a/src/lib/flows/wave/add-issues-to-wave-program/configure-details.svelte
+++ b/src/lib/flows/wave/add-issues-to-wave-program/configure-details.svelte
@@ -21,6 +21,7 @@
   import { getIssue } from '$lib/utils/wave/issues';
   import { getPointsForComplexity } from '$lib/utils/wave/get-points-for-complexity';
   import extractApiErrorMessage from '$lib/utils/wave/utils/extract-api-error-message';
+  import mapWithConcurrency from '$lib/utils/map-with-concurrency';
   import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 
   const dispatch = createEventDispatcher<StepComponentEvents>();
@@ -299,10 +300,12 @@
         const selectedWaveId = selectedWaveIds[0];
         const issuesToAdd = submittableIssues;
 
-        const results = await Promise.allSettled(
-          issuesToAdd.map((issue) =>
-            addIssueToWaveProgram(undefined, selectedWaveId, issue.id, activeComplexity),
-          ),
+        // Adds sequentialize on an org-wide lock on the backend, so firing them
+        // all at once just piles up lock waiters. Keep concurrency low.
+        const results = await mapWithConcurrency(
+          issuesToAdd,
+          (issue) => addIssueToWaveProgram(undefined, selectedWaveId, issue.id, activeComplexity),
+          2,
         );
 
         // Refresh every issue that was added successfully — even on partial

--- a/src/lib/utils/__test__/map-with-concurrency.unit.test.ts
+++ b/src/lib/utils/__test__/map-with-concurrency.unit.test.ts
@@ -1,0 +1,47 @@
+import mapWithConcurrency from '../map-with-concurrency';
+
+describe('map-with-concurrency.ts', () => {
+  it('returns settled results in input order', async () => {
+    const results = await mapWithConcurrency(
+      [1, 2, 3, 4],
+      (n) => (n === 3 ? Promise.reject(new Error('nope')) : Promise.resolve(n * 2)),
+      2,
+    );
+
+    expect(results).toEqual([
+      { status: 'fulfilled', value: 2 },
+      { status: 'fulfilled', value: 4 },
+      { status: 'rejected', reason: new Error('nope') },
+      { status: 'fulfilled', value: 8 },
+    ]);
+  });
+
+  it('never runs more than `concurrency` tasks at once', async () => {
+    let running = 0;
+    let maxRunning = 0;
+
+    await mapWithConcurrency(
+      Array.from({ length: 10 }, (_, i) => i),
+      async () => {
+        running++;
+        maxRunning = Math.max(maxRunning, running);
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        running--;
+      },
+      3,
+    );
+
+    expect(maxRunning).toBe(3);
+  });
+
+  it('continues past rejections and processes all items', async () => {
+    const results = await mapWithConcurrency(
+      Array.from({ length: 5 }, (_, i) => i),
+      (n) => (n % 2 === 0 ? Promise.reject(new Error(`fail ${n}`)) : Promise.resolve(n)),
+      1,
+    );
+
+    expect(results.filter((r) => r.status === 'rejected')).toHaveLength(3);
+    expect(results.filter((r) => r.status === 'fulfilled')).toHaveLength(2);
+  });
+});

--- a/src/lib/utils/map-with-concurrency.ts
+++ b/src/lib/utils/map-with-concurrency.ts
@@ -1,0 +1,31 @@
+/**
+ * Like `Promise.allSettled(items.map(fn))`, but runs at most `concurrency`
+ * invocations of `fn` at a time. Results are returned in input order.
+ * @param items The items to map over.
+ * @param fn The async function to run for each item.
+ * @param concurrency Maximum number of concurrent invocations.
+ * @returns Settled results in the same order as `items`.
+ */
+export default async function <T, R>(
+  items: T[],
+  fn: (item: T, index: number) => Promise<R>,
+  concurrency: number,
+): Promise<PromiseSettledResult<R>[]> {
+  const results: PromiseSettledResult<R>[] = new Array(items.length);
+  let nextIndex = 0;
+
+  async function worker() {
+    while (nextIndex < items.length) {
+      const index = nextIndex++;
+      try {
+        results[index] = { status: 'fulfilled', value: await fn(items[index], index) };
+      } catch (reason) {
+        results[index] = { status: 'rejected', reason };
+      }
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.max(1, concurrency) }, worker));
+
+  return results;
+}


### PR DESCRIPTION
adding a big batch of issues to a wave program fired one request per issue all at once, and they all just pile up on the backend's org-wide lock. now the adds run through a small concurrency-limited runner (max 2 in flight) instead, so the lock queue stays shallow while keeping a bit of pipelining.

the helper keeps `Promise.allSettled` semantics (results in input order, keeps going past failures), so the existing partial-failure handling in the flow is unchanged. added unit tests for it.