### PR TITLE
Add the Quick checkpoint flow for rewards

### DIFF
--- a/src/lib/utils/wave/call.ts
+++ b/src/lib/utils/wave/call.ts
@@ -22,12 +22,33 @@ export class AccountRestrictedError extends Error {
   }
 }
 
+/**
+ * Thrown for 403 responses where the API is holding the request until the user
+ * completes a short identity check.
+ *
+ * Route guards normally catch this before the request is made, so seeing it
+ * means a check fell due mid-session. Callers should send the user to
+ * /wave/checkpoint rather than surfacing a generic error.
+ */
+export class LivenessCheckpointRequiredError extends Error {
+  constructor() {
+    super('A quick identity check is needed before you can continue.');
+    this.name = 'LivenessCheckpointRequiredError';
+  }
+}
+
 function isAccountSuspendedResponse(status: number, body: string): boolean {
   return status === 403 && body.includes('suspended');
 }
 
 function isAccountRestrictedResponse(status: number, body: string): boolean {
   return status === 403 && body.includes('restricted');
+}
+
+// Matched on the machine-readable `code` the backend sets rather than the
+// prose, which is free to change.
+function isCheckpointRequiredResponse(status: number, body: string): boolean {
+  return status === 403 && body.includes('liveness_checkpoint_required');
 }
 
 const MAX_RETRIES = 3;
