### PR TITLE
fix(wave): show recovery copy when a login email is already linked

### DIFF
--- a/src/lib/utils/wave/call.ts
+++ b/src/lib/utils/wave/call.ts
@@ -23,6 +23,23 @@ export class AccountRestrictedError extends Error {
 }
 
 /**
+ * Thrown for the 409 the API returns when the GitHub account's primary email is
+ * already linked to a *different* Wave account.
+ *
+ * Terminal by nature: `users.email` is unique, so the same login will fail the
+ * same way forever. Callers must surface recovery copy rather than the generic
+ * "something went wrong, try again" — a retry can never succeed.
+ */
+export class EmailAlreadyLinkedError extends Error {
+  constructor(message?: string) {
+    super(
+      message ?? 'The email on this GitHub account is already linked to a different Wave account.',
+    );
+    this.name = 'EmailAlreadyLinkedError';
+  }
+}
+
+/**
  * Thrown for 403 responses where the API is holding the request until the user
  * completes a short identity check.
  *
@@ -49,6 +66,25 @@ function isAccountRestrictedResponse(status: number, body: string): boolean {
 // prose, which is free to change.
 function isCheckpointRequiredResponse(status: number, body: string): boolean {
   return status === 403 && body.includes('liveness_checkpoint_required');
+}
+
+// Ditto — matched on the backend's `code`, not the prose.
+function isEmailAlreadyLinkedResponse(status: number, body: string): boolean {
+  return status === 409 && body.includes('email_already_linked');
+}
+
+/**
+ * Pulls the human-readable `error` out of an API error body so we can show the
+ * backend's specific copy (which names the address) instead of a generic
+ * fallback. Returns undefined if the body isn't the shape we expect.
+ */
+function extractErrorMessage(body: string): string | undefined {
+  try {
+    const parsed = JSON.parse(body);
+    return typeof parsed?.error === 'string' ? parsed.error : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 const MAX_RETRIES = 3;
@@ -101,6 +137,10 @@ export async function call(path: string, options: RequestInit = {}) {
 
     if (isAccountRestrictedResponse(response.status, errorText)) {
       throw new AccountRestrictedError();
+    }
+
+    if (isEmailAlreadyLinkedResponse(response.status, errorText)) {
+      throw new EmailAlreadyLinkedError(extractErrorMessage(errorText));
     }
 
     throw new Error(`API call failed: ${response.status} ${response.statusText} - ${errorText}`);

--- a/src/lib/utils/wave/call.unit.test.ts
+++ b/src/lib/utils/wave/call.unit.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// `call.ts` resolves the API base URL at module load, and pulls in `./auth`
+// (which reaches for SvelteKit's navigation/environment modules). Stub both so
+// the module can be imported in isolation.
+vi.mock('$env/static/public', () => ({
+  PUBLIC_WAVE_API_URL: 'http://wave.test',
+  PUBLIC_INTERNAL_WAVE_API_URL: 'http://wave.test',
+  PUBLIC_SUPPRESS_MISSING_VAR_IN_PROD_ERRORS: 'true',
+}));
+
+vi.mock('./auth', () => ({
+  getRefreshedAuthToken: vi.fn(async () => null),
+}));
+
+import { AccountSuspendedError, call, EmailAlreadyLinkedError } from './call';
+
+function errorResponse(status: number, body: unknown) {
+  return {
+    ok: false,
+    status,
+    statusText: 'Error',
+    text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
+  } as Response;
+}
+
+describe('call — email-already-linked handling', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('throws EmailAlreadyLinkedError for a 409 carrying the code', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        errorResponse(409, {
+          error: 'The email address on this GitHub account (dev@example.com) is already linked…',
+          code: 'email_already_linked',
+        }),
+      ),
+    );
+
+    await expect(call('/api/auth/oauth/github/redeem-login')).rejects.toBeInstanceOf(
+      EmailAlreadyLinkedError,
+    );
+  });
+
+  it("surfaces the backend's message, which names the address", async () => {
+    const message =
+      'The email address on this GitHub account (dev@example.com) is already linked to a different Wave account.';
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => errorResponse(409, { error: message, code: 'email_already_linked' })),
+    );
+
+    await expect(call('/api/auth/oauth/github/redeem-login')).rejects.toThrow(message);
+  });
+
+  it('falls back to generic copy when the body has no usable message', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => errorResponse(409, 'email_already_linked but not json')),
+    );
+
+    const err = await call('/api/auth/oauth/github/redeem-login').catch((e) => e);
+
+    expect(err).toBeInstanceOf(EmailAlreadyLinkedError);
+    expect(err.message).toBe(
+      'The email on this GitHub account is already linked to a different Wave account.',
+    );
+  });
+
+  it('leaves other 409s as generic errors', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => errorResponse(409, { error: 'Something else conflicted' })),
+    );
+
+    const err = await call('/api/whatever').catch((e) => e);
+
+    expect(err).not.toBeInstanceOf(EmailAlreadyLinkedError);
+    expect(err.message).toContain('API call failed: 409');
+  });
+
+  it('does not mistake the code on a non-409 status', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => errorResponse(500, { error: 'boom', code: 'email_already_linked' })),
+    );
+
+    const err = await call('/api/whatever').catch((e) => e);
+
+    expect(err).not.toBeInstanceOf(EmailAlreadyLinkedError);
+  });
+
+  it('still routes 403 suspensions to AccountSuspendedError', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => errorResponse(403, { error: 'Account suspended' })),
+    );
+
+    await expect(call('/api/whatever')).rejects.toBeInstanceOf(AccountSuspendedError);
+  });
+});

