### PR TITLE
feat(wave): restriction category + Discord unlink in the admin ban UI

### DIFF
--- a/src/lib/utils/wave/bans.ts
+++ b/src/lib/utils/wave/bans.ts
@@ -10,11 +10,22 @@ import {
 export const restrictionTypeSchema = z.enum(['ban', 'restriction']);
 export type RestrictionType = z.infer<typeof restrictionTypeSchema>;
 
+/**
+ * Why a restriction was applied. `offense` is conduct (T&C violation, evasion,
+ * sybil, …) and counts as a negative signal in integrity analysis;
+ * `account_migration` retires an old account the user moved away from (KYC
+ * transfer, GitHub suspension, duplicate consolidation) and is administrative.
+ * Only bans can be account migrations.
+ */
+export const restrictionCategorySchema = z.enum(['offense', 'account_migration']);
+export type RestrictionCategory = z.infer<typeof restrictionCategorySchema>;
+
 export const bannedUserSchema = z.object({
   id: z.uuid(),
   gitHubUserId: z.number().int(),
   gitHubUsername: z.string().nullable(),
   type: restrictionTypeSchema,
+  category: restrictionCategorySchema,
   reason: z.string().nullable(),
   bannedAt: z.coerce.date(),
   bannedBy: z
@@ -29,10 +40,14 @@ export type BannedUser = z.infer<typeof bannedUserSchema>;
 export const discordBanResultSchema = z.enum(['banned', 'no_linked_account', 'failed']);
 export type DiscordBanResult = z.infer<typeof discordBanResultSchema>;
 
+export const discordUnlinkResultSchema = z.enum(['unlinked', 'no_linked_account']);
+export type DiscordUnlinkResult = z.infer<typeof discordUnlinkResultSchema>;
+
 export const banGitHubUserResponseSchema = z.object({
   success: z.boolean(),
   revokedTokenCount: z.number().int().nonnegative(),
   discordBanResult: discordBanResultSchema.nullable().optional(),
+  discordUnlinkResult: discordUnlinkResultSchema.nullable().optional(),
 });
 export type BanGitHubUserResponse = z.infer<typeof banGitHubUserResponseSchema>;
 
@@ -51,11 +66,18 @@ export type BanTargetDiscordAccount = z.infer<
 
 export async function listBans(
   f = fetch,
-  options: { pagination?: PaginationInput; type?: RestrictionType } = {},
+  options: {
+    pagination?: PaginationInput;
+    type?: RestrictionType;
+    category?: RestrictionCategory;
+  } = {},
 ) {
   const params = new URLSearchParams(toPaginationParams(options.pagination));
   if (options.type) {
     params.append('type', options.type);
+  }
+  if (options.category) {
+    params.append('category', options.category);
   }
 
   const queryString = params.toString();
@@ -70,9 +92,14 @@ export async function banGitHubUser(
   data: {
     gitHubUserId: number;
     type: RestrictionType;
+    /** Defaults to `offense` on the backend. `account_migration` requires type `ban`. */
+    category?: RestrictionCategory;
     reason?: string;
     skipNotification?: boolean;
+    /** Ban the linked Discord account from the server. Mutually exclusive with `unlinkDiscord`. */
     banFromDiscord?: boolean;
+    /** Unlink the Discord account from this Wave account so it can be re-linked to a new one. */
+    unlinkDiscord?: boolean;
   },
 ) {
   const res = await authenticatedCall(f, '/api/admin/bans', {

--- a/src/routes/(pages)/wave/(base-layout)/admin/bans/+page.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/admin/bans/+page.svelte
@@ -20,12 +20,19 @@
 
   let bans = $derived(data.bans);
   let typeFilter = $state<string>(data.type ?? 'all');
+  let categoryFilter = $state<string>(data.category ?? 'all');
   let refreshing = $state(false);
 
   const typeOptions = [
     { value: 'all', title: 'All' },
     { value: 'ban', title: 'Bans' },
     { value: 'restriction', title: 'Restrictions' },
+  ];
+
+  const categoryOptions = [
+    { value: 'all', title: 'All' },
+    { value: 'offense', title: 'Offenses' },
+    { value: 'account_migration', title: 'Account migrations' },
   ];
 
   async function refresh() {
@@ -40,6 +47,11 @@
       url.searchParams.delete('type');
     } else {
       url.searchParams.set('type', typeFilter);
+    }
+    if (categoryFilter === 'all') {
+      url.searchParams.delete('category');
+    } else {
+      url.searchParams.set('category', categoryFilter);
     }
     await goto(url.pathname + url.search, { keepFocus: true, noScroll: true });
   }
@@ -106,12 +118,18 @@
           : typeFilter === 'ban'
             ? 'No active bans'
             : 'No active restrictions',
-      emptyStateText: 'Use the button above to ban or restrict a GitHub user.',
+      emptyStateText:
+        categoryFilter === 'all'
+          ? 'Use the button above to ban or restrict a GitHub user.'
+          : 'Nothing matches the current category filter.',
     }}
   >
-    <div class="filter">
+    <div class="filters">
       <FormField title="Type">
         <Dropdown options={typeOptions} bind:value={typeFilter} onchange={applyFilter} />
+      </FormField>
+      <FormField title="Category">
+        <Dropdown options={categoryOptions} bind:value={categoryFilter} onchange={applyFilter} />
       </FormField>
     </div>
 
@@ -129,6 +147,14 @@
                 >
                   {ban.type}
                 </span>
+                {#if ban.category === 'account_migration'}
+                  <span
+                    class="badge migration"
+                    title="Administrative — the user moved to a new account"
+                  >
+                    account migration
+                  </span>
+                {/if}
                 <span class="dim">·</span>
                 <span class="dim">{formatDate(ban.bannedAt)}</span>
                 {#if ban.bannedBy}
@@ -163,9 +189,15 @@
     gap: 1.5rem;
   }
 
-  .filter {
-    max-width: 16rem;
+  .filters {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
     margin-bottom: 1.5rem;
+  }
+
+  .filters > :global(*) {
+    width: 16rem;
   }
 
   .list {
@@ -221,6 +253,11 @@
   .badge.restriction {
     background: var(--color-caution-level-1);
     color: var(--color-caution-level-6);
+  }
+
+  .badge.migration {
+    background: var(--color-foreground-level-2);
+    color: var(--color-foreground-level-6);
   }
 
   .dim {

--- a/src/routes/(pages)/wave/(base-layout)/admin/bans/+page.ts
+++ b/src/routes/(pages)/wave/(base-layout)/admin/bans/+page.ts
@@ -1,4 +1,4 @@
-import { listBans, type RestrictionType } from '$lib/utils/wave/bans.js';
+import { listBans, type RestrictionCategory, type RestrictionType } from '$lib/utils/wave/bans.js';
 import { getAllPaginated } from '$lib/utils/wave/getAllPaginated.js';
 import { redirect } from '@sveltejs/kit';
 
@@ -15,12 +15,19 @@ export const load = async ({ parent, fetch, depends, url }) => {
   const type: RestrictionType | undefined =
     typeParam === 'ban' || typeParam === 'restriction' ? typeParam : undefined;
 
+  const categoryParam = url.searchParams.get('category');
+  const category: RestrictionCategory | undefined =
+    categoryParam === 'offense' || categoryParam === 'account_migration'
+      ? categoryParam
+      : undefined;
+
   const bans = await getAllPaginated((page, limit) =>
-    listBans(fetch, { pagination: { page, limit }, type }),
+    listBans(fetch, { pagination: { page, limit }, type, category }),
   );
 
   return {
     bans,
     type,
+    category,
   };
 };

--- a/src/routes/(pages)/wave/(base-layout)/admin/bans/components/create-ban-modal.svelte
+++ b/src/routes/(pages)/wave/(base-layout)/admin/bans/components/create-ban-modal.svelte
@@ -13,6 +13,7 @@
     banGitHubUser,
     getBanTargetDiscordAccount,
     type BanTargetDiscordAccount,
+    type RestrictionCategory,
     type RestrictionType,
   } from '$lib/utils/wave/bans';
 
@@ -30,8 +31,26 @@
     },
   ];
 
+  const categoryOptions = [
+    { value: 'offense', title: 'Offense — T&C violation, evasion, sybil, harassment, …' },
+    {
+      value: 'account_migration',
+      title: 'Account migration — retiring an old account the user has moved away from',
+    },
+  ];
+
+  const discordActionOptions = [
+    { value: 'ban', title: 'Ban from the Discord server' },
+    {
+      value: 'unlink',
+      title: 'Unlink from this Wave account — lets them link it to their new account',
+    },
+    { value: 'none', title: 'Leave as is' },
+  ];
+
   let query = $state('');
   let type = $state<string>('ban');
+  let category = $state<string>('offense');
   let reason = $state('');
   let skipNotification = $state(false);
 
@@ -43,7 +62,7 @@
   let lookupToken = 0;
 
   let discordAccount = $state<BanTargetDiscordAccount>(null);
-  let banFromDiscord = $state(true);
+  let discordAction = $state<string>('ban');
 
   let submitting = $state(false);
   let submitError = $state<string | null>(null);
@@ -51,6 +70,29 @@
 
   const trimmedQuery = $derived(query.trim());
   const canSubmit = $derived(!!resolvedUser && !submitting && !lookingUp && reason.length <= 500);
+  // Restrictions are always offenses; only bans can be account migrations.
+  const effectiveCategory = $derived<RestrictionCategory>(
+    type === 'ban' && category === 'account_migration' ? 'account_migration' : 'offense',
+  );
+
+  /**
+   * The category decides what the rest of the form should default to: an
+   * account migration is not punitive, so the user shouldn't get the "you've
+   * been banned" email, and their Discord account should follow them to the
+   * new Wave account rather than get banned from the server.
+   */
+  function applyCategoryDefaults(value: string) {
+    const migration = value === 'account_migration';
+    skipNotification = migration;
+    discordAction = migration ? 'unlink' : 'ban';
+  }
+
+  function onTypeChange(value: string) {
+    if (value === 'restriction' && category === 'account_migration') {
+      category = 'offense';
+      applyCategoryDefaults('offense');
+    }
+  }
   // Wave stores no avatar for accounts it only knows by ID, so fall back to
   // GitHub's ID-keyed avatar URL, which needs no API call.
   const avatarUrl = $derived(
@@ -102,7 +144,7 @@
       const { discordAccount: account } = await getBanTargetDiscordAccount(fetch, gitHubUserId);
       if (token !== lookupToken) return;
       discordAccount = account;
-      banFromDiscord = true;
+      discordAction = effectiveCategory === 'account_migration' ? 'unlink' : 'ban';
     } catch {
       // Non-fatal — the admin just won't see the Discord ban option.
       if (token === lookupToken) discordAccount = null;
@@ -127,9 +169,11 @@
       const result = await banGitHubUser(fetch, {
         gitHubUserId: resolvedUser.gitHubUserId,
         type: type as RestrictionType,
+        category: effectiveCategory,
         reason: reason.trim() ? reason.trim() : undefined,
         skipNotification,
-        banFromDiscord: discordAccount ? banFromDiscord : undefined,
+        banFromDiscord: discordAccount ? discordAction === 'ban' : undefined,
+        unlinkDiscord: discordAccount ? discordAction === 'unlink' : undefined,
       });
 
       onCreated();
@@ -200,8 +244,21 @@
       {/if}
 
       <FormField title="Type">
-        <Dropdown options={typeOptions} bind:value={type} />
+        <Dropdown options={typeOptions} bind:value={type} onchange={onTypeChange} />
       </FormField>
+
+      {#if type === 'ban'}
+        <FormField
+          title="Category"
+          description="Account migrations are administrative, not punitive: picking one defaults the notification and Discord options below accordingly."
+        >
+          <Dropdown
+            options={categoryOptions}
+            bind:value={category}
+            onchange={applyCategoryDefaults}
+          />
+        </FormField>
+      {/if}
 
       <FormField title="Reason" description="Optional. Up to 500 characters.">
         <TextArea bind:value={reason} placeholder="Why is this user being banned or restricted?" />
@@ -217,7 +274,7 @@
       {#if discordAccount}
         <FormField
           title="Discord"
-          description="This user has a linked Discord account. You can ban it from the Discord server at the same time."
+          description="This user has a linked Discord account. You can ban it from the Discord server, or unlink it from this Wave account so they can link it to a new one once they no longer have access to this one."
         >
           <div class="discord-section">
             <div class="preview">
@@ -236,7 +293,7 @@
                 {/if}
               </div>
             </div>
-            <Checkbox bind:checked={banFromDiscord} label="Also ban from the Discord server" />
+            <Dropdown options={discordActionOptions} bind:value={discordAction} />
           </div>
         </FormField>
       {/if}


### PR DESCRIPTION
## Summary

Admin bans UI follow-ups for the matching Wave API change (drips-network/wave#799):

- **Category** selector in the ban modal (shown for bans only): *Offense* or *Account migration*. Picking *Account migration* defaults the notification checkbox to "don't notify" and the Discord option to "unlink".
- **Discord action** is now a dropdown instead of a checkbox: ban from the server, unlink from this Wave account (so it can be linked to the user's new account), or leave as is. Sends `banFromDiscord` / `unlinkDiscord` accordingly.
- Bans list shows an *account migration* badge and gains a **Category** filter (`?category=`), combinable with the existing type filter.
- `bans.ts` client: `category` on the list item and request, `unlinkDiscord` on the request, `discordUnlinkResult` on the response.

Deploy after the backend change; the list schema requires `category` on each row.
