### PR TITLE
feat(wave): show account-owned grants in the withdrawal magic links admin

### DIFF
--- a/src/lib/utils/wave/admin/magic-links.ts
+++ b/src/lib/utils/wave/admin/magic-links.ts
@@ -43,6 +43,8 @@ const withdrawableGrantSummarySchema = z.object({
   waveProgramSlug: z.string(),
   waveProgramName: z.string(),
   waveNumber: z.number().int(),
+  isOrgGrant: z.boolean(),
+  orgLogin: z.string().nullable(),
   activeMagicLink: magicLinkSchema.nullable(),
 });
 export type WithdrawableGrantSummary = z.infer<typeof withdrawableGrantSummarySchema>;

--- a/src/routes/(pages)/wave/(base-layout)/admin/withdrawal-magic-links/+page.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/admin/withdrawal-magic-links/+page.svelte
@@ -102,8 +102,10 @@
     <p class="intro typo-text">
       Issue a one-time withdrawal link for a user who can no longer sign in to Wave via GitHub. Send
       the URL to the user out-of-band — they can use it to initiate test transactions and
-      withdrawals on their personal grants without an authenticated session. Links last 7 days and
-      can be revoked at any time.
+      withdrawals without an authenticated session. Covers their personal grants and grants issued
+      to an installation on their own GitHub account. Grants issued to a GitHub organization are not
+      listed: those are recoverable by adding another member to the organization. Links last 7 days
+      and can be revoked at any time.
     </p>
 
     <div class="form-row">
@@ -166,7 +168,7 @@
 
       {#if lookupResult.grants.length === 0}
         <AnnotationBox type="info">
-          This user has no personal grants that are currently withdrawable.
+          This user has no eligible grants that are currently withdrawable.
         </AnnotationBox>
       {:else}
         <div class="grants-table">
@@ -182,6 +184,12 @@
                   <span>{grant.type}</span>
                   <span class="tnum">${grant.currentAmountUSD.toLocaleString()} USD</span>
                   <span>expires {formatDate(grant.expiresAt, 'dayAndYear')}</span>
+                  {#if grant.isOrgGrant}
+                    <span
+                      title="Issued to the GitHub App installation on this person's own account, so it resolves to the same user."
+                      >account grant{grant.orgLogin ? ` · ${grant.orgLogin}` : ''}</span
+                    >
+                  {/if}
                 </div>
                 {#if grant.activeMagicLink}
                   <div class="grant-line subtle typo-text-small">

--- a/src/routes/(pages)/wave/(flows)/withdraw/magic/session/+page.ts
+++ b/src/routes/(pages)/wave/(flows)/withdraw/magic/session/+page.ts
@@ -37,7 +37,7 @@ const sessionGrantSchema = z.object({
   expiresAt: z.coerce.date(),
   createdAt: z.coerce.date(),
   updatedAt: z.coerce.date(),
-  recipientGitHubUsername: z.string(),
+  recipientGitHubUsername: z.string().nullable(),
   transactions: z.array(
     z.object({
       id: z.uuid(),


### PR DESCRIPTION
Follows the corresponding Wave API change (drips-network/wave#796), which widens the withdrawable-grants lookup so one username returns both a user's personal grants and grants issued to an installation on their own GitHub account.

## Deploy order: backend first

`isOrgGrant` and `orgLogin` are required fields in the response schema, so this must not ship ahead of drips-network/wave#796. If it does, `parseRes` throws a `ZodError` and the admin lookup page fails for **every** username — not just ones with account-owned grants — surfacing a raw Zod error instead of results.

## Changes

- **Admin table** labels which rows are account-owned, so it is clear at a glance which grant a link is being issued for.
- **Intro copy** no longer says "personal grants" only, and notes that organization-issued grants are not listed — those are recoverable by adding another member to the organization.
- **Empty state** reworded from "no personal grants" to "no eligible grants".

## Schema updates

Two response schemas relaxed to match the API:

- `withdrawableGrantSummarySchema` gained `isOrgGrant` and `orgLogin`.
- The magic-link session grant's `recipientGitHubUsername` is now nullable.

## Verification

`svelte-check` reports 440 errors / 177 warnings — byte-identical to the count on `main`, so this adds none. `prettier` and `eslint` clean on the changed files.