@@ -151,6 +172,10 @@ export async function authenticatedCall(
 
       if (isAccountRestrictedResponse(res.status, errorText)) {
         throw new AccountRestrictedError();
+      }
+
+      if (isCheckpointRequiredResponse(res.status, errorText)) {
+        throw new LivenessCheckpointRequiredError();
       }
 
       if (res.status === 401) {

--- a/src/lib/utils/wave/liveness.ts
+++ b/src/lib/utils/wave/liveness.ts
@@ -1,0 +1,47 @@
+import z from 'zod';
+import { authenticatedCall } from './call';
+import parseRes from './utils/parse-res';
+
+/** Areas that a checkpoint can be required for. */
+export const livenessCheckpointPurposes = ['grant_access'] as const;
+export type LivenessCheckpointPurpose = (typeof livenessCheckpointPurposes)[number];
+
+/**
+ * Only the fields the UI actually needs. The API decides entirely on its own
+ * whether a check is due; the client never reproduces that logic, and anything
+ * else the response carries is deliberately not picked up here.
+ */
+export const livenessCheckpointStatusSchema = z.object({
+  purpose: z.enum(livenessCheckpointPurposes),
+  satisfied: z.boolean(),
+  challengeStatus: z.enum(['pending', 'approved', 'rejected', 'expired']).nullable(),
+  locked: z.boolean(),
+});
+
+export type LivenessCheckpointStatus = z.infer<typeof livenessCheckpointStatusSchema>;
+
+export async function getLivenessCheckpointStatus(f = fetch, purpose: LivenessCheckpointPurpose) {
+  return parseRes(
+    livenessCheckpointStatusSchema,
+    await authenticatedCall(f, `/api/liveness-checkpoints/status?purpose=${purpose}`, {
+      method: 'GET',
+    }),
+  );
+}
+
+/**
+ * Starts (or resumes) a check and returns a SumSub token scoped to it. Throws
+ * if the user isn't currently allowed to start one.
+ */
+export async function startLivenessCheckpoint(f = fetch, purpose: LivenessCheckpointPurpose) {
+  return parseRes(
+    z.object({
+      accessToken: z.string(),
+      checkpointId: z.uuid(),
+    }),
+    await authenticatedCall(f, `/api/liveness-checkpoints/session`, {
+      method: 'POST',
+      body: JSON.stringify({ purpose }),
+    }),
+  );
+}

--- a/src/routes/(pages)/wave/(base-layout)/rewards/+layout.ts
+++ b/src/routes/(pages)/wave/(base-layout)/rewards/+layout.ts
@@ -1,0 +1,43 @@
+import { getLivenessCheckpointStatus } from '$lib/utils/wave/liveness.js';
+import { redirect } from '@sveltejs/kit';
+
+/**
+ * Sends the user to the checkpoint screen when the API says one is due.
+ *
+ * The API refuses the grants endpoints outright in that case, so without this
+ * guard the user would land on a broken page. Whether a check is actually due
+ * is entirely the API's call — this just asks and acts on the answer.
+ */
+export const load = async ({ parent, url, fetch, depends }) => {
+  depends('wave:liveness-checkpoint');
+
+  const { user } = await parent();
+
+  // Unauthenticated users are redirected to login by the child loads; there is
+  // no checkpoint to evaluate for them.
+  if (!user) return {};
+
+  try {
+    const checkpoint = await getLivenessCheckpointStatus(fetch, 'grant_access');
+
+    if (!checkpoint.satisfied) {
+      throw redirect(
+        302,
+        `/wave/checkpoint?backTo=${encodeURIComponent(url.pathname + url.search)}`,
+      );
+    }
+
+    return { checkpoint };
+  } catch (err) {
+    // Preserve our own redirect above.
+    if (err && typeof err === 'object' && 'status' in err && err.status === 302) {
+      throw err;
+    }
+    // Let the child loads handle auth — they own the login redirect and the
+    // backTo round trip.
+    if (err && typeof err === 'object' && 'status' in err && err.status === 401) {
+      return {};
+    }
+    throw err;
+  }
+};

--- a/src/routes/(pages)/wave/(flows)/checkpoint/+layout.svelte
+++ b/src/routes/(pages)/wave/(flows)/checkpoint/+layout.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  import HeadMeta from '$lib/components/head-meta/head-meta.svelte';
+
+  let { children } = $props();
+</script>
+
+<HeadMeta title="Quick checkpoint | Wave" />
+
+{@render children?.()}

--- a/src/routes/(pages)/wave/(flows)/checkpoint/+layout.ts
+++ b/src/routes/(pages)/wave/(flows)/checkpoint/+layout.ts
@@ -1,3 +1,4 @@
+import { getKycStatus } from '$lib/utils/wave/kyc.js';
 import { getLivenessCheckpointStatus } from '$lib/utils/wave/liveness.js';
 import { redirect } from '@sveltejs/kit';
 
@@ -11,6 +12,25 @@ export const load = async ({ parent, url, fetch, depends }) => {
   }
 
   const checkpoint = await getLivenessCheckpointStatus(fetch, 'grant_access');
+
+  // A checkpoint is a Sumsub applicant *action*, which needs an approved KYC to
+  // hang off — the API refuses to start one otherwise, so this flow would just
+  // dead-end. Identity verification is the actual next step for those users,
+  // and passing it satisfies the checkpoint anyway.
+  //
+  // `backTo` is dropped on purpose: wherever they were headed is gated on the
+  // check they can't take yet, so sending them back would bounce them right
+  // back here — and for a rejected KYC, `kyc-required` redirects to `backTo`,
+  // which would make that an endless loop.
+  if (!checkpoint.satisfied) {
+    const kycStatus = await getKycStatus(fetch);
+    const kycApproved =
+      kycStatus.status === 'applicantReviewed' && kycStatus.reviewAnswer === 'GREEN';
+
+    if (!kycApproved) {
+      throw redirect(302, `/wave/kyc-required?backTo=${encodeURIComponent('/wave')}`);
+    }
+  }
 
   return {
     checkpoint,

--- a/src/routes/(pages)/wave/(flows)/checkpoint/+layout.ts
+++ b/src/routes/(pages)/wave/(flows)/checkpoint/+layout.ts
@@ -1,0 +1,18 @@
+import { getLivenessCheckpointStatus } from '$lib/utils/wave/liveness.js';
+import { redirect } from '@sveltejs/kit';
+
+export const load = async ({ parent, url, fetch, depends }) => {
+  depends('wave:liveness-checkpoint');
+
+  const { user } = await parent();
+
+  if (!user) {
+    throw redirect(302, `/wave/login?backTo=${encodeURIComponent(url.pathname + url.search)}`);
+  }
+
+  const checkpoint = await getLivenessCheckpointStatus(fetch, 'grant_access');
+
+  return {
+    checkpoint,
+  };
+};

--- a/src/routes/(pages)/wave/(flows)/checkpoint/+page.svelte
+++ b/src/routes/(pages)/wave/(flows)/checkpoint/+page.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+  import AnnotationBox from '$lib/components/annotation-box/annotation-box.svelte';
+  import Button from '$lib/components/button/button.svelte';
+  import ArrowRight from '$lib/components/icons/ArrowRight.svelte';
+  import ArrowBoxUpRight from '$lib/components/icons/ArrowBoxUpRight.svelte';
+  import LockAndKeyEmoji from '$lib/components/icons/🔐.svelte';
+  import FlowStepWrapper from '../shared/flow-step-wrapper.svelte';
+
+  let { data } = $props();
+  let { checkpoint, backTo } = $derived(data);
+
+  let previousAttemptFailed = $derived(checkpoint.challengeStatus === 'rejected');
+
+  let description = $derived(
+    previousAttemptFailed
+      ? "That check didn't go through. Take a new selfie in good light with nothing covering your face."
+      : "Before you continue, we need to verify it's really you with a quick selfie.",
+  );
+</script>
+
+<FlowStepWrapper icon={LockAndKeyEmoji} headline="Quick checkpoint" {description}>
+  {#if checkpoint.locked}
+    <AnnotationBox type="warning">
+      <span class="typo-text-small-bold">You've run out of identity checks for now.</span>
+      Please get in touch with support and we'll help you sort it out.
+
+      {#snippet actions()}
+        <Button href="https://docs.drips.network/wave/contributors/faq" target="_blank">
+          Contact support
+        </Button>
+      {/snippet}
+    </AnnotationBox>
+  {:else}
+    <AnnotationBox type="info">
+      It usually takes less than a minute, and you'll be able to withdraw your rewards immediately
+      afterwards.
+
+      {#snippet actions()}
+        <Button
+          href="https://docs.drips.network/wave/contributors/solving-issues-and-earning-rewards#verifying-your-identity"
+          target="_blank"
+          icon={ArrowBoxUpRight}
+        >
+          Learn more
+        </Button>
+      {/snippet}
+    </AnnotationBox>
+  {/if}
+
+  {#snippet leftActions()}
+    <Button variant="ghost" href="/wave">Back to Wave</Button>
+  {/snippet}
+
+  {#snippet actions()}
+    {#if !checkpoint.locked}
+      <Button
+        variant="primary"
+        icon={ArrowRight}
+        href={`/wave/checkpoint/verify?backTo=${encodeURIComponent(backTo)}`}
+      >
+        {previousAttemptFailed ? 'Try again' : 'Start check'}
+      </Button>
+    {/if}
+  {/snippet}
+</FlowStepWrapper>

--- a/src/routes/(pages)/wave/(flows)/checkpoint/+page.svelte
+++ b/src/routes/(pages)/wave/(flows)/checkpoint/+page.svelte
@@ -2,7 +2,6 @@
   import AnnotationBox from '$lib/components/annotation-box/annotation-box.svelte';
   import Button from '$lib/components/button/button.svelte';
   import ArrowRight from '$lib/components/icons/ArrowRight.svelte';
-  import ArrowBoxUpRight from '$lib/components/icons/ArrowBoxUpRight.svelte';
   import LockAndKeyEmoji from '$lib/components/icons/🔐.svelte';
   import FlowStepWrapper from '../shared/flow-step-wrapper.svelte';
 
@@ -36,17 +35,8 @@
   {:else}
     <AnnotationBox type="info">
       It usually takes less than a minute, and you'll be able to withdraw your rewards immediately
-      afterwards.
-
-      {#snippet actions()}
-        <Button
-          href="https://docs.drips.network/wave/contributors/solving-issues-and-earning-rewards#verifying-your-identity"
-          target="_blank"
-          icon={ArrowBoxUpRight}
-        >
-          Learn more
-        </Button>
-      {/snippet}
+      afterwards. <span class="typo-text-small-bold">If your device does not have a webcam,</span>
+      come back here from a mobile device or a laptop with a camera to complete the check.
     </AnnotationBox>
   {/if}
 

--- a/src/routes/(pages)/wave/(flows)/checkpoint/+page.svelte
+++ b/src/routes/(pages)/wave/(flows)/checkpoint/+page.svelte
@@ -56,9 +56,12 @@
 
   {#snippet actions()}
     {#if !checkpoint.locked}
+      <!-- `noPreload` because the verify load starts a checkpoint challenge —
+           hover-preloading it would burn an attempt without a click. -->
       <Button
         variant="primary"
         icon={ArrowRight}
+        noPreload
         href={`/wave/checkpoint/verify?backTo=${encodeURIComponent(backTo)}`}
       >
         {previousAttemptFailed ? 'Try again' : 'Start check'}

--- a/src/routes/(pages)/wave/(flows)/checkpoint/+page.svelte
+++ b/src/routes/(pages)/wave/(flows)/checkpoint/+page.svelte
@@ -9,6 +9,9 @@
   let { data } = $props();
   let { checkpoint, backTo } = $derived(data);
 
+  // Only 'rejected' is a failure. An 'expired' attempt was abandoned or
+  // superseded by a newer one rather than failed, so telling that user "that
+  // check didn't go through" would be wrong — they get the first-time copy.
   let previousAttemptFailed = $derived(checkpoint.challengeStatus === 'rejected');
 
   let description = $derived(

--- a/src/routes/(pages)/wave/(flows)/checkpoint/+page.ts
+++ b/src/routes/(pages)/wave/(flows)/checkpoint/+page.ts
@@ -1,0 +1,19 @@
+import { safeParseBackToParam } from '$lib/utils/safe-path';
+import { redirect } from '@sveltejs/kit';
+
+export const load = async ({ parent, url }) => {
+  const { checkpoint } = await parent();
+
+  const backTo = safeParseBackToParam(url) || '/wave/rewards';
+
+  // Nothing to ask for — either they're already through or the checkpoint
+  // doesn't apply to them.
+  if (checkpoint.satisfied) {
+    throw redirect(302, backTo);
+  }
+
+  return {
+    checkpoint,
+    backTo,
+  };
+};

--- a/src/routes/(pages)/wave/(flows)/checkpoint/success/+page.svelte
+++ b/src/routes/(pages)/wave/(flows)/checkpoint/success/+page.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import Button from '$lib/components/button/button.svelte';
+  import ArrowRight from '$lib/components/icons/ArrowRight.svelte';
+  import FlowStepWrapper from '../../shared/flow-step-wrapper.svelte';
+
+  let { data } = $props();
+  let { backTo } = $derived(data);
+</script>
+
+<FlowStepWrapper
+  confetti
+  headline="You're all set"
+  description="Thanks — that's you verified. Your rewards are unlocked and you can withdraw right away."
+>
+  {#snippet actions()}
+    <Button variant="primary" icon={ArrowRight} href={backTo}>Continue</Button>
+  {/snippet}
+</FlowStepWrapper>

--- a/src/routes/(pages)/wave/(flows)/checkpoint/success/+page.svelte
+++ b/src/routes/(pages)/wave/(flows)/checkpoint/success/+page.svelte
@@ -10,7 +10,7 @@
 <FlowStepWrapper
   confetti
   headline="You're all set"
-  description="Thanks — that's you verified. Your rewards are unlocked and you can withdraw right away."
+  description="Your rewards are unlocked and you can withdraw right away."
 >
   {#snippet actions()}
     <Button variant="primary" icon={ArrowRight} href={backTo}>Continue</Button>

--- a/src/routes/(pages)/wave/(flows)/checkpoint/success/+page.ts
+++ b/src/routes/(pages)/wave/(flows)/checkpoint/success/+page.ts
@@ -1,0 +1,18 @@
+import { safeParseBackToParam } from '$lib/utils/safe-path';
+import { redirect } from '@sveltejs/kit';
+
+export const load = async ({ parent, url }) => {
+  const { checkpoint } = await parent();
+
+  const backTo = safeParseBackToParam(url) || '/wave/rewards';
+
+  // Landing here without having passed means something went wrong on the way —
+  // send them back to the start rather than showing a success screen.
+  if (!checkpoint.satisfied) {
+    throw redirect(302, `/wave/checkpoint?backTo=${encodeURIComponent(backTo)}`);
+  }
+
+  return {
+    backTo,
+  };
+};

--- a/src/routes/(pages)/wave/(flows)/checkpoint/verify/+page.svelte
+++ b/src/routes/(pages)/wave/(flows)/checkpoint/verify/+page.svelte
@@ -118,6 +118,17 @@
         theme: $themeStore.currentTheme === 'light' ? 'light' : 'dark',
       })
       .withOptions({ addViewportTag: false, adaptIframeHeight: true })
+      // What this flow emits once the selfie is uploaded, confirmed against the
+      // SDK's event stream — the unprefixed names below never fire for it.
+      .on('idCheck.onApplicantActionSubmitted', () => {
+        startChecking();
+      })
+      .on('idCheck.onApplicantActionResubmitted', () => {
+        startChecking();
+      })
+      // Sumsub's typings carry a second, unprefixed family of the same events,
+      // and nothing guarantees which one a given level emits. Handling both is
+      // free — the spinner is idempotent, and the poll owns the navigation.
       .on('idCheck.onActionSubmitted', () => {
         startChecking();
       })
@@ -150,6 +161,7 @@
 
 {#if phase === 'checking'}
   <FlowStepWrapper
+    centered
     headline="Checking..."
     description="Hang tight, this usually takes a few seconds. Don't close this page."
   >

--- a/src/routes/(pages)/wave/(flows)/checkpoint/verify/+page.svelte
+++ b/src/routes/(pages)/wave/(flows)/checkpoint/verify/+page.svelte
@@ -1,0 +1,142 @@
+<script lang="ts">
+  import { goto, invalidate } from '$app/navigation';
+  import Spinner from '$lib/components/spinner/spinner.svelte';
+  import themeStore from '$lib/stores/theme/theme.store.js';
+  import {
+    getLivenessCheckpointStatus,
+    startLivenessCheckpoint,
+  } from '$lib/utils/wave/liveness.js';
+  import snsWebSdk, { type SnsWebSdk } from '@sumsub/websdk';
+  import { onDestroy, onMount } from 'svelte';
+  import FlowStepWrapper from '../../shared/flow-step-wrapper.svelte';
+
+  let { data } = $props();
+  let { backTo, sumsubToken } = $derived(data);
+
+  /**
+   * `capturing` — the SumSub SDK is on screen taking the selfie.
+   * `checking` — the selfie is submitted and we're waiting for the verdict.
+   */
+  let phase = $state<'capturing' | 'checking'>('capturing');
+
+  let snsWebSdkInstance: SnsWebSdk | null = null;
+  let pollTimer: ReturnType<typeof setTimeout> | null = null;
+  let stopped = false;
+
+  const POLL_INTERVAL_MS = 2000;
+
+  /**
+   * Polls the backend until the checkpoint resolves.
+   *
+   * The backend is the only authority here: it resolves the challenge from
+   * SumSub's webhook, and falls back to asking SumSub directly if that webhook
+   * is slow or lost. Polling starts as soon as the SDK mounts rather than
+   * waiting for an SDK event, so an event we don't recognise can never leave
+   * the user stuck on a spinner.
+   */
+  async function poll() {
+    if (stopped) return;
+
+    try {
+      const status = await getLivenessCheckpointStatus(undefined, 'grant_access');
+
+      if (status.satisfied) {
+        stopped = true;
+        await invalidate('wave:liveness-checkpoint');
+        await goto(`/wave/checkpoint/success?backTo=${encodeURIComponent(backTo)}`);
+        return;
+      }
+
+      if (status.challengeStatus === 'rejected' || status.locked) {
+        stopped = true;
+        await invalidate('wave:liveness-checkpoint');
+        await goto(`/wave/checkpoint?backTo=${encodeURIComponent(backTo)}`);
+        return;
+      }
+    } catch {
+      // A blip shouldn't end the flow — the next tick will try again.
+    }
+
+    pollTimer = setTimeout(poll, POLL_INTERVAL_MS);
+  }
+
+  function launchWebSdk(accessToken: string) {
+    snsWebSdkInstance = snsWebSdk
+      .init(accessToken, async () => {
+        const refreshed = await startLivenessCheckpoint(undefined, 'grant_access');
+        return refreshed.accessToken;
+      })
+      .withConf({
+        lang: 'en',
+        theme: $themeStore.currentTheme === 'light' ? 'light' : 'dark',
+      })
+      .withOptions({ addViewportTag: false, adaptIframeHeight: true })
+      .on('idCheck.onActionSubmitted', () => {
+        phase = 'checking';
+      })
+      .on('idCheck.onActionCompleted', () => {
+        phase = 'checking';
+      })
+      .build();
+
+    snsWebSdkInstance.launch('#sumsub-target');
+  }
+
+  onMount(() => {
+    launchWebSdk(sumsubToken);
+    pollTimer = setTimeout(poll, POLL_INTERVAL_MS);
+  });
+
+  onDestroy(() => {
+    stopped = true;
+    if (pollTimer) clearTimeout(pollTimer);
+    snsWebSdkInstance?.destroy();
+  });
+</script>
+
+{#if phase === 'checking'}
+  <FlowStepWrapper
+    headline="Checking..."
+    description="Hang tight, this usually takes a few seconds. Don't close this page."
+  >
+    <div class="spinner-wrapper">
+      <Spinner classes="w-12 h-12" />
+    </div>
+  </FlowStepWrapper>
+{/if}
+
+<div class="wrapper" class:hidden={phase === 'checking'}>
+  <div id="sumsub-target"></div>
+</div>
+
+<style>
+  .wrapper {
+    height: 100%;
+    width: 100%;
+    flex: 1;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
+  /* Kept mounted rather than destroyed — tearing the SDK down mid-review can
+     abort the upload it's still finishing in the background. */
+  .wrapper.hidden {
+    display: none;
+  }
+
+  #sumsub-target {
+    width: 100%;
+    height: fit-content;
+    border-radius: 1rem;
+    overflow: hidden;
+    padding: 2rem;
+  }
+
+  .spinner-wrapper {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 3rem 0;
+  }
+</style>

--- a/src/routes/(pages)/wave/(flows)/checkpoint/verify/+page.svelte
+++ b/src/routes/(pages)/wave/(flows)/checkpoint/verify/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { goto, invalidate } from '$app/navigation';
+  import { goto } from '$app/navigation';
+  import AnnotationBox from '$lib/components/annotation-box/annotation-box.svelte';
   import Spinner from '$lib/components/spinner/spinner.svelte';
   import themeStore from '$lib/stores/theme/theme.store.js';
   import {
@@ -19,11 +20,36 @@
    */
   let phase = $state<'capturing' | 'checking'>('capturing');
 
+  /** Set once we've been waiting on a verdict for longer than we'd expect. */
+  let verdictSlow = $state(false);
+
   let snsWebSdkInstance: SnsWebSdk | null = null;
   let pollTimer: ReturnType<typeof setTimeout> | null = null;
   let stopped = false;
+  let checkingSince: number | null = null;
 
   const POLL_INTERVAL_MS = 2000;
+
+  /**
+   * How long we hide the SDK waiting for a verdict before showing it again.
+   *
+   * The SDK re-presents its own retry UI in place (bad lighting, no face
+   * detected, ...), and it does so without an event we can reliably hook, so
+   * an unconditional spinner can bury a prompt the user needs to answer.
+   */
+  const VERDICT_TIMEOUT_MS = 60000;
+
+  function startChecking() {
+    phase = 'checking';
+    verdictSlow = false;
+    checkingSince = Date.now();
+  }
+
+  /** Puts the SDK back on screen — it needs the user again. */
+  function backToCapturing() {
+    phase = 'capturing';
+    checkingSince = null;
+  }
 
   /**
    * Polls the backend until the checkpoint resolves.
@@ -40,10 +66,14 @@
     try {
       const status = await getLivenessCheckpointStatus(undefined, 'grant_access');
 
+      // `invalidateAll` rather than a separate `invalidate` call: invalidating
+      // before navigating re-runs *this* route's loads, which would start a
+      // second challenge and redirect us somewhere we don't want to go.
       if (status.satisfied) {
         stopped = true;
-        await invalidate('wave:liveness-checkpoint');
-        await goto(`/wave/checkpoint/success?backTo=${encodeURIComponent(backTo)}`);
+        await goto(`/wave/checkpoint/success?backTo=${encodeURIComponent(backTo)}`, {
+          invalidateAll: true,
+        });
         return;
       }
 
@@ -56,12 +86,22 @@
         status.locked
       ) {
         stopped = true;
-        await invalidate('wave:liveness-checkpoint');
-        await goto(`/wave/checkpoint?backTo=${encodeURIComponent(backTo)}`);
+        await goto(`/wave/checkpoint?backTo=${encodeURIComponent(backTo)}`, {
+          invalidateAll: true,
+        });
         return;
       }
     } catch {
       // A blip shouldn't end the flow — the next tick will try again.
+    }
+
+    if (
+      phase === 'checking' &&
+      checkingSince !== null &&
+      Date.now() - checkingSince > VERDICT_TIMEOUT_MS
+    ) {
+      verdictSlow = true;
+      backToCapturing();
     }
 
     pollTimer = setTimeout(poll, POLL_INTERVAL_MS);
@@ -79,10 +119,17 @@
       })
       .withOptions({ addViewportTag: false, adaptIframeHeight: true })
       .on('idCheck.onActionSubmitted', () => {
-        phase = 'checking';
+        startChecking();
       })
       .on('idCheck.onActionCompleted', () => {
-        phase = 'checking';
+        startChecking();
+      })
+      // Both mean the SDK is showing the user something they have to act on.
+      .on('idCheck.onError', () => {
+        backToCapturing();
+      })
+      .on('idCheck.onUploadError', () => {
+        backToCapturing();
       })
       .build();
 
@@ -113,6 +160,14 @@
 {/if}
 
 <div class="wrapper" class:hidden={phase === 'checking'}>
+  {#if verdictSlow}
+    <div class="slow-note">
+      <AnnotationBox type="info">
+        This is taking longer than usual. If the check is asking you to try again, follow the
+        prompts — otherwise hang tight, we're still waiting on the result.
+      </AnnotationBox>
+    </div>
+  {/if}
   <div id="sumsub-target"></div>
 </div>
 
@@ -122,8 +177,15 @@
     width: 100%;
     flex: 1;
     display: flex;
+    flex-direction: column;
     justify-content: center;
     align-items: center;
+  }
+
+  .slow-note {
+    width: 100%;
+    max-width: 38rem;
+    padding: 0 2rem;
   }
 
   /* Kept mounted rather than destroyed — tearing the SDK down mid-review can

--- a/src/routes/(pages)/wave/(flows)/checkpoint/verify/+page.svelte
+++ b/src/routes/(pages)/wave/(flows)/checkpoint/verify/+page.svelte
@@ -30,9 +30,9 @@
    *
    * The backend is the only authority here: it resolves the challenge from
    * SumSub's webhook, and falls back to asking SumSub directly if that webhook
-   * is slow or lost. Polling starts as soon as the SDK mounts rather than
-   * waiting for an SDK event, so an event we don't recognise can never leave
-   * the user stuck on a spinner.
+   * is slow or lost. The loop runs on a fixed interval from the moment the SDK
+   * mounts rather than being kicked off by an SDK event, so an event we don't
+   * recognise can never leave the user stuck on a spinner.
    */
   async function poll() {
     if (stopped) return;
@@ -47,7 +47,14 @@
         return;
       }
 
-      if (status.challengeStatus === 'rejected' || status.locked) {
+      // 'expired' means this attempt was superseded (another tab started a new
+      // one), so nothing will ever resolve it. Terminal here too, otherwise the
+      // loop would spin indefinitely.
+      if (
+        status.challengeStatus === 'rejected' ||
+        status.challengeStatus === 'expired' ||
+        status.locked
+      ) {
         stopped = true;
         await invalidate('wave:liveness-checkpoint');
         await goto(`/wave/checkpoint?backTo=${encodeURIComponent(backTo)}`);

--- a/src/routes/(pages)/wave/(flows)/checkpoint/verify/+page.ts
+++ b/src/routes/(pages)/wave/(flows)/checkpoint/verify/+page.ts
@@ -1,0 +1,30 @@
+import { safeParseBackToParam } from '$lib/utils/safe-path';
+import { startLivenessCheckpoint } from '$lib/utils/wave/liveness.js';
+import { redirect } from '@sveltejs/kit';
+
+export const load = async ({ parent, url, fetch }) => {
+  const { checkpoint } = await parent();
+
+  const backTo = safeParseBackToParam(url) || '/wave/rewards';
+
+  if (checkpoint.satisfied) {
+    throw redirect(302, backTo);
+  }
+
+  // Out of tries — the intro step explains what to do about it.
+  if (checkpoint.locked) {
+    throw redirect(302, `/wave/checkpoint?backTo=${encodeURIComponent(backTo)}`);
+  }
+
+  // Starting here rather than on a button press in the component means the
+  // token is fetched server-side on first paint, so the SDK can mount as soon
+  // as the page does. Resumes an in-flight challenge instead of creating a
+  // second one, so a reload mid-flow is harmless.
+  const session = await startLivenessCheckpoint(fetch, 'grant_access');
+
+  return {
+    backTo,
+    sumsubToken: session.accessToken,
+    waveFullscreenFlow: true,
+  };
+};

--- a/src/routes/(pages)/wave/(flows)/shared/flow-step-wrapper.svelte
+++ b/src/routes/(pages)/wave/(flows)/shared/flow-step-wrapper.svelte
@@ -14,6 +14,12 @@
     leftActions?: import('svelte').Snippet;
     actions?: import('svelte').Snippet;
     confetti?: boolean;
+    /**
+     * Centres the whole step vertically instead of anchoring the header to the
+     * top. For steps that are only a header and one element, where the default
+     * "header top, actions bottom" spread leaves a hole in the middle.
+     */
+    centered?: boolean;
   }
 
   let {
@@ -21,13 +27,14 @@
     description = undefined,
     icon = undefined,
     confetti = false,
+    centered = false,
     children,
     leftActions,
     actions,
   }: Props = $props();
 </script>
 
-<div class="step-layout">
+<div class="step-layout" class:centered>
   <div class="top">
     {#if confetti}
       <ConfettiOnClick alsoOnMount>
@@ -92,6 +99,10 @@
     min-height: 8rem;
     width: 100%;
     flex: 1;
+  }
+
+  .step-layout.centered {
+    justify-content: center;
   }
 
   .top {


### PR DESCRIPTION
Adds the "Quick checkpoint" flow — a short identity check users may be asked to complete before viewing or withdrawing their rewards.

The API decides on its own whether a check is due; this PR is the UI for it, plus a guard on `/wave/rewards` that sends the user to the flow when the API says one is needed. Without the guard those pages would break for anyone the API is holding back.

## Flow

Follows the same shape as phone verification, which is the closest existing precedent:

- `/wave/checkpoint` — intro, with a Learn more link.
- `/wave/checkpoint/verify` — the Sumsub WebSDK, then a "Checking…" state.
- `/wave/checkpoint/success` — confetti, then back to wherever they came from via `backTo`.

Copy leads with how quick it is and that withdrawal is available immediately afterwards, so it reads as a speed bump rather than another verification.

The intro's button opts out of hover preloading, since loading the verify route starts a challenge and hovering shouldn't burn an attempt.

A checkpoint is a Sumsub applicant action, so it needs an approved KYC to hang off — the API refuses to start one otherwise. Anyone holding a grant who hasn't verified yet is sent to identity verification instead, which is both the real next step and what satisfies the checkpoint anyway.

## Waiting for the result

Once the selfie is submitted the page polls the API until there's a result. The API is the only authority on the outcome, so the client just asks it every 2s.

Polling starts as soon as the SDK mounts rather than waiting on an SDK event — if we didn't recognise an event, the poll still resolves the flow rather than leaving someone stuck on a spinner. The SDK's own events only drive the switch to the spinner UI, on `idCheck.onApplicantActionSubmitted` (the unprefixed `onActionSubmitted` in Sumsub's typings never fires for this flow; both are handled). The iframe is hidden rather than destroyed during the wait, since tearing it down mid-review can abort an upload it's still finishing.

Hiding it is only ever temporary, though: the SDK re-presents its own retry UI in place (bad lighting, no face detected), which the user can't answer while it's behind the spinner. So it comes back on an SDK error, and after a minute without a verdict.

A failed check returns to the intro with retry wording. Users who can't currently retry get a "contact support" message and no retry button.

## Also

A typed error in the API client for the 403 the API returns while a check is outstanding, so one falling due mid-session is actionable rather than a generic 403.

## Notes for review

- Nothing changes for anyone until this is switched on server-side, and the API change needs to go out first.
- The client deliberately parses only the few response fields it needs and never reproduces any of the API's decision logic.
- The guard lives in `rewards/+layout.ts` so it covers both the list and the detail page. Both child loads `await parent()` before touching the rewards API, so a redirect stops them before they'd hit a 403.
- `npm run check` is clean (0 errors; the 177 warnings are pre-existing and none are from these files).