--- a/src/routes/(pages)/wave/(flows)/login/callback/+page.svelte
+++ b/src/routes/(pages)/wave/(flows)/login/callback/+page.svelte
@@ -5,13 +5,20 @@
   import { goto, invalidateAll } from '$app/navigation';
   import Spinner from '$lib/components/spinner/spinner.svelte';
   import Button from '$lib/components/button/button.svelte';
-  import { AccountSuspendedError } from '$lib/utils/wave/call';
+  import { AccountSuspendedError, EmailAlreadyLinkedError } from '$lib/utils/wave/call';
+  import LargeEmptyState from '$lib/components/large-empty-state/large-empty-state.svelte';
   import { getKycStatus } from '$lib/utils/wave/kyc';
 
   let { data } = $props();
   let { backTo, skipWelcome } = $derived(data);
 
   let error = $state<boolean>(false);
+
+  // Set instead of `error` when the GitHub account's primary email already
+  // belongs to another Wave account. Holds the backend's copy, which names the
+  // address. Distinct state because this one is terminal: the generic branch
+  // offers "Try again", which for this failure can never work.
+  let emailAlreadyLinkedMessage = $state<string | null>(null);
 
   // If backTo already points at /wave/kyc-required (e.g. the user was bounced
   // through login from that page), unwrap the inner backTo so we don't nest
@@ -73,6 +80,11 @@
         return goto('/wave/suspended');
       }
 
+      if (err instanceof EmailAlreadyLinkedError) {
+        emailAlreadyLinkedMessage = err.message;
+        return;
+      }
+
       // eslint-disable-next-line no-console
       console.error('Login callback error:', err);
       error = true;
@@ -87,7 +99,27 @@
   style:align-items="center"
   style:gap="1rem"
 >
-  {#if error}
+  {#if emailAlreadyLinkedMessage}
+    <LargeEmptyState
+      emoji="✉️"
+      headline="That email is already linked to another account"
+      description={emailAlreadyLinkedMessage}
+      secondaryButton={{
+        label: 'Use a different account',
+        handler: () => {
+          window.location.href = '/wave/login';
+        },
+      }}
+      button={{
+        label: 'Contact support',
+        handler: () => {
+          window.location.href =
+            'mailto:support@drips.network?subject=' +
+            encodeURIComponent('Wave login: email already linked to another account');
+        },
+      }}
+    />
+  {:else if error}
     <div class="typo-heading-3" style:text-align="center" style:color="var(--color-error)">
       Something went wrong. Please try again, and if this problem persists, contact us at
       support@drips.network.

--- a/src/routes/(pages)/wave/(flows)/login/callback/perform-login.ts
+++ b/src/routes/(pages)/wave/(flows)/login/callback/perform-login.ts
@@ -1,5 +1,5 @@
 import { redeemGitHubOAuthCode } from '$lib/utils/wave/auth';
-import { AccountSuspendedError } from '$lib/utils/wave/call';
+import { AccountSuspendedError, EmailAlreadyLinkedError } from '$lib/utils/wave/call';
 import { error } from '@sveltejs/kit';
 
 export default async function performLogin(url: URL) {
@@ -23,6 +23,9 @@ export default async function performLogin(url: URL) {
     return { accessToken, newUser };
   } catch (e) {
     if (e instanceof AccountSuspendedError) throw e;
+    // Terminal and actionable — the caller renders specific recovery copy, so
+    // it must not be flattened into the generic "GitHub may be having issues".
+    if (e instanceof EmailAlreadyLinkedError) throw e;
     throw error(500, 'GitHub OAuth exchange failed. GitHub may be experiencing issues.');
   }
 }


### PR DESCRIPTION
## What

When a GitHub account's primary email already belongs to a different Wave account, login cannot succeed — `users.email` is unique, so the same login fails the same way forever.

Until now the callback page rendered the generic branch:

> Something went wrong. Please try again, and if this problem persists, contact us at support@drips.network.

…behind a **Try again** button. For this failure that button can never work, so people loop on it and give up. Production shows 3-5 attempts in ~13 minutes before abandonment.

## Change

The backend now returns `409` with `code: "email_already_linked"` (drips-network/wave#790). This PR surfaces it:

- `EmailAlreadyLinkedError` in `call.ts`, matched on the machine-readable `code` rather than the prose — same pattern as the existing suspended / restricted / checkpoint errors.
- The backend's message (which names the address) is carried through, with a generic fallback if the body isn't the expected shape.
- `perform-login` rethrows it instead of flattening it into "GitHub may be experiencing issues".
- The callback page renders a `LargeEmptyState` with the two actions that can actually help — **Use a different account** and **Contact support** — instead of a dead "Try again".

## Tests

6 new unit tests in `call.unit.test.ts`: the 409 + code maps to the typed error, the backend message is surfaced, the fallback copy applies when the body isn't JSON, other 409s stay generic, the code on a non-409 status is ignored, and 403 suspensions still route to `AccountSuspendedError`.

`npm run check` reports no errors in the touched files.

## Deploy order

Merge drips-network/wave#790 first. Safe either way — without the backend change this code path simply never triggers and today's generic message still shows.