### PR TITLE
fix(wave): send users with unverified GitHub emails to a dedicated page

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -46,6 +46,13 @@ const waveHandle: Handle = async ({ event, resolve }) => {
           if (!res.ok) {
             if (res.status === 403) {
               const body = await res.text();
+              // The machine-readable `code` match runs before the bare-word
+              // 'suspended' one so prose can't shadow it.
+              if (body.includes('unverified_email')) {
+                event.cookies.delete('wave_refresh_token', { path: '/' });
+                event.cookies.delete('wave_access_token', { path: '/' });
+                throw redirect(302, '/wave/unverified-email');
+              }
               if (body.includes('suspended')) {
                 event.cookies.delete('wave_refresh_token', { path: '/' });
                 event.cookies.delete('wave_access_token', { path: '/' });

--- a/src/lib/utils/wave/auth.ts
+++ b/src/lib/utils/wave/auth.ts
@@ -1,5 +1,5 @@
 import z from 'zod';
-import { authenticatedCall, call, AccountSuspendedError } from './call';
+import { authenticatedCall, call, AccountSuspendedError, UnverifiedEmailError } from './call';
 import { jwtDecode } from 'jwt-decode';
 import type { WaveUser } from './types/user';
 import parseRes from './utils/parse-res';
@@ -115,6 +115,11 @@ export async function getRefreshedAuthToken(manualCookie?: string) {
 
       if (e instanceof AccountSuspendedError) {
         await goto('/wave/suspended');
+        return null;
+      }
+
+      if (e instanceof UnverifiedEmailError) {
+        await goto('/wave/unverified-email');
         return null;
       }
 

--- a/src/lib/utils/wave/call.ts
+++ b/src/lib/utils/wave/call.ts
@@ -37,6 +37,19 @@ export class LivenessCheckpointRequiredError extends Error {
   }
 }
 
+/**
+ * Thrown for 403 responses where the backend rejects a login or token refresh
+ * because the user's GitHub primary email address is unverified. Callers
+ * should send the user to /wave/unverified-email, which explains how to
+ * verify the address on GitHub.
+ */
+export class UnverifiedEmailError extends Error {
+  constructor() {
+    super("Your GitHub account's primary email address is not verified.");
+    this.name = 'UnverifiedEmailError';
+  }
+}
+
 function isAccountSuspendedResponse(status: number, body: string): boolean {
   return status === 403 && body.includes('suspended');
 }
@@ -49,6 +62,12 @@ function isAccountRestrictedResponse(status: number, body: string): boolean {
 // prose, which is free to change.
 function isCheckpointRequiredResponse(status: number, body: string): boolean {
   return status === 403 && body.includes('liveness_checkpoint_required');
+}
+
+// Matched on the machine-readable `code` the backend sets rather than the
+// prose, which is free to change.
+function isUnverifiedEmailResponse(status: number, body: string): boolean {
+  return status === 403 && body.includes('unverified_email');
 }
 
 const MAX_RETRIES = 3;
@@ -94,6 +113,12 @@ export async function call(path: string, options: RequestInit = {}) {
 
   if (!response.ok) {
     const errorText = await response.text();
+
+    // The machine-readable code match runs before the bare-word ones so prose
+    // containing "suspended"/"restricted" can't shadow it.
+    if (isUnverifiedEmailResponse(response.status, errorText)) {
+      throw new UnverifiedEmailError();
+    }
 
     if (isAccountSuspendedResponse(response.status, errorText)) {
       throw new AccountSuspendedError();
@@ -166,16 +191,22 @@ export async function authenticatedCall(
     } else if ((!res.ok && res.status !== 404) || res.status === 403) {
       const errorText = await res.text();
 
+      // The machine-readable code match runs before the bare-word ones so
+      // prose containing "suspended"/"restricted" can't shadow it. The
+      // unverified-email code is only set on login and token refresh, which go
+      // through call() and the server hook, so it is not matched here — an
+      // unhandled UnverifiedEmailError in an SSR load would surface as a 500
+      // instead of the 403 page.
+      if (isCheckpointRequiredResponse(res.status, errorText)) {
+        throw new LivenessCheckpointRequiredError();
+      }
+
       if (isAccountSuspendedResponse(res.status, errorText)) {
         throw new AccountSuspendedError();
       }
 
       if (isAccountRestrictedResponse(res.status, errorText)) {
         throw new AccountRestrictedError();
-      }
-
-      if (isCheckpointRequiredResponse(res.status, errorText)) {
-        throw new LivenessCheckpointRequiredError();
       }
 
       if (res.status === 401) {

--- a/src/routes/(pages)/wave/(flows)/login/callback/+page.svelte
+++ b/src/routes/(pages)/wave/(flows)/login/callback/+page.svelte
@@ -5,7 +5,7 @@
   import { goto, invalidateAll } from '$app/navigation';
   import Spinner from '$lib/components/spinner/spinner.svelte';
   import Button from '$lib/components/button/button.svelte';
-  import { AccountSuspendedError } from '$lib/utils/wave/call';
+  import { AccountSuspendedError, UnverifiedEmailError } from '$lib/utils/wave/call';
   import { getKycStatus } from '$lib/utils/wave/kyc';
 
   let { data } = $props();
@@ -71,6 +71,10 @@
     } catch (err) {
       if (err instanceof AccountSuspendedError) {
         return goto('/wave/suspended');
+      }
+
+      if (err instanceof UnverifiedEmailError) {
+        return goto('/wave/unverified-email');
       }
 
       // eslint-disable-next-line no-console

--- a/src/routes/(pages)/wave/(flows)/login/callback/perform-login.ts
+++ b/src/routes/(pages)/wave/(flows)/login/callback/perform-login.ts
@@ -1,5 +1,5 @@
 import { redeemGitHubOAuthCode } from '$lib/utils/wave/auth';
-import { AccountSuspendedError } from '$lib/utils/wave/call';
+import { AccountSuspendedError, UnverifiedEmailError } from '$lib/utils/wave/call';
 import { error } from '@sveltejs/kit';
 
 export default async function performLogin(url: URL) {
@@ -22,7 +22,7 @@ export default async function performLogin(url: URL) {
 
     return { accessToken, newUser };
   } catch (e) {
-    if (e instanceof AccountSuspendedError) throw e;
+    if (e instanceof AccountSuspendedError || e instanceof UnverifiedEmailError) throw e;
     throw error(500, 'GitHub OAuth exchange failed. GitHub may be experiencing issues.');
   }
 }

--- a/src/routes/(pages)/wave/(flows)/unverified-email/+page.svelte
+++ b/src/routes/(pages)/wave/(flows)/unverified-email/+page.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import LargeEmptyState from '$lib/components/large-empty-state/large-empty-state.svelte';
+</script>
+
+<LargeEmptyState
+  emoji="📭"
+  headline="Verify your email on GitHub"
+  description="Your GitHub account's primary email address isn't verified, which is required for using Wave. Verify it on GitHub, then sign in again."
+  learnMoreLink={{
+    label: 'How to verify your email address on GitHub',
+    url: 'https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/verifying-your-email-address',
+  }}
+  button={{
+    label: 'Sign in again',
+    handler: () => {
+      window.location.href = '/wave/login';
+    },
+  }}
+/>


### PR DESCRIPTION
Frontend half of drips-network/wave#791 (backend: drips-network/wave#792).

## Problem

The wave backend now rejects logins and token refreshes with a 403 carrying the
machine-readable code `unverified_email` when the user's GitHub primary email
address is unverified. Without frontend handling, those users would land on the
generic "Something went wrong" screen (login) or be silently logged out
(refresh) with no explanation.

## Changes

- New typed `UnverifiedEmailError` in `call.ts`, matched on the backend's
  `unverified_email` code. The machine-readable code matches now run before the
  bare-word `suspended`/`restricted` matches so prose can't shadow them. The
  check is deliberately scoped to `call()` — the backend only sets this code on
  login and refresh, and matching it in `authenticatedCall()` would turn an SSR
  load failure into an unhandled 500.
- New `/wave/unverified-email` page (mirrors `/wave/suspended`): explains the
  situation, links GitHub's "verifying your email address" docs, and offers
  "Sign in again".
- All three rejection paths route there: the login callback, the client-side
  token refresh (after logout), and the server-side refresh hook (cookies
  cleared, 302).

## Notes

Recovery is self-healing: the user verifies the address on GitHub and signs in
again — no app-side verification flow needed.